### PR TITLE
fix: validate queryEvent parameter

### DIFF
--- a/packages/typescript/src/client/client.ts
+++ b/packages/typescript/src/client/client.ts
@@ -522,6 +522,9 @@ export class SuiClient {
 	 * Get events for a given query criteria
 	 */
 	async queryEvents(input: QueryEventsParams): Promise<PaginatedEvents> {
+		if (Object.keys(input.query).length > 1)
+			throw new Error('Invalid query parameters, please provide only one query object');
+
 		return await this.transport.request({
 			method: 'suix_queryEvents',
 			params: [

--- a/packages/typescript/test/e2e/read-events.test.ts
+++ b/packages/typescript/test/e2e/read-events.test.ts
@@ -38,4 +38,15 @@ describe('Event Reading API', () => {
 		});
 		expect(query1.data.length).toEqual(0);
 	});
+
+	it('Error: Get All Events', async () => {
+		await expect(async () => {
+			await toolbox.client.queryEvents({
+				query: {
+					TimeRange: { startTime: '0', endTime: Date.now().toString() },
+					Sender: toolbox.address(),
+				},
+			});
+		}).rejects.toThrowError('Invalid query parameters, please provide only one query object');
+	});
 });


### PR DESCRIPTION
## Descriptiona

Fix the issue that parameter of `queryEvent` can't be a multi objects.

The Typescript type checker won’t throw error if developers pass multi objects as `query`, but this is invalid format for sending request to rpc and the error message returned from rpc response isn't clear. Therefore, I added a validation logic and more clear error message before request to check keyof input object

```typescript
      await toolbox.client.queryEvents({
		query: {
			TimeRange: { startTime: '0', endTime: Date.now().toString() },
			Sender: toolbox.address(), // not throw error in VSCode type safe checker
		},
	});
```

I have not found any additional rules or pattern for contribution open source code, so if I make something wrong, please tell me

## Test plan

Added error test in e2e test cases

---
