### PR TITLE
Update useAutoConnectWallet.mdx - Provided Usage of autoConnect Props in Wallet Provider

### DIFF
--- a/packages/docs/pages/dapp-kit/wallet-hooks/useAutoConnectWallet.mdx
+++ b/packages/docs/pages/dapp-kit/wallet-hooks/useAutoConnectWallet.mdx
@@ -23,6 +23,26 @@ function MyComponent() {
 
 <UseAutoConnectionStatusExample />
 
+## To Enable Auto-Connect Wallet
+Use `autoConnect` as props in `<WalletProvider/>` 
+- `autoConnect` - Enables automatically reconnecting to the most recently used wallet account upon
+  mounting.
+
+ 
+```tsx
+import { WalletProvider } from '@mysten/dapp-kit';
+ 
+function App() {
+	return (
+		<WalletProvider autoConnect>
+			<YourApp />
+		</WalletProvider>
+	);
+}
+```
+
+[Read More](https://sdk.mystenlabs.com/dapp-kit/wallet-provider)
+
 ## Auto-connection status properties
 
 - `disabled` - When the auto-connection functionality is disabled.


### PR DESCRIPTION
Added autoConnect usage example for WalletProvider in useAutoConnectWallet hook
## Description
This PR updates the documentation for the useAutoConnectWallet hook to include an example of using the autoConnect prop with the <WalletProvider /> component. This addition provides better clarity on enabling automatic reconnection to the most recently used wallet account upon mounting.

Changes include:

Added a code example demonstrating the use of the autoConnect prop in the WalletProvider component.
Included a brief explanation about the autoConnect prop and its functionality.

## Test plan

Since this PR is limited to documentation updates:

Verified that the example is syntactically correct and aligns with the @mysten/dapp-kit API.
Ensured that the added content enhances clarity and usability for developers referencing the documentation.

---
