### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1216,7 +1216,7 @@
 
 ### Minor Changes
 
-- 6c1f81228: Remove signature from trasaction digest hash
+- 6c1f81228: Remove signature from transaction digest hash
 - 519e11551: Allow keypairs to be exported
 - b03bfaec2: Add getTransactionAuthSigners endpoint
 


### PR DESCRIPTION
## Summary
Fixed a typo in `CHANGELOG.md` (`trasaction` → `transaction`) for better accuracy.

## Changes
- Corrected **"trasaction"** to **"transaction"**.

## Motivation
Ensuring clear and professional documentation.

## Checklist
- [x] Verified the typo fix.
- [x] Ensured no unintended changes were introduced.

---

Let me know if you need any refinements! 🚀
