### PR TITLE
Add apple as an AuthProvider

### DIFF
--- a/packages/enoki/src/EnokiFlow.ts
+++ b/packages/enoki/src/EnokiFlow.ts
@@ -50,7 +50,7 @@ export interface ZkLoginSession {
 	proof?: ZkLoginSignatureInputs;
 }
 
-export type AuthProvider = 'google' | 'facebook' | 'twitch';
+export type AuthProvider = 'google' | 'facebook' | 'twitch' | 'apple';
 
 const createStorageKeys = (apiKey: string) => ({
 	STATE: `@enoki/flow/state/${apiKey}`,
@@ -151,6 +151,14 @@ export class EnokiFlow {
 			case 'twitch': {
 				params.set('force_verify', 'true');
 				oauthUrl = `https://id.twitch.tv/oauth2/authorize?${params}`;
+				break;
+			}
+
+			case 'apple': {
+				params.set('response_type', 'code%20id_token')
+				params.set('scope', 'email')
+				params.set('response_mode', 'form_post')
+				oauthUrl = `https://appleid.apple.com/auth/authorize?${params}`;
 				break;
 			}
 


### PR DESCRIPTION
## Description

I'm adding apple based on https://docs.sui.io/guides/developer/cryptography/zklogin-integration#get-jwt

## Test plan

I just ran this:

```
      const authUrl = await flow.createAuthorizationURL({
        provider: 'apple',
        network: 'mainnet',
        clientId: 'CLIENT_ID',
        redirectUrl: 'REDIRECT_URI',
      });
```

---
