### PR TITLE
[walrus] make blob metadata fetches more robust

### DIFF
--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -188,7 +188,7 @@ export class WalrusClient {
 	async getBlobMetadata({ blobId, signal }: GetBlobMetadataOptions) {
 		const controller = new AbortController();
 		signal?.addEventListener('abort', () => {
-			controller.abort();
+			controller.abort(signal.reason);
 		});
 
 		const committee = await this.#getReadCommittee({ blobId, signal });
@@ -268,7 +268,7 @@ export class WalrusClient {
 	async getVerifiedBlobStatus({ blobId, signal }: GetVerifiedBlobStatusOptions) {
 		const controller = new AbortController();
 		signal?.addEventListener('abort', () => {
-			controller.abort();
+			controller.abort(signal.reason);
 		});
 
 		// Read from the latest committee because, during epoch change, it is the committee

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -19,7 +19,9 @@ import { SystemStateInnerV1 } from './contracts/system_state_inner.js';
 import { init as initSystemContract, System } from './contracts/system.js';
 import {
 	BehindCurrentEpochError,
+	BlobBlockedError,
 	BlobNotCertifiedError,
+	NoBlobMetadataReceivedError,
 	NoBlobStatusReceivedError,
 	NotEnoughBlobConfirmationsError,
 	NotEnoughSliversReceivedError,
@@ -28,13 +30,14 @@ import {
 	WalrusClientError,
 } from './error.js';
 import { StorageNodeClient } from './storage-node/client.js';
-import { NotFoundError, UserAbortError } from './storage-node/error.js';
-import type { BlobStatus } from './storage-node/types.js';
+import { LegallyUnavailableError, NotFoundError, UserAbortError } from './storage-node/error.js';
+import type { BlobMetadataWithId, BlobStatus } from './storage-node/types.js';
 import type {
 	CertifyBlobOptions,
 	CommitteeInfo,
 	DeleteBlobOptions,
 	ExtendBlobOptions,
+	GetBlobMetadataOptions,
 	GetCertificationEpochOptions,
 	GetStorageConfirmationOptions,
 	GetVerifiedBlobStatusOptions,
@@ -53,6 +56,7 @@ import type {
 } from './types.js';
 import { blobIdToInt, IntentType, SliverData, StorageConfirmation } from './utils/bcs.js';
 import {
+	chunk,
 	encodedBlobLength,
 	getPrimarySourceSymbols,
 	getShardIndicesByNodeId,
@@ -64,7 +68,7 @@ import {
 	toShardIndex,
 } from './utils/index.js';
 import { SuiObjectDataLoader } from './utils/object-loader.js';
-import { getRandom } from './utils/randomness.js';
+import { shuffle } from './utils/randomness.js';
 import { combineSignatures, decodePrimarySlivers, encodeBlob } from './wasm.js';
 
 export class WalrusClient {
@@ -73,7 +77,10 @@ export class WalrusClient {
 	packageConfig: WalrusPackageConfig;
 	#suiClient: SuiClient;
 	#objectLoader: SuiObjectDataLoader;
+
+	#blobMetadataConcurrencyLimit = 10;
 	#activeCommittee?: CommitteeInfo | Promise<CommitteeInfo> | null;
+	#readCommittee?: CommitteeInfo | Promise<CommitteeInfo> | null;
 
 	constructor(config: WalrusClientConfig) {
 		if (config.network && !config.packageConfig) {
@@ -147,19 +154,12 @@ export class WalrusClient {
 	readBlob = this.#retryOnPossibleEpochChange(this.#internalReadBlob);
 
 	async #internalReadBlob({ blobId, signal }: ReadBlobOptions) {
-		const certificationEpoch = await this.getCertificationEpoch({ blobId, signal });
-		const committee = await this.#getReadCommittee(certificationEpoch);
-
 		const systemState = await this.systemState();
 		const numShards = systemState.committee.n_shards;
 		const minSymbols = getPrimarySourceSymbols(numShards);
 
-		const randomStorageNode = getRandom(committee.nodes);
-
-		const blobMetadata = await this.#storageNodeClient.getBlobMetadata(
-			{ blobId },
-			{ nodeUrl: randomStorageNode.networkUrl, signal },
-		);
+		const blobMetadata = await this.getBlobMetadata({ blobId, signal });
+		const committee = await this.#getReadCommittee({ blobId, signal });
 
 		// TODO: implement better shard selection logic
 		const sliverPromises = Array.from({ length: minSymbols }).map(async (_, shardIndex) => {
@@ -183,6 +183,83 @@ export class WalrusClient {
 		}
 
 		return decodePrimarySlivers(numShards, blobMetadata.metadata.V1.unencoded_length, slivers);
+	}
+
+	async getBlobMetadata({ blobId, signal }: GetBlobMetadataOptions) {
+		const controller = new AbortController();
+		signal?.addEventListener('abort', () => {
+			controller.abort();
+		});
+
+		const committee = await this.#getReadCommittee({ blobId, signal });
+		const randomizedNodes = shuffle(committee.nodes);
+
+		const stakingState = await this.stakingState();
+		const numShards = stakingState.n_shards;
+
+		let numNotFoundWeight = 0;
+		let numBlockedWeight = 0;
+		let totalErrorCount = 0;
+
+		const metadataExecutors = randomizedNodes.map((node) => async () => {
+			try {
+				return await this.#storageNodeClient.getBlobMetadata(
+					{ blobId },
+					{ nodeUrl: node.networkUrl, signal: controller.signal },
+				);
+			} catch (error) {
+				if (error instanceof NotFoundError) {
+					numNotFoundWeight += node.shardIndices.length;
+				} else if (error instanceof LegallyUnavailableError) {
+					numBlockedWeight += node.shardIndices.length;
+				}
+
+				totalErrorCount += 1;
+				throw error;
+			}
+		});
+
+		try {
+			const attemptGetMetadata = metadataExecutors.shift()!;
+			return await attemptGetMetadata();
+		} catch (error) {
+			const chunkSize = Math.floor(metadataExecutors.length / this.#blobMetadataConcurrencyLimit);
+			const chunkedExecutors = chunk(metadataExecutors, chunkSize);
+
+			return await new Promise<BlobMetadataWithId>((resolve, reject) => {
+				chunkedExecutors.forEach(async (executors) => {
+					for (const executor of executors) {
+						try {
+							const result = await executor();
+							controller.abort('Blob metadata successfully retrieved.');
+							resolve(result);
+						} catch (error) {
+							if (error instanceof UserAbortError) {
+								reject(error);
+								return;
+							} else if (isQuorum(numBlockedWeight + numNotFoundWeight, numShards)) {
+								const abortError =
+									numNotFoundWeight > numBlockedWeight
+										? new BlobNotCertifiedError(`The specified blob ${blobId} is not certified.`)
+										: new BlobBlockedError(`The specified blob ${blobId} is blocked.`);
+
+								controller.abort(abortError);
+								reject(abortError);
+								return;
+							}
+
+							if (totalErrorCount === metadataExecutors.length) {
+								reject(
+									new NoBlobMetadataReceivedError(
+										'No valid blob metadata could be retrieved from any storage node.',
+									),
+								);
+							}
+						}
+					}
+				});
+			});
+		}
 	}
 
 	/**
@@ -280,10 +357,7 @@ export class WalrusClient {
 		);
 	}
 
-	/**
-	 * Returns the epoch at which a blob was certified at.
-	 */
-	async getCertificationEpoch({ blobId, signal }: GetCertificationEpochOptions) {
+	async #getCertificationEpoch({ blobId, signal }: GetCertificationEpochOptions) {
 		const stakingState = await this.stakingState();
 		const currentEpoch = stakingState.epoch;
 
@@ -317,9 +391,17 @@ export class WalrusClient {
 	 * information as nodes from the current committee might still be receiving transferred shards
 	 * from the previous committeee.
 	 */
-	async #getReadCommittee(certificationEpoch: number) {
+	async #getReadCommittee(options: ReadBlobOptions) {
+		if (!this.#readCommittee) {
+			this.#readCommittee = this.#forceGetReadCommittee(options);
+		}
+		return await this.#readCommittee;
+	}
+
+	async #forceGetReadCommittee({ blobId, signal }: ReadBlobOptions) {
 		const stakingState = await this.stakingState();
 		const isTransitioning = stakingState.epoch_state.$kind === 'EpochChangeSync';
+		const certificationEpoch = await this.#getCertificationEpoch({ blobId, signal });
 
 		if (isTransitioning && certificationEpoch < stakingState.epoch) {
 			return await this.#getCommittee(stakingState.previous_committee);
@@ -982,6 +1064,7 @@ export class WalrusClient {
 	reset() {
 		this.#objectLoader.clearAll();
 		this.#activeCommittee = null;
+		this.#readCommittee = null;
 	}
 
 	#retryOnPossibleEpochChange<T extends (...args: any[]) => Promise<any>>(fn: T): T {

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -395,7 +395,7 @@ export class WalrusClient {
 		if (!this.#readCommittee) {
 			this.#readCommittee = this.#forceGetReadCommittee(options);
 		}
-		return await this.#readCommittee;
+		return this.#readCommittee;
 	}
 
 	async #forceGetReadCommittee({ blobId, signal }: ReadBlobOptions) {

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -101,6 +101,8 @@ export type ReadBlobOptions = {
 
 export type GetCertificationEpochOptions = ReadBlobOptions;
 
+export type GetBlobMetadataOptions = ReadBlobOptions;
+
 export type GetVerifiedBlobStatusOptions = ReadBlobOptions;
 
 export interface SliversForNode {

--- a/packages/walrus/src/utils/index.ts
+++ b/packages/walrus/src/utils/index.ts
@@ -119,3 +119,9 @@ export function nodesByShardIndex(committee: InferBcsType<ReturnType<typeof Comm
 
 	return nodesByShardIndex;
 }
+
+export function chunk<T>(array: T[], size: number) {
+	return Array.from({ length: Math.ceil(array.length / size) }, (_, i) => {
+		return array.slice(i * size, (i + 1) * size);
+	});
+}

--- a/packages/walrus/src/utils/randomness.ts
+++ b/packages/walrus/src/utils/randomness.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export function getRandom<T>(array: T[]): T {
-	const randomIndex = Math.floor(Math.random() * array.length);
-	return array[randomIndex];
+export function shuffle<T>(arr: readonly T[]): T[] {
+	const result = [...arr];
+
+	for (let i = result.length - 1; i > 0; i -= 1) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+
+	return result;
 }


### PR DESCRIPTION
## Description
Storage nodes don't always contain the metadata for a blob, so this PR implements the same strategy the Rust client uses for metadata reads – we randomize the committee, try to fetch metadata from the first node and return if successful, otherwise start fetching in parallel until we get a successful response or reach quorum on the blob being blocked/not certified.

## Test plan
- Tested with reading a bunch of blobs

---
