### PR TITLE
[walrus] add getBlobStatus to the storage node API client

### DIFF
--- a/packages/walrus/src/storage-node/types.ts
+++ b/packages/walrus/src/storage-node/types.ts
@@ -16,6 +16,64 @@ export type StorageConfirmation = {
 	signature: string;
 };
 
+export type GetBlobStatusRequestInput = {
+	blobId: string;
+};
+
+export type GetBlobStatusResponse = BlobStatus;
+
+export type BlobStatus =
+	| { type: 'nonexistent' }
+	| ({ type: 'invalid' } & InvalidBlobStatus['invalid'])
+	| ({ type: 'permanent' } & PermanentBlobStatus['permanent'])
+	| ({ type: 'deletable' } & DeletableBlobStatus['deletable']);
+
+export type RawGetBlobStatusResponse = {
+	code: number;
+	success: {
+		data: RawBlobStatus;
+	};
+};
+
+export type RawBlobStatus =
+	| 'nonexistent'
+	| InvalidBlobStatus
+	| PermanentBlobStatus
+	| DeletableBlobStatus;
+
+export type InvalidBlobStatus = {
+	invalid: {
+		event: StatusEvent;
+	};
+};
+
+export type PermanentBlobStatus = {
+	permanent: {
+		deletableCounts: DeletableCounts;
+		endEpoch: number;
+		isCertified: boolean;
+		statusEvent: StatusEvent;
+		initialCertifiedEpoch: number | null;
+	};
+};
+
+export type DeletableBlobStatus = {
+	deletable: {
+		deletableCounts: DeletableCounts;
+		initialCertifiedEpoch: number | null;
+	};
+};
+
+export type DeletableCounts = {
+	count_deletable_total: number;
+	count_deletable_certified: number;
+};
+
+export type StatusEvent = {
+	eventSeq: string;
+	txDigest: string;
+};
+
 export type GetBlobMetadataRequestInput = {
 	blobId: string;
 };


### PR DESCRIPTION
## Description

We need the `getBlobStatus` method for retrieving information about the certification epoch of a blob which is needed to determine which committee to read blobs from during epoch changes. I transformed the API response at the client level because it's annoying to work with a union of nested objects vs having a discriminated union


See: https://github.com/MystenLabs/ts-sdks/pull/67

## Test plan
- Lewks good locally
