### PR TITLE
[walrus][out on PTO - plz take over] make sliver reads more robust

### DIFF
--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -31,7 +31,7 @@ import {
 } from './error.js';
 import { StorageNodeClient } from './storage-node/client.js';
 import { LegallyUnavailableError, NotFoundError, UserAbortError } from './storage-node/error.js';
-import type { BlobMetadataWithId, BlobStatus } from './storage-node/types.js';
+import type { BlobMetadataWithId, BlobStatus, GetSliverResponse } from './storage-node/types.js';
 import type {
 	CertifyBlobOptions,
 	CommitteeInfo,
@@ -39,6 +39,7 @@ import type {
 	ExtendBlobOptions,
 	GetBlobMetadataOptions,
 	GetCertificationEpochOptions,
+	GetSliversOptions,
 	GetStorageConfirmationOptions,
 	GetVerifiedBlobStatusOptions,
 	ReadBlobOptions,
@@ -68,7 +69,7 @@ import {
 	toShardIndex,
 } from './utils/index.js';
 import { SuiObjectDataLoader } from './utils/object-loader.js';
-import { shuffle } from './utils/randomness.js';
+import { shuffle, weightedShuffle } from './utils/randomness.js';
 import { combineSignatures, decodePrimarySlivers, encodeBlob } from './wasm.js';
 
 export class WalrusClient {
@@ -156,31 +157,9 @@ export class WalrusClient {
 	async #internalReadBlob({ blobId, signal }: ReadBlobOptions) {
 		const systemState = await this.systemState();
 		const numShards = systemState.committee.n_shards;
-		const minSymbols = getPrimarySourceSymbols(numShards);
 
 		const blobMetadata = await this.getBlobMetadata({ blobId, signal });
-		const committee = await this.#getReadCommittee({ blobId, signal });
-
-		// TODO: implement better shard selection logic
-		const sliverPromises = Array.from({ length: minSymbols }).map(async (_, shardIndex) => {
-			const storageNode = await this.#getNodeByShardIndex(committee, shardIndex);
-			const sliverPairIndex = toPairIndex(shardIndex, blobId, numShards);
-
-			return await this.#storageNodeClient.getSliver(
-				{ blobId, sliverPairIndex, sliverType: 'primary' },
-				{ nodeUrl: storageNode.networkUrl, signal },
-			);
-		});
-
-		// TODO: implement retry/scheduling logic
-		const sliverResults = await Promise.allSettled(sliverPromises);
-		const slivers = sliverResults
-			.map((result) => (result.status === 'fulfilled' ? result.value : null))
-			.filter((sliver) => !!sliver);
-
-		if (slivers.length < minSymbols) {
-			throw new NotEnoughSliversReceivedError('Not enough slivers to decode');
-		}
+		const slivers = await this.getSlivers({ blobId, signal });
 
 		return decodePrimarySlivers(numShards, blobMetadata.metadata.V1.unencoded_length, slivers);
 	}
@@ -260,6 +239,103 @@ export class WalrusClient {
 				});
 			});
 		}
+	}
+
+	async getSlivers({ blobId, signal }: GetSliversOptions) {
+		const controller = new AbortController();
+		signal?.addEventListener('abort', () => {
+			controller.abort(signal.reason);
+		});
+
+		const committee = await this.#getReadCommittee({ blobId, signal });
+		const randomizedNodes = weightedShuffle(
+			committee.nodes.map((node) => ({
+				value: node,
+				weight: node.shardIndices.length,
+			})),
+		);
+
+		const stakingState = await this.stakingState();
+		const numShards = stakingState.n_shards;
+		const minSymbols = getPrimarySourceSymbols(numShards);
+
+		const sliverPairIndices = randomizedNodes.flatMap((node) =>
+			node.shardIndices.map((shardIndex) => ({
+				url: node.networkUrl,
+				sliverPairIndex: toPairIndex(shardIndex, blobId, numShards),
+			})),
+		);
+
+		const chunkedSliverPairIndices = chunk(sliverPairIndices, minSymbols);
+		const slivers: GetSliverResponse[] = [];
+		const failedNodes = new Set<string>();
+		let numNotFoundWeight = 0;
+		let numBlockedWeight = 0;
+		let totalErrorCount = 0;
+
+		return new Promise<GetSliverResponse[]>((resolve, reject) => {
+			chunkedSliverPairIndices[0].forEach(async (_, colIndex) => {
+				for (let rowIndex = 0; rowIndex < chunkedSliverPairIndices.length; rowIndex += 1) {
+					const value = chunkedSliverPairIndices.at(rowIndex)?.at(colIndex);
+					if (!value) break;
+
+					const { url, sliverPairIndex } = value;
+
+					try {
+						if (failedNodes.has(url)) {
+							throw new Error('Auto-fail bad node');
+						}
+
+						const sliver = await this.#storageNodeClient.getSliver(
+							{ blobId, sliverPairIndex, sliverType: 'primary' },
+							{ nodeUrl: url, signal: controller.signal },
+						);
+
+						if (slivers.length === minSymbols) {
+							controller.abort('Enough slivers successfully retrieved.');
+							resolve(slivers);
+							return;
+						}
+
+						slivers.push(sliver);
+					} catch (error) {
+						if (error instanceof NotFoundError) {
+							numNotFoundWeight += 1;
+						} else if (error instanceof LegallyUnavailableError) {
+							numBlockedWeight += 1;
+						} else if (error instanceof UserAbortError) {
+							reject(error);
+							return;
+						}
+
+						if (isQuorum(numBlockedWeight + numNotFoundWeight, numShards)) {
+							const abortError =
+								numNotFoundWeight > numBlockedWeight
+									? new BlobNotCertifiedError(`The specified blob ${blobId} is not certified.`)
+									: new BlobBlockedError(`The specified blob ${blobId} is blocked.`);
+
+							controller.abort(abortError);
+							reject(abortError);
+							return;
+						}
+
+						failedNodes.add(url);
+						totalErrorCount += 1;
+
+						const remainingTasks = sliverPairIndices.length - (slivers.length + totalErrorCount);
+						const tooManyFailures = slivers.length + remainingTasks < minSymbols;
+
+						if (tooManyFailures) {
+							const abortError = new NotEnoughSliversReceivedError(
+								`Unable to retrieve enough slivers to decode blob ${blobId}.`,
+							);
+							controller.abort(abortError);
+							reject(abortError);
+						}
+					}
+				}
+			});
+		});
 	}
 
 	/**

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -283,7 +283,7 @@ export class WalrusClient {
 
 					try {
 						if (failedNodes.has(url)) {
-							throw new Error('Auto-fail bad node');
+							throw new Error(`Skipping node at ${url} due to previous failure.`);
 						}
 
 						const sliver = await this.#storageNodeClient.getSliver(

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -103,6 +103,8 @@ export type GetCertificationEpochOptions = ReadBlobOptions;
 
 export type GetBlobMetadataOptions = ReadBlobOptions;
 
+export type GetSliversOptions = ReadBlobOptions;
+
 export type GetVerifiedBlobStatusOptions = ReadBlobOptions;
 
 export interface SliversForNode {

--- a/packages/walrus/src/utils/randomness.ts
+++ b/packages/walrus/src/utils/randomness.ts
@@ -7,34 +7,13 @@ type WeightedItem<T> = {
 };
 
 export function weightedShuffle<T>(arr: WeightedItem<T>[]): T[] {
-	const totalWeight = arr.reduce((sum, element) => sum + element.weight, 0);
-
-	function getRandomWeightedIndex() {
-		const randomWeight = Math.random() * totalWeight;
-		let cumulativeWeight = 0;
-
-		for (let i = 0; i < arr.length; i += 1) {
-			cumulativeWeight += arr[i].weight;
-			if (randomWeight <= cumulativeWeight) {
-				return i;
-			}
-		}
-
-		return arr.length - 1;
-	}
-
-	const selectedIndexes = new Set<number>();
-	const result: T[] = [];
-
-	while (result.length < arr.length) {
-		const index = getRandomWeightedIndex();
-		if (!selectedIndexes.has(index)) {
-			selectedIndexes.add(index);
-			result.push(arr[index].value);
-		}
-	}
-
-	return result;
+	return arr
+		.map(({ value, weight }) => ({
+			value,
+			weight: Math.pow(Math.random(), 1 / weight),
+		}))
+		.sort((a, b) => b.weight - a.weight)
+		.map((item) => item.value);
 }
 
 export function shuffle<T>(arr: T[]): T[] {

--- a/packages/walrus/src/utils/randomness.ts
+++ b/packages/walrus/src/utils/randomness.ts
@@ -6,31 +6,38 @@ type WeightedItem<T> = {
 	weight: number;
 };
 
-export function weightedShuffle<T>(array: WeightedItem<T>[]): T[] {
-	const result: T[] = [];
-	const remainingItems = [...array];
+export function weightedShuffle<T>(arr: WeightedItem<T>[]): T[] {
+	const totalWeight = arr.reduce((sum, element) => sum + element.weight, 0);
 
-	for (let i = 0; i < array.length; i += 1) {
-		let totalWeight = remainingItems.reduce((sum, { weight }) => sum + weight, 0);
-		let randomValue = Math.random() * totalWeight;
+	function getRandomWeightedIndex() {
+		const randomWeight = Math.random() * totalWeight;
 		let cumulativeWeight = 0;
 
-		for (let j = 0; j < remainingItems.length; j) {
-			const { value, weight } = remainingItems[j];
-			cumulativeWeight += weight;
-
-			if (randomValue <= cumulativeWeight) {
-				result.push(value);
-				remainingItems.splice(j, 1);
-				break;
+		for (let i = 0; i < arr.length; i += 1) {
+			cumulativeWeight += arr[i].weight;
+			if (randomWeight <= cumulativeWeight) {
+				return i;
 			}
+		}
+
+		return arr.length - 1;
+	}
+
+	const selectedIndexes = new Set<number>();
+	const result: T[] = [];
+
+	while (result.length < arr.length) {
+		const index = getRandomWeightedIndex();
+		if (!selectedIndexes.has(index)) {
+			selectedIndexes.add(index);
+			result.push(arr[index].value);
 		}
 	}
 
 	return result;
 }
 
-export function shuffle<T>(arr: readonly T[]): T[] {
+export function shuffle<T>(arr: T[]): T[] {
 	const result = [...arr];
 
 	for (let i = result.length - 1; i > 0; i -= 1) {

--- a/packages/walrus/src/utils/randomness.ts
+++ b/packages/walrus/src/utils/randomness.ts
@@ -1,6 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+type WeightedItem<T> = {
+	value: T;
+	weight: number;
+};
+
+export function weightedShuffle<T>(array: WeightedItem<T>[]): T[] {
+	const result: T[] = [];
+	const remainingItems = [...array];
+
+	for (let i = 0; i < array.length; i += 1) {
+		let totalWeight = remainingItems.reduce((sum, { weight }) => sum + weight, 0);
+		let randomValue = Math.random() * totalWeight;
+		let cumulativeWeight = 0;
+
+		for (let j = 0; j < remainingItems.length; j) {
+			const { value, weight } = remainingItems[j];
+			cumulativeWeight += weight;
+
+			if (randomValue <= cumulativeWeight) {
+				result.push(value);
+				remainingItems.splice(j, 1);
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
 export function shuffle<T>(arr: readonly T[]): T[] {
 	const result = [...arr];
 


### PR DESCRIPTION
## Description

This PR makes the sliver fetching more robust, specifically:
  - We want to try to fetch slivers from nodes at random proportional to how many shards they possess
  - If we fail fetching from a given node, we skip subsequent requests to that node
  - If we hit too many 404/451 errors, we bail out if quorum was reached
  - If we hit so many errors so that we can't fetch `minSymbols`, we bail out

I'm out all this week on PTO, so just getting this up and if there's a more preferred way to go about the async control flow management here please be my guest! I just used a simple chunking approach where we execute against the chunked sliver indices in column-wise order so that we preserve the weighted random ordering (felt kinda meh about this but it works). 

## Test plan
---
- Tested reads on a bunch of blobs