### PR TITLE
[mvr-plugin] Rewrite plugin to use the new API

### DIFF
--- a/.changeset/metal-steaks-grab.md
+++ b/.changeset/metal-steaks-grab.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Update NamedPackagesPlugin to use the new MVR API and support single-types in the cache

--- a/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
+++ b/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
@@ -26,8 +26,7 @@ export type NamedPackagesPluginOptions = {
 	 * Local overrides for the resolution plugin. Pass this to pre-populate
 	 * the cache with known packages / types (especially useful for local or CI testing).
 	 *
-	 * The types cache works best with first level types, so it might be better to list
-	 * non-generic types here.
+	 * The type cache expects ONLY first-level types to ensure the cache is more composable.
 	 *
 	 * 	Expected format example:
 	 *  {
@@ -78,7 +77,7 @@ export const namedPackagesPlugin = ({
 				pageSize,
 			),
 			resolveTypes(
-				getFirstLevelNamedTypes(names.types).filter((x) => !cache.types[x]),
+				[...getFirstLevelNamedTypes(names.types)].filter((x) => !cache.types[x]),
 				url,
 				pageSize,
 			),
@@ -94,7 +93,7 @@ export const namedPackagesPlugin = ({
 		replaceNames(transactionData, {
 			packages: { ...cache.packages },
 			// we include the "composed" type cache too.
-			types: { ...cache.types, ...composedTypes },
+			types: composedTypes,
 		});
 
 		await next();

--- a/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
+++ b/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
@@ -63,7 +63,7 @@ export const namedPackagesPlugin = ({
 	pageSize = 50,
 	overrides = { packages: {}, types: {} },
 }: NamedPackagesPluginOptions) => {
-	const cache = overrides || { packages: {}, types: {} };
+	const cache = overrides;
 
 	return async (
 		transactionData: TransactionDataBuilder,

--- a/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
+++ b/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
@@ -68,9 +68,6 @@ export const namedPackagesPlugin = ({
 		// Compose types, and save in cache (for next runs).
 		Object.assign(cache.types, fixComposableTypes(names.types, cache.types));
 
-		// TODO: Once the API can support partial type resolution, we should
-		// resolve nested types separately. That will allow us to compose
-		// type resolution.
 		const [packages, types] = await Promise.all([
 			resolvePackages(
 				names.packages.filter((x) => !cache.packages[x]),

--- a/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
+++ b/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { parseStructTag } from '../../utils/sui-types.js';
 import type { BuildTransactionOptions } from '../json-rpc-resolver.js';
 import type { TransactionDataBuilder } from '../TransactionData.js';
 import type { NamedPackagesPluginCache } from './utils.js';
@@ -61,6 +62,14 @@ export const namedPackagesPlugin = ({
 	pageSize = 50,
 	overrides = { packages: {}, types: {} },
 }: NamedPackagesPluginOptions) => {
+	// validate that types are first-level only.
+	Object.keys(overrides.types).forEach((type) => {
+		if (parseStructTag(type).typeParams.length > 0)
+			throw new Error(
+				'Type overrides must be first-level only. If you want to supply generic types, just pass each type individually.',
+			);
+	});
+
 	const cache = overrides;
 
 	return async (

--- a/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
+++ b/packages/typescript/src/transactions/plugins/NamedPackagesPlugin.ts
@@ -4,7 +4,7 @@
 import type { BuildTransactionOptions } from '../json-rpc-resolver.js';
 import type { TransactionDataBuilder } from '../TransactionData.js';
 import type { NamedPackagesPluginCache } from './utils.js';
-import { batch, findTransactionBlockNames, replaceNames } from './utils.js';
+import { batch, findTransactionBlockNames, fixComposableTypes, replaceNames } from './utils.js';
 
 export type NamedPackagesPluginOptions = {
 	/**
@@ -65,6 +65,9 @@ export const namedPackagesPlugin = ({
 	) => {
 		const names = findTransactionBlockNames(transactionData);
 
+		// Compose types, and save in cache (for next runs).
+		Object.assign(cache.types, fixComposableTypes(names.types, cache.types));
+
 		// TODO: Once the API can support partial type resolution, we should
 		// resolve nested types separately. That will allow us to compose
 		// type resolution.
@@ -90,8 +93,9 @@ export const namedPackagesPlugin = ({
 	};
 
 	async function resolvePackages(packages: string[], apiUrl: string, pageSize: number) {
-		const batches = batch(packages, pageSize);
+		if (packages.length === 0) return {};
 
+		const batches = batch(packages, pageSize);
 		const results: Record<string, string> = {};
 
 		await Promise.all(
@@ -123,8 +127,9 @@ export const namedPackagesPlugin = ({
 	}
 
 	async function resolveTypes(types: string[], apiUrl: string, pageSize: number) {
-		const batches = batch(types, pageSize);
+		if (types.length === 0) return {};
 
+		const batches = batch(types, pageSize);
 		const results: Record<string, string> = {};
 
 		await Promise.all(

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -125,18 +125,9 @@ function findAndReplaceCachedTypes(
 	let typeTag = `${type.address}::${type.module}::${type.name}`;
 	const cacheHit = typeCache[typeTag];
 
-	if (cacheHit) {
-		let [mvrName] = cacheHit.split('::');
-
-		return {
-			...type,
-			address: mvrName,
-			typeParams: type.typeParams.map((param) => findAndReplaceCachedTypes(param, typeCache)),
-		};
-	}
-
 	return {
 		...type,
+		address: cacheHit ? cacheHit.split('::')[0] : type.address,
 		typeParams: type.typeParams.map((param) => findAndReplaceCachedTypes(param, typeCache)),
 	};
 }

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -114,31 +114,7 @@ export const replaceNames = (builder: TransactionDataBuilder, cache: NamedPackag
 	}
 };
 
-export const listToRequests = (
-	names: { packages: string[]; types: string[] },
-	batchSize: number,
-): NameResolutionRequest[][] => {
-	const results: NameResolutionRequest[] = [];
-	const uniqueNames = deduplicate(names.packages);
-	const uniqueTypes = deduplicate(names.types);
-
-	for (const [idx, name] of uniqueNames.entries()) {
-		results.push({ id: idx, type: 'package', name } as NameResolutionRequest);
-	}
-	for (const [idx, type] of uniqueTypes.entries()) {
-		results.push({
-			id: idx + uniqueNames.length,
-			type: 'moveType',
-			name: type,
-		} as NameResolutionRequest);
-	}
-
-	return batch(results, batchSize);
-};
-
-const deduplicate = <T>(arr: T[]): T[] => [...new Set(arr)];
-
-const batch = <T>(arr: T[], size: number): T[][] => {
+export const batch = <T>(arr: T[], size: number): T[][] => {
 	const batches = [];
 	for (let i = 0; i < arr.length; i += size) {
 		batches.push(arr.slice(i, i + size));

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -77,16 +77,20 @@ export function getFirstLevelNamedTypes(types: string[]) {
 /**
  * Extracts all named types from a given type.
  */
-function findMvrNames(type: string | StructTag, result: Set<string> = new Set()) {
-	if (typeof type === 'string' && !hasMvrName(type)) return result;
+function findMvrNames(type: string | StructTag) {
+	const types: Set<string> = new Set();
+
+	if (typeof type === 'string' && !hasMvrName(type)) return [];
 
 	let tag = isStructTag(type) ? type : parseStructTag(type);
 
-	if (hasMvrName(tag.address)) result.add(`${tag.address}::${tag.module}::${tag.name}`);
+	if (hasMvrName(tag.address)) types.add(`${tag.address}::${tag.module}::${tag.name}`);
 
-	for (const param of tag.typeParams) findMvrNames(param, result);
+	for (const param of tag.typeParams) {
+		findMvrNames(param).forEach((name) => types.add(name));
+	}
 
-	return result;
+	return [...types];
 }
 
 // /**

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -71,7 +71,7 @@ export function getFirstLevelNamedTypes(types: string[]) {
 		findMvrNames(type).forEach((name) => results.add(name));
 	}
 
-	return [...results];
+	return results;
 }
 
 /**
@@ -90,7 +90,7 @@ function findMvrNames(type: string | StructTag) {
 		findMvrNames(param).forEach((name) => types.add(name));
 	}
 
-	return [...types];
+	return types;
 }
 
 // /**
@@ -204,7 +204,7 @@ function getNamesFromTypeList(types: string[]) {
 			names.add(type);
 		}
 	}
-	return [...names];
+	return names;
 }
 
 function hasMvrName(nameOrType: string) {

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -57,6 +57,33 @@ export const findTransactionBlockNames = (
 };
 
 /**
+ * Allows partial replacements of known types with their resolved equivalents.
+ * E.g. `@mvr/demo::a::A<@mvr/demo::b::B>` can be resolved, if we already have
+ * the address for `@mvr/demo::b::B` and the address for `@mvr/demo::a::A`,
+ * without the need to have the full type in the cache.
+ *
+ * Returns composed cached types.
+ */
+export const fixComposableTypes = (
+	types: string[],
+	typeCache: Record<string, string>,
+): Record<string, string> => {
+	const newTypes: Record<string, string> = {};
+	for (const type of types) {
+		// if we already have a resolution for this type, skip.
+		if (typeCache[type]) continue;
+		let replacement = type;
+		for (const [name, address] of Object.entries(typeCache)) {
+			if (type.includes(name)) replacement = replacement.replaceAll(name, address);
+		}
+
+		if (replacement !== type) newTypes[type] = replacement;
+	}
+
+	return newTypes;
+};
+
+/**
  * Returns a list of unique types that include a name
  * from the given list.
  *  */

--- a/packages/typescript/src/transactions/plugins/utils.ts
+++ b/packages/typescript/src/transactions/plugins/utils.ts
@@ -80,7 +80,7 @@ export function getFirstLevelNamedTypes(types: string[]) {
 function findMvrNames(type: string | StructTag) {
 	const types: Set<string> = new Set();
 
-	if (typeof type === 'string' && !hasMvrName(type)) return [];
+	if (typeof type === 'string' && !hasMvrName(type)) return types;
 
 	let tag = isStructTag(type) ? type : parseStructTag(type);
 

--- a/packages/typescript/src/utils/sui-types.ts
+++ b/packages/typescript/src/utils/sui-types.ts
@@ -3,6 +3,8 @@
 
 import { fromBase58, splitGenericParameters } from '@mysten/bcs';
 
+import { isValidNamedPackage } from './move-registry.js';
+
 const TX_DIGEST_LENGTH = 32;
 
 /** Returns whether the tx digest is valid based on the serialization format */
@@ -30,7 +32,7 @@ export function isValidSuiObjectId(value: string): boolean {
 	return isValidSuiAddress(value);
 }
 
-type StructTag = {
+export type StructTag = {
 	address: string;
 	module: string;
 	name: string;
@@ -46,6 +48,8 @@ function parseTypeTag(type: string): string | StructTag {
 export function parseStructTag(type: string): StructTag {
 	const [address, module] = type.split('::');
 
+	const isMvrPackage = isValidNamedPackage(address);
+
 	const rest = type.slice(address.length + module.length + 4);
 	const name = rest.includes('<') ? rest.slice(0, rest.indexOf('<')) : rest;
 	const typeParams = rest.includes('<')
@@ -55,7 +59,7 @@ export function parseStructTag(type: string): StructTag {
 		: [];
 
 	return {
-		address: normalizeSuiAddress(address),
+		address: isMvrPackage ? address : normalizeSuiAddress(address),
 		module,
 		name,
 		typeParams,

--- a/packages/typescript/test/e2e/named-packages-plugin.test.ts
+++ b/packages/typescript/test/e2e/named-packages-plugin.test.ts
@@ -189,6 +189,10 @@ describe.concurrent('Utility functions', () => {
 					'@mvr/demo::e::E',
 				],
 			},
+			{
+				input: ['u64', '0x2::balance::Balance<0x2::sui::SUI>'],
+				output: [],
+			}
 		];
 
 		for (const testSet of testSets) {

--- a/packages/typescript/test/e2e/named-packages-plugin.test.ts
+++ b/packages/typescript/test/e2e/named-packages-plugin.test.ts
@@ -247,6 +247,22 @@ describe.concurrent('Utility functions', () => {
 			client: new SuiClient({ url: getFullnodeUrl('mainnet') }),
 		});
 	});
+
+	it('Should fail to initialize a plugin with generic type tags', () => {
+		const cache = {
+			packages: {},
+			types: {
+				'@mvr/demo::a::A<@mvr/demo::b::B>': '0x1::a::A<0x1::b::B>',
+			},
+		};
+
+		expect(() =>
+			namedPackagesPlugin({
+				url: '',
+				overrides: cache,
+			}),
+		).toThrow();
+	});
 });
 
 const simplePtb = async (network: 'mainnet' | 'testnet') => {

--- a/packages/typescript/test/e2e/named-packages-plugin.test.ts
+++ b/packages/typescript/test/e2e/named-packages-plugin.test.ts
@@ -62,7 +62,7 @@ const dryRun = async (transaction: Transaction, network: 'mainnet' | 'testnet') 
 	return client.dryRunTransactionBlock({ transactionBlock: await transaction.build({ client }) });
 };
 
-describe.concurrent('Name Resolution Plugin (.move)', () => {
+describe.concurrent('Name Resolution Plugin', () => {
 	it('Should replace names in a given PTB', async () => {
 		const transaction = new Transaction();
 		transaction.addSerializationPlugin(mainnetPlugin);
@@ -117,6 +117,15 @@ describe.concurrent('Name Resolution Plugin (MVR) - Mainnet', () => {
 			arguments: [v1],
 		});
 
+		transaction.makeMoveVec({
+			type: '@pkg/qwer::mvr_a::V1',
+			elements: [
+				transaction.moveCall({
+					target: `@pkg/qwer::mvr_a::new_v1`,
+				}),
+			],
+		});
+
 		const res = await dryRun(transaction, 'mainnet');
 		expect(res.effects.status.status).toEqual('success');
 	});
@@ -155,6 +164,15 @@ describe.concurrent('Name Resolution Plugin (MVR) - Testnet', () => {
 		transaction.moveCall({
 			target: `@pkg/qwer::mvr_a::new`,
 			arguments: [v1],
+		});
+
+		transaction.makeMoveVec({
+			type: '@pkg/qwer::mvr_a::V1',
+			elements: [
+				transaction.moveCall({
+					target: `@pkg/qwer::mvr_a::new_v1`,
+				}),
+			],
 		});
 
 		const res = await dryRun(transaction, 'testnet');

--- a/packages/typescript/test/e2e/named-packages-plugin.test.ts
+++ b/packages/typescript/test/e2e/named-packages-plugin.test.ts
@@ -177,6 +177,18 @@ describe.concurrent('Utility functions', () => {
 				input: ['@mvr/demo::a::A<u64, @mvr/another-demo::b::B<u128>>', '@mvr/demo::c::C'],
 				output: ['@mvr/demo::a::A', '@mvr/another-demo::b::B', '@mvr/demo::c::C'],
 			},
+			{
+				input: [
+					'@mvr/demo::a::A<@mvr/demo::b::B<@mvr/demo::c::C<u64, bool,@mvr/demo::d::D>,@mvr/demo::e::E>>',
+				],
+				output: [
+					'@mvr/demo::a::A',
+					'@mvr/demo::b::B',
+					'@mvr/demo::c::C',
+					'@mvr/demo::d::D',
+					'@mvr/demo::e::E',
+				],
+			},
 		];
 
 		for (const testSet of testSets) {

--- a/packages/typescript/test/e2e/named-packages-plugin.test.ts
+++ b/packages/typescript/test/e2e/named-packages-plugin.test.ts
@@ -192,11 +192,11 @@ describe.concurrent('Utility functions', () => {
 			{
 				input: ['u64', '0x2::balance::Balance<0x2::sui::SUI>'],
 				output: [],
-			}
+			},
 		];
 
 		for (const testSet of testSets) {
-			expect(getFirstLevelNamedTypes(testSet.input)).toEqual(testSet.output);
+			expect(getFirstLevelNamedTypes(testSet.input)).toEqual(new Set(testSet.output));
 		}
 	});
 	it('The plugin cache should properly hold a list of types', async () => {

--- a/packages/typescript/test/unit/types/common.test.ts
+++ b/packages/typescript/test/unit/types/common.test.ts
@@ -48,6 +48,35 @@ describe('parseStructTag', () => {
       }
     `);
 	});
+
+	it('parses named struct tags correctly', () => {
+		expect(parseStructTag('@mvr/demo::foo::bar')).toMatchInlineSnapshot(`
+      {
+        "address": "@mvr/demo",
+        "module": "foo",
+        "name": "bar",
+        "typeParams": [],
+      }
+    `);
+
+		expect(parseStructTag('@mvr/demo::foo::bar<inner.mvr.sui/demo::baz::qux, bool>'))
+			.toMatchInlineSnapshot(`
+      {
+        "address": "@mvr/demo",
+        "module": "foo",
+        "name": "bar",
+        "typeParams": [
+          {
+            "address": "inner.mvr.sui/demo",
+            "module": "baz",
+            "name": "qux",
+            "typeParams": [],
+          },
+          "bool",
+        ],
+      }
+    `);
+	});
 });
 
 describe('normalizeStructTag', () => {
@@ -59,5 +88,15 @@ describe('normalizeStructTag', () => {
 		expect(normalizeStructTag('0x2::foo::bar<0x3::another::package>')).toEqual(
 			'0x0000000000000000000000000000000000000000000000000000000000000002::foo::bar<0x0000000000000000000000000000000000000000000000000000000000000003::another::package>',
 		);
+	});
+
+	it('normalizes named package addresses', () => {
+		const checks = [
+			'@mvr/demo::foo::bar<inner.mvr.sui/demo::baz::qux,bool>',
+			'@mvr/demo::foo::bar',
+			'@mvr/demo::foo::bar<inner.mvr.sui/demo::baz::Qux,bool,inner@mvr/demo::foo::Nested<u64,bool>>',
+		];
+
+		for (const check of checks) expect(normalizeStructTag(parseStructTag(check))).toEqual(check);
 	});
 });


### PR DESCRIPTION
## Description

This PR:
1. Rewrites the plugin to use the new MVR API endpoints
2. Enables composite type resolution, so that it can work with the "static" generation tool
3. Adds e2e testing using a pretty complex package (multi-versions, cross-chain).

## Test plan

Added new e2e tests.


regarding backwards compatibility (breaking): the GQL endpoints won't really be usable anymore. We are still in an experimental state.