### PR TITLE
[dapp-kit / wallet-standard] let signPersonalMessage take a chain parameter and default the signing chain to the active network

### DIFF
--- a/.changeset/curvy-beans-complain.md
+++ b/.changeset/curvy-beans-complain.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-standard': minor
+---
+
+Add an optional `chain` parameter to the `signPersonalMessage` feature

--- a/.changeset/four-lobsters-promise.md
+++ b/.changeset/four-lobsters-promise.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': minor
+---
+
+Default the `chain` identifier to the active network for all signing operations

--- a/.changeset/ninety-moles-raise.md
+++ b/.changeset/ninety-moles-raise.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zksend': patch
+---
+
+Fix the chain and feature list for the wallet standard interface

--- a/packages/dapp-kit/src/hooks/wallet/useSignAndExecuteTransaction.ts
+++ b/packages/dapp-kit/src/hooks/wallet/useSignAndExecuteTransaction.ts
@@ -18,7 +18,7 @@ import {
 	WalletNotConnectedError,
 } from '../../errors/walletErrors.js';
 import type { PartialBy } from '../../types/utilityTypes.js';
-import { useSuiClient } from '../useSuiClient.js';
+import { useSuiClientContext } from '../useSuiClient.js';
 import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 import { useReportTransactionEffects } from './useReportTransactionEffects.js';
@@ -77,7 +77,7 @@ export function useSignAndExecuteTransaction<
 > {
 	const { currentWallet, supportedIntents } = useCurrentWallet();
 	const currentAccount = useCurrentAccount();
-	const client = useSuiClient();
+	const { client, network } = useSuiClientContext();
 	const { mutate: reportTransactionEffects } = useReportTransactionEffects();
 
 	const executeTransaction: ({
@@ -119,7 +119,6 @@ export function useSignAndExecuteTransaction<
 					'No wallet account is selected to sign the transaction with.',
 				);
 			}
-			const chain = signTransactionArgs.chain ?? signerAccount?.chains[0];
 
 			if (
 				!currentWallet.features['sui:signTransaction'] &&
@@ -130,6 +129,7 @@ export function useSignAndExecuteTransaction<
 				);
 			}
 
+			const chain = signTransactionArgs.chain ?? `sui:${network}`;
 			const { signature, bytes } = await signTransaction(currentWallet, {
 				...signTransactionArgs,
 				transaction: {
@@ -143,7 +143,7 @@ export function useSignAndExecuteTransaction<
 					},
 				},
 				account: signerAccount,
-				chain: signTransactionArgs.chain ?? signerAccount.chains[0],
+				chain,
 			});
 
 			const result = await executeTransaction({ bytes, signature });

--- a/packages/dapp-kit/src/hooks/wallet/useSignPersonalMessage.ts
+++ b/packages/dapp-kit/src/hooks/wallet/useSignPersonalMessage.ts
@@ -15,10 +15,11 @@ import {
 } from '../..//errors/walletErrors.js';
 import { walletMutationKeys } from '../../constants/walletMutationKeys.js';
 import type { PartialBy } from '../../types/utilityTypes.js';
+import { useSuiClientContext } from '../useSuiClient.js';
 import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 
-type UseSignPersonalMessageArgs = PartialBy<SuiSignPersonalMessageInput, 'account'>;
+type UseSignPersonalMessageArgs = PartialBy<SuiSignPersonalMessageInput, 'account' | 'chain'>;
 
 type UseSignPersonalMessageResult = SuiSignPersonalMessageOutput;
 
@@ -51,6 +52,7 @@ export function useSignPersonalMessage({
 > {
 	const { currentWallet } = useCurrentWallet();
 	const currentAccount = useCurrentAccount();
+	const { network } = useSuiClientContext();
 
 	return useMutation({
 		mutationKey: walletMutationKeys.signPersonalMessage(mutationKey),
@@ -71,6 +73,7 @@ export function useSignPersonalMessage({
 				return await signPersonalMessageFeature.signPersonalMessage({
 					...signPersonalMessageArgs,
 					account: signerAccount,
+					chain: signPersonalMessageArgs.chain ?? `sui:${network}`,
 				});
 			}
 

--- a/packages/dapp-kit/src/hooks/wallet/useSignTransaction.ts
+++ b/packages/dapp-kit/src/hooks/wallet/useSignTransaction.ts
@@ -14,7 +14,7 @@ import {
 	WalletNotConnectedError,
 } from '../../errors/walletErrors.js';
 import type { PartialBy } from '../../types/utilityTypes.js';
-import { useSuiClient } from '../useSuiClient.js';
+import { useSuiClientContext } from '../useSuiClient.js';
 import { useCurrentAccount } from './useCurrentAccount.js';
 import { useCurrentWallet } from './useCurrentWallet.js';
 import { useReportTransactionEffects } from './useReportTransactionEffects.js';
@@ -59,7 +59,7 @@ export function useSignTransaction({
 > {
 	const { currentWallet } = useCurrentWallet();
 	const currentAccount = useCurrentAccount();
-	const client = useSuiClient();
+	const { client, network } = useSuiClientContext();
 
 	const { mutate: reportTransactionEffects } = useReportTransactionEffects();
 
@@ -86,6 +86,7 @@ export function useSignTransaction({
 				);
 			}
 
+			const chain = signTransactionArgs.chain ?? `sui:${network}`;
 			const { bytes, signature } = await signTransaction(currentWallet, {
 				...signTransactionArgs,
 				transaction: {
@@ -99,7 +100,7 @@ export function useSignTransaction({
 					},
 				},
 				account: signerAccount,
-				chain: signTransactionArgs.chain ?? signerAccount.chains[0],
+				chain,
 			});
 
 			return {
@@ -109,7 +110,7 @@ export function useSignTransaction({
 					reportTransactionEffects({
 						effects,
 						account: signerAccount,
-						chain: signTransactionArgs.chain ?? signerAccount.chains[0],
+						chain,
 					});
 				},
 			};

--- a/packages/dapp-kit/src/hooks/wallet/useUnsafeBurnerWallet.ts
+++ b/packages/dapp-kit/src/hooks/wallet/useUnsafeBurnerWallet.ts
@@ -98,7 +98,7 @@ function registerUnsafeBurnerWallet(suiClient: SuiClient) {
 					on: this.#on,
 				},
 				'sui:signPersonalMessage': {
-					version: '1.0.0',
+					version: '1.1.0',
 					signPersonalMessage: this.#signPersonalMessage,
 				},
 				'sui:signTransactionBlock': {

--- a/packages/dapp-kit/test/hooks/useSignPersonalMessage.test.tsx
+++ b/packages/dapp-kit/test/hooks/useSignPersonalMessage.test.tsx
@@ -109,8 +109,55 @@ describe('useSignPersonalMessage', () => {
 
 		signPersonalMessageMock.mockReturnValueOnce({ bytes: 'abc', signature: '123' });
 
-		result.current.signPersonalMessage.mutate({
-			message: new Uint8Array().fill(123),
+		const message = new Uint8Array().fill(123);
+		result.current.signPersonalMessage.mutate({ message, chain: 'sui:testnet' });
+
+		expect(signPersonalMessageMock).toHaveBeenCalledWith({
+			message,
+			account: mockWallet.accounts[0],
+			chain: `sui:testnet`,
+		});
+
+		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));
+		expect(result.current.signPersonalMessage.data).toStrictEqual({
+			bytes: 'abc',
+			signature: '123',
+		});
+
+		act(() => unregister());
+	});
+
+	test('defaults the `chain` to the active network', async () => {
+		const { unregister, mockWallet } = registerMockWallet({
+			walletName: 'Mock Wallet 1',
+			features: suiFeatures,
+		});
+
+		const wrapper = createWalletProviderContextWrapper();
+		const { result } = renderHook(
+			() => ({
+				connectWallet: useConnectWallet(),
+				signPersonalMessage: useSignPersonalMessage(),
+			}),
+			{ wrapper },
+		);
+
+		result.current.connectWallet.mutate({ wallet: mockWallet });
+
+		await waitFor(() => expect(result.current.connectWallet.isSuccess).toBe(true));
+
+		const signPersonalMessageFeature = mockWallet.features['sui:signPersonalMessage'];
+		const signPersonalMessageMock = signPersonalMessageFeature!.signPersonalMessage as Mock;
+
+		signPersonalMessageMock.mockReturnValueOnce({ bytes: 'abc', signature: '123' });
+
+		const message = new Uint8Array().fill(123);
+		result.current.signPersonalMessage.mutate({ message });
+
+		expect(signPersonalMessageMock).toHaveBeenCalledWith({
+			message,
+			account: mockWallet.accounts[0],
+			chain: 'sui:test',
 		});
 
 		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));

--- a/packages/dapp-kit/test/hooks/useSignPersonalMessage.test.tsx
+++ b/packages/dapp-kit/test/hooks/useSignPersonalMessage.test.tsx
@@ -112,13 +112,14 @@ describe('useSignPersonalMessage', () => {
 		const message = new Uint8Array().fill(123);
 		result.current.signPersonalMessage.mutate({ message, chain: 'sui:testnet' });
 
+		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));
+
 		expect(signPersonalMessageMock).toHaveBeenCalledWith({
 			message,
 			account: mockWallet.accounts[0],
 			chain: `sui:testnet`,
 		});
 
-		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));
 		expect(result.current.signPersonalMessage.data).toStrictEqual({
 			bytes: 'abc',
 			signature: '123',
@@ -154,13 +155,14 @@ describe('useSignPersonalMessage', () => {
 		const message = new Uint8Array().fill(123);
 		result.current.signPersonalMessage.mutate({ message });
 
+		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));
+
 		expect(signPersonalMessageMock).toHaveBeenCalledWith({
 			message,
 			account: mockWallet.accounts[0],
 			chain: 'sui:test',
 		});
 
-		await waitFor(() => expect(result.current.signPersonalMessage.isSuccess).toBe(true));
 		expect(result.current.signPersonalMessage.data).toStrictEqual({
 			bytes: 'abc',
 			signature: '123',

--- a/packages/dapp-kit/test/mocks/mockFeatures.ts
+++ b/packages/dapp-kit/test/mocks/mockFeatures.ts
@@ -20,7 +20,7 @@ export const superCoolFeature: IdentifierRecord<unknown> = {
 export const suiFeatures: SuiFeatures = {
 	...signMessageFeature,
 	'sui:signPersonalMessage': {
-		version: '1.0.0',
+		version: '1.1.0',
 		signPersonalMessage: vi.fn(),
 	},
 	'sui:signTransactionBlock': {

--- a/packages/docs/content/dapp-kit/wallet-hooks/useSignAndExecuteTransaction.mdx
+++ b/packages/docs/content/dapp-kit/wallet-hooks/useSignAndExecuteTransaction.mdx
@@ -124,7 +124,8 @@ function MyComponent() {
 ## Arguments
 
 - `transaction`: The transaction to sign and execute.
-- `chain`: (optional) The chain identifier the transaction should be signed for.
+- `chain`: (optional) The chain identifier the transaction should be signed for. Defaults to the
+  active network of the dApp.
 - `execute`: (optional) A custom function to execute the transaction
 
 In addition to these options, you can also pass any options that the

--- a/packages/docs/content/dapp-kit/wallet-hooks/useSignPersonalMessage.mdx
+++ b/packages/docs/content/dapp-kit/wallet-hooks/useSignPersonalMessage.mdx
@@ -56,6 +56,8 @@ function MyComponent() {
 ## Arguments
 
 - `message`: The message to sign, as a `Uint8Array`.
+- `chain`: (optional) The chain identifier the message should be signed for. Defaults to the active
+  network of the dApp.
 
 ## Result
 

--- a/packages/docs/content/dapp-kit/wallet-hooks/useSignTransaction.mdx
+++ b/packages/docs/content/dapp-kit/wallet-hooks/useSignTransaction.mdx
@@ -68,7 +68,8 @@ function MyComponent() {
 ## Arguments
 
 - `transactionBlock`: The transaction to sign.
-- `chain`: (optional) The chain identifier the transaction should be signed for.
+- `chain`: (optional) The chain identifier the transaction should be signed for. Defaults to the
+  active network of the dApp.
 
 ## Result
 

--- a/packages/wallet-standard/src/chains.ts
+++ b/packages/wallet-standard/src/chains.ts
@@ -22,11 +22,7 @@ export const SUI_CHAINS = [
 	SUI_MAINNET_CHAIN,
 ] as const;
 
-export type SuiChain =
-	| typeof SUI_DEVNET_CHAIN
-	| typeof SUI_TESTNET_CHAIN
-	| typeof SUI_LOCALNET_CHAIN
-	| typeof SUI_MAINNET_CHAIN;
+export type SuiChain = (typeof SUI_CHAINS)[number];
 
 /**
  * Utility that returns whether or not a chain identifier is a valid Sui chain.

--- a/packages/wallet-standard/src/features/suiSignPersonalMessage.ts
+++ b/packages/wallet-standard/src/features/suiSignPersonalMessage.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { WalletAccount } from '@wallet-standard/core';
+import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
 
 /** The latest API version of the signPersonalMessage API. */
-export type SuiSignPersonalMessageVersion = '1.0.0';
+export type SuiSignPersonalMessageVersion = '1.1.0';
 
 /**
  * A Wallet Standard feature for signing a personal message, and returning the
@@ -27,6 +27,7 @@ export type SuiSignPersonalMessageMethod = (
 export interface SuiSignPersonalMessageInput {
 	message: Uint8Array;
 	account: WalletAccount;
+	chain?: IdentifierString;
 }
 
 /** Output of signing personal messages. */

--- a/packages/zksend/src/wallet/index.ts
+++ b/packages/zksend/src/wallet/index.ts
@@ -54,7 +54,7 @@ export class StashedWallet implements Wallet {
 	}
 
 	get chains() {
-		return [SUI_MAINNET_CHAIN] as const;
+		return [`sui:${this.#network}`] as const;
 	}
 
 	get accounts() {
@@ -89,7 +89,7 @@ export class StashedWallet implements Wallet {
 				signTransaction: this.#signTransaction,
 			},
 			'sui:signPersonalMessage': {
-				version: '1.0.0',
+				version: '1.1.0',
 				signPersonalMessage: this.#signPersonalMessage,
 			},
 		};
@@ -194,8 +194,8 @@ export class StashedWallet implements Wallet {
 			this.#accounts = [
 				new ReadonlyWalletAccount({
 					address,
-					chains: [SUI_MAINNET_CHAIN],
-					features: ['sui:signTransactionBlock', 'sui:signPersonalMessage'],
+					chains: this.chains,
+					features: ['sui:signTransaction', 'sui:signTransactionBlock', 'sui:signPersonalMessage'],
 					// NOTE: Stashed doesn't support getting public keys, and zkLogin accounts don't have meaningful public keys anyway
 					publicKey: new Uint8Array(),
 				}),

--- a/packages/zksend/src/wallet/index.ts
+++ b/packages/zksend/src/wallet/index.ts
@@ -19,7 +19,7 @@ import type {
 	SuiSignTransactionMethod,
 	Wallet,
 } from '@mysten/wallet-standard';
-import { getWallets, ReadonlyWalletAccount, SUI_MAINNET_CHAIN } from '@mysten/wallet-standard';
+import { getWallets, ReadonlyWalletAccount } from '@mysten/wallet-standard';
 import type { Emitter } from 'mitt';
 import mitt from 'mitt';
 


### PR DESCRIPTION
## Description

Message signing for zkLogin accounts technically depends on a `chain`/`network` because proofs are network-bound. While I'm at it, I'm also going to tweak the default `chain` behavior when interacting with wallets from dapp-kit so that the active network of the dApp is used during signing by default.

## Test plan
- Existing test coverage + new tests
- Manual testing with a dApp
