### PR TITLE
Include all public values in hash

### DIFF
--- a/packages/seal/src/decrypt.ts
+++ b/packages/seal/src/decrypt.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fromHex } from '@mysten/bcs';
 import { combine as externalCombine } from 'shamir-secret-sharing';
 
 import type { EncryptedObject } from './bcs.js';
@@ -12,7 +13,6 @@ import { BonehFranklinBLS12381Services, DST } from './ibe.js';
 import { deriveKey, KeyPurpose } from './kdf.js';
 import type { KeyCacheKey } from './types.js';
 import { createFullId } from './utils.js';
-import { fromHex } from '@mysten/bcs';
 
 export interface DecryptOptions {
 	encryptedObject: typeof EncryptedObject.$inferType;

--- a/packages/seal/src/decrypt.ts
+++ b/packages/seal/src/decrypt.ts
@@ -12,6 +12,7 @@ import { BonehFranklinBLS12381Services, DST } from './ibe.js';
 import { deriveKey, KeyPurpose } from './kdf.js';
 import type { KeyCacheKey } from './types.js';
 import { createFullId } from './utils.js';
+import { fromHex } from '@mysten/bcs';
 
 export interface DecryptOptions {
 	encryptedObject: typeof EncryptedObject.$inferType;
@@ -59,6 +60,7 @@ export async function decrypt({ encryptedObject, keys }: DecryptOptions): Promis
 			nonce,
 			keys.get(`${fullId}:${objectId}`)!,
 			encryptedShares[i],
+			fromHex(fullId),
 			info,
 		);
 		// The Shamir secret sharing library expects the index/x-coordinate to be at the end of the share.

--- a/packages/seal/src/ibe.ts
+++ b/packages/seal/src/ibe.ts
@@ -73,7 +73,7 @@ export class BonehFranklinBLS12381Services extends IBEServers {
 		}
 		const [r, nonce, keys] = encapBatched(this.publicKeys, id);
 		const encryptedShares = msgAndInfos.map((msgAndInfo, i) =>
-			xor(msgAndInfo.msg, kdf(keys[i], msgAndInfo.info)),
+			xor(msgAndInfo.msg, kdf(keys[i], nonce, id, msgAndInfo.info)),
 		);
 		const encryptedRandomness = xor(randomnessKey, r.toBytes());
 
@@ -113,9 +113,10 @@ export class BonehFranklinBLS12381Services extends IBEServers {
 		nonce: G2Element,
 		sk: G1Element,
 		ciphertext: Uint8Array,
+		id: Uint8Array,
 		info: Uint8Array,
 	): Uint8Array {
-		return xor(ciphertext, kdf(decap(nonce, sk), info));
+		return xor(ciphertext, kdf(decap(nonce, sk), nonce, id, info));
 	}
 }
 

--- a/packages/seal/src/kdf.ts
+++ b/packages/seal/src/kdf.ts
@@ -5,7 +5,8 @@ import { hkdf } from '@noble/hashes/hkdf';
 import { hmac } from '@noble/hashes/hmac';
 import { sha3_256 } from '@noble/hashes/sha3';
 
-import { G1Element, type G2Element, type GTElement } from './bls12381.js';
+import { G1Element } from './bls12381.js';
+import type { G2Element, GTElement } from './bls12381.js';
 
 /**
  * The default key derivation function.

--- a/packages/seal/src/kdf.ts
+++ b/packages/seal/src/kdf.ts
@@ -5,7 +5,7 @@ import { hkdf } from '@noble/hashes/hkdf';
 import { hmac } from '@noble/hashes/hmac';
 import { sha3_256 } from '@noble/hashes/sha3';
 
-import type { GTElement } from './bls12381.js';
+import type { G2Element, GTElement } from './bls12381.js';
 
 /**
  * The default key derivation function.
@@ -14,7 +14,12 @@ import type { GTElement } from './bls12381.js';
  * @param info Optional context and application specific information.
  * @returns The derived key.
  */
-export function kdf(element: GTElement, info: Uint8Array): Uint8Array {
+export function kdf(
+	element: GTElement,
+	nonce: G2Element,
+	id: Uint8Array,
+	info: Uint8Array,
+): Uint8Array {
 	// This permutation flips the order of 6 pairs of coefficients of the GT element.
 	// The permutation may be computed as:
 	// for i in 0..3 {
@@ -34,7 +39,8 @@ export function kdf(element: GTElement, info: Uint8Array): Uint8Array {
 			pi * COEFFICIENT_SIZE,
 		);
 	});
-	return hkdf(sha3_256, permutedBytes, '', info, 32);
+	const inputBytes = new Uint8Array([...permutedBytes, ...nonce.toBytes(), ...id]);
+	return hkdf(sha3_256, inputBytes, '', info, 32);
 }
 
 export enum KeyPurpose {

--- a/packages/seal/src/kdf.ts
+++ b/packages/seal/src/kdf.ts
@@ -5,7 +5,7 @@ import { hkdf } from '@noble/hashes/hkdf';
 import { hmac } from '@noble/hashes/hmac';
 import { sha3_256 } from '@noble/hashes/sha3';
 
-import type { G2Element, GTElement } from './bls12381.js';
+import { G1Element, type G2Element, type GTElement } from './bls12381.js';
 
 /**
  * The default key derivation function.
@@ -39,7 +39,11 @@ export function kdf(
 			pi * COEFFICIENT_SIZE,
 		);
 	});
-	const inputBytes = new Uint8Array([...permutedBytes, ...nonce.toBytes(), ...id]);
+	const inputBytes = new Uint8Array([
+		...permutedBytes,
+		...nonce.toBytes(),
+		...G1Element.hashToCurve(id).toBytes(),
+	]);
 	return hkdf(sha3_256, inputBytes, '', info, 32);
 }
 

--- a/packages/seal/test/unit/encrypt.test.ts
+++ b/packages/seal/test/unit/encrypt.test.ts
@@ -356,9 +356,9 @@ describe('Seal encryption tests', () => {
 			G2Element.generator().multiply(Scalar.fromNumber(12345)),
 		);
 		const nonce = G2Element.generator().multiply(Scalar.fromNumber(12345));
-		const key = kdf(x, nonce, new Uint8Array([]), new Uint8Array([]));
+		const key = kdf(x, nonce, new Uint8Array([0]), new Uint8Array([]));
 		expect(key).toEqual(
-			fromHex('11c52f2f2df356ffdb11c0811bba3dedb7f56376d26ad5551be9a4b1ede0b87e'),
+			fromHex('57d43441a0b561088d4162a1b38ea8a2d443dd2c50ec4aca0610a1a79c057f74'),
 		);
 	});
 

--- a/packages/seal/test/unit/encrypt.test.ts
+++ b/packages/seal/test/unit/encrypt.test.ts
@@ -355,9 +355,10 @@ describe('Seal encryption tests', () => {
 		const x = G1Element.generator().pairing(
 			G2Element.generator().multiply(Scalar.fromNumber(12345)),
 		);
-		const key = kdf(x, new Uint8Array([]));
+		const nonce = G2Element.generator().multiply(Scalar.fromNumber(12345));
+		const key = kdf(x, nonce, new Uint8Array([]), new Uint8Array([]));
 		expect(key).toEqual(
-			fromHex('55e99a131b254f1687727bbf1f255e73bb80fcfac8901c371e53df32f45c1fb3'),
+			fromHex('11c52f2f2df356ffdb11c0811bba3dedb7f56376d26ad5551be9a4b1ede0b87e'),
 		);
 	});
 


### PR DESCRIPTION
## Description

Update the IBE in Seal to include all public parameters in the hash, aligning the implementation with that of "Identity Based Encryption Without Redundancy" by Libert and Quisquater.

## Test plan

Unit tests.

---
