### PR TITLE
[DO NOT MERGE YET][faucet] Update faucet routes

### DIFF
--- a/.changeset/little-spoons-bet.md
+++ b/.changeset/little-spoons-bet.md
@@ -1,0 +1,6 @@
+---
+'@mysten/create-dapp': minor
+'@mysten/sui': minor
+---
+
+Added a requestSuiFromFaucetV2 and added a deprecation comment on the previous requestSuiFromFaucetV0, V1, and status.

--- a/packages/create-dapp/templates/react-e2e-counter/README.md
+++ b/packages/create-dapp/templates/react-e2e-counter/README.md
@@ -47,17 +47,7 @@ sui client switch --address 0xYOUR_ADDRESS...
 ```
 
 We can ensure we have some Sui in our new wallet by requesting Sui from the
-faucet (make sure to replace the address with your address):
-
-```bash
-curl --location --request POST 'https://faucet.testnet.sui.io/gas' \
---header 'Content-Type: application/json' \
---data-raw '{
-    "FixedAmountRequest": {
-        "recipient": "<YOUR_ADDRESS>"
-    }
-}'
-```
+faucet `https://faucet.sui.io`.
 
 ### Publishing the move package
 

--- a/packages/docs/content/typescript/index.mdx
+++ b/packages/docs/content/typescript/index.mdx
@@ -15,12 +15,12 @@ npm i @mysten/sui
 
 The following table lists the locations for Sui networks.
 
-| Network | Full node                             | faucet                                |
-| ------- | ------------------------------------- | ------------------------------------- |
+| Network | Full node                             | faucet                                   |
+| ------- | ------------------------------------- | ---------------------------------------- |
 | local   | `http://127.0.0.1:9000` (default)     | `http://127.0.0.1:9123/v2/gas` (default) |
 | Devnet  | `https://fullnode.devnet.sui.io:443`  | `https://faucet.devnet.sui.io/v2/gas`    |
 | Testnet | `https://fullnode.testnet.sui.io:443` | `https://faucet.testnet.sui.io/v2/gas`   |
-| Mainnet | `https://fullnode.mainnet.sui.io:443` | `null`                                |
+| Mainnet | `https://fullnode.mainnet.sui.io:443` | `null`                                   |
 
 <Callout type="warn">
 

--- a/packages/docs/content/typescript/index.mdx
+++ b/packages/docs/content/typescript/index.mdx
@@ -17,9 +17,9 @@ The following table lists the locations for Sui networks.
 
 | Network | Full node                             | faucet                                |
 | ------- | ------------------------------------- | ------------------------------------- |
-| local   | `http://127.0.0.1:9000` (default)     | `http://127.0.0.1:9123/gas` (default) |
-| Devnet  | `https://fullnode.devnet.sui.io:443`  | `https://faucet.devnet.sui.io/gas`    |
-| Testnet | `https://fullnode.testnet.sui.io:443` | `https://faucet.testnet.sui.io/gas`   |
+| local   | `http://127.0.0.1:9000` (default)     | `http://127.0.0.1:9123/v2/gas` (default) |
+| Devnet  | `https://fullnode.devnet.sui.io:443`  | `https://faucet.devnet.sui.io/v2/gas`    |
+| Testnet | `https://fullnode.testnet.sui.io:443` | `https://faucet.testnet.sui.io/v2/gas`   |
 | Mainnet | `https://fullnode.mainnet.sui.io:443` | `null`                                |
 
 <Callout type="warn">

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -100,7 +100,7 @@ https://stackoverflow.com/questions/52676244/node-version-not-updating-after-nvm
 To run E2E tests against Devnet
 
 ```
-VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' pnpm --filter @mysten/sui exec vitest e2e
+VITE_FAUCET_URL='https://faucet.devnet.sui.io:443/v2/gas' VITE_FULLNODE_URL='https://fullnode.devnet.sui.io' pnpm --filter @mysten/sui exec vitest e2e
 ```
 
 ## Connecting to Sui Network

--- a/packages/typescript/src/faucet/faucet.ts
+++ b/packages/typescript/src/faucet/faucet.ts
@@ -103,6 +103,24 @@ export async function requestSuiFromFaucetV1(input: {
 	});
 }
 
+export async function requestSuiFromFaucetV2(input: {
+	host: string;
+	recipient: string;
+	headers?: HeadersInit;
+}): Promise<BatchFaucetResponse> {
+	return faucetRequest({
+		host: input.host,
+		path: '/v2/gas',
+		body: {
+			FixedAmountRequest: {
+				recipient: input.recipient,
+			},
+		},
+		headers: input.headers,
+		method: 'POST',
+	});
+}
+
 export async function getFaucetRequestStatus(input: {
 	host: string;
 	taskId: string;

--- a/packages/typescript/src/faucet/index.ts
+++ b/packages/typescript/src/faucet/index.ts
@@ -4,6 +4,7 @@
 export {
 	requestSuiFromFaucetV0,
 	requestSuiFromFaucetV1,
+	requestSuiFromFaucetV2,
 	getFaucetRequestStatus,
 	getFaucetHost,
 	FaucetRateLimitError,


### PR DESCRIPTION
## Description

The faucet will use the new `/v2/gas` routes very soon. This PR updates it in a few places, but ideally I would need @hayes-mysten to have a look to make sure we're covering it everywhere.

Please note that both `/gas` and `/v1/gas` will be deprecated, and an error response will be returned to use `/v2/gas` instead (which is heavily rate limited). Also, the response has changed. See https://github.com/MystenLabs/sui/issues/21775

!!! Not sure how the CI picks up changes from main `sui` repo, but probably this PR: https://github.com/MystenLabs/sui/pull/21865 needs to be merged there first.

## Test plan

How did you test the new or updated feature?

---
