### PR TITLE
feat(seal): add import and export session key

### DIFF
--- a/.changeset/wicked-teams-read.md
+++ b/.changeset/wicked-teams-read.md
@@ -1,0 +1,5 @@
+---
+'@mysten/seal': patch
+---
+
+feat(seal): add import export to session key

--- a/packages/seal/src/session-key.ts
+++ b/packages/seal/src/session-key.ts
@@ -8,7 +8,6 @@ import { SuiGraphQLClient } from '@mysten/sui/graphql';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { isValidSuiAddress, isValidSuiObjectId } from '@mysten/sui/utils';
 import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
-
 import { generateSecretKey, toPublicKey, toVerificationKey } from './elgamal.js';
 import {
 	ExpiredSessionKeyError,
@@ -28,6 +27,15 @@ export type Certificate = {
 	creation_time: number;
 	ttl_min: number;
 	signature: string;
+};
+
+export type SessionKeyType = {
+	address: string;
+	packageId: string;
+	creationTimeMs: number;
+	ttlMin: number;
+	personalMessageSignature?: string;
+	sessionKey: string;
 };
 
 export class SessionKey {
@@ -134,5 +142,53 @@ export class SessionKey {
 			decryptionKey: egSk,
 			requestSignature: toBase64(await this.#sessionKey.sign(msgToSign)),
 		};
+	}
+
+	/**
+	 * Export the Session Key object from the instance. Store the object in IndexedDB to persist.
+	 */
+	export(): SessionKeyType {
+		const obj = {
+			address: this.#address,
+			packageId: this.#packageId,
+			creationTimeMs: this.#creationTimeMs,
+			ttlMin: this.#ttlMin,
+			personalMessageSignature: this.#personalMessageSignature,
+			sessionKey: this.#sessionKey.getSecretKey(), // bech32 encoded string
+		};
+
+		Object.defineProperty(obj, 'toJSON', {
+			enumerable: false,
+			value: () => {
+				throw new Error('This object is not serializable');
+			},
+		});
+		return obj;
+	}
+
+	/**
+	 * Restore a SessionKey instance for the given object.
+	 * @returns A new SessionKey instance with restored state
+	 */
+	static async import(data: SessionKeyType): Promise<SessionKey> {
+		const instance = new SessionKey({
+			address: data.address,
+			packageId: data.packageId,
+			ttlMin: data.ttlMin,
+		});
+
+		instance.#creationTimeMs = data.creationTimeMs;
+		instance.#sessionKey = Ed25519Keypair.fromSecretKey(data.sessionKey);
+
+		// check if personal message signature is consistent with the personal message committing to
+		// the session key pk, package id, ttlMin.
+		if (data.personalMessageSignature) {
+			await instance.setPersonalMessageSignature(data.personalMessageSignature);
+		}
+
+		if (instance.isExpired()) {
+			throw new ExpiredSessionKeyError();
+		}
+		return instance;
 	}
 }

--- a/packages/seal/test/unit/integration.test.ts
+++ b/packages/seal/test/unit/integration.test.ts
@@ -16,7 +16,6 @@ import {
 	InvalidPersonalMessageSignatureError,
 	InvalidPTBError,
 	InvalidThresholdError,
-	InvalidUserSignatureError,
 	NoAccessError,
 	toMajorityError,
 } from '../../src/error';
@@ -266,10 +265,6 @@ describe('Integration test', () => {
 	it('test fetchKeys throws SealAPIError', async () => {
 		// Setup encrypted object.
 		const whitelistId = '0xaae704d2280f2c3d24fc08972bb31f2ef1f1c968784935434c3296be5bfd9d5b';
-		const txBytes = await constructTxBytes(TESTNET_PACKAGE_ID, 'whitelist', suiClient, [
-			whitelistId,
-		]);
-
 		const client = new SealClient({
 			suiClient,
 			serverObjectIds: objectIds,
@@ -291,17 +286,11 @@ describe('Integration test', () => {
 			address: wrongSuiAddress,
 			packageId: TESTNET_PACKAGE_ID,
 			ttlMin: 10,
-			signer: keypair,
 		});
-
-		await expect(
-			client.fetchKeys({
-				ids: [encryptedObject.id],
-				txBytes,
-				sessionKey,
-				threshold: encryptedObject.threshold,
-			}),
-		).rejects.toThrow(InvalidUserSignatureError);
+		const sig = await keypair.signPersonalMessage(sessionKey.getPersonalMessage());
+		await expect(sessionKey.setPersonalMessageSignature(sig.signature)).rejects.toThrow(
+			InvalidPersonalMessageSignatureError,
+		);
 
 		// Wrong txBytes fails to verify.
 		const sessionKey2 = new SessionKey({

--- a/packages/seal/test/unit/session-key.test.ts
+++ b/packages/seal/test/unit/session-key.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { SessionKey } from '../../src/session-key';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { InvalidPersonalMessageSignatureError } from '../../src/error';
+
+describe('Session key tests', () => {
+	const TESTNET_PACKAGE_ID = '0x9709d4ee371488c2bc09f508e98e881bd1d5335e0805d7e6a99edd54a7027954';
+	it('import and export session key', async () => {
+		const kp = Ed25519Keypair.generate();
+		const sessionKey = new SessionKey({
+			address: kp.getPublicKey().toSuiAddress(),
+			packageId: TESTNET_PACKAGE_ID,
+			ttlMin: 1,
+		});
+		const sig = await kp.signPersonalMessage(sessionKey.getPersonalMessage());
+		await sessionKey.setPersonalMessageSignature(sig.signature);
+
+		const exportedSessionKey = sessionKey.export();
+		const restoredSessionKey = await SessionKey.import(exportedSessionKey);
+
+		expect(restoredSessionKey.getAddress()).toBe(kp.getPublicKey().toSuiAddress());
+		expect(restoredSessionKey.getPackageId()).toBe(TESTNET_PACKAGE_ID);
+		expect(restoredSessionKey.export().sessionKey).toBe(sessionKey.export().sessionKey);
+		expect(restoredSessionKey.getPersonalMessage()).toEqual(sessionKey.getPersonalMessage());
+
+		await expect(
+			SessionKey.import({
+				address: kp.getPublicKey().toSuiAddress(),
+				packageId: TESTNET_PACKAGE_ID,
+				ttlMin: 1,
+				sessionKey: sessionKey.export().sessionKey,
+				creationTimeMs: sessionKey.export().creationTimeMs,
+				personalMessageSignature: 'invalid',
+			}),
+		).rejects.toThrowError(InvalidPersonalMessageSignatureError);
+	});
+});

--- a/packages/seal/test/unit/session-key.test.ts
+++ b/packages/seal/test/unit/session-key.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import { SessionKey } from '../../src/session-key';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import { InvalidPersonalMessageSignatureError } from '../../src/error';
+import { InvalidPersonalMessageSignatureError, UserError } from '../../src/error';
 
 describe('Session key tests', () => {
 	const TESTNET_PACKAGE_ID = '0x9709d4ee371488c2bc09f508e98e881bd1d5335e0805d7e6a99edd54a7027954';
@@ -19,22 +19,42 @@ describe('Session key tests', () => {
 		await sessionKey.setPersonalMessageSignature(sig.signature);
 
 		const exportedSessionKey = sessionKey.export();
-		const restoredSessionKey = await SessionKey.import(exportedSessionKey);
+		const restoredSessionKey = await SessionKey.import(exportedSessionKey, {});
 
 		expect(restoredSessionKey.getAddress()).toBe(kp.getPublicKey().toSuiAddress());
 		expect(restoredSessionKey.getPackageId()).toBe(TESTNET_PACKAGE_ID);
 		expect(restoredSessionKey.export().sessionKey).toBe(sessionKey.export().sessionKey);
 		expect(restoredSessionKey.getPersonalMessage()).toEqual(sessionKey.getPersonalMessage());
 
+		// invalid personal sig
 		await expect(
-			SessionKey.import({
-				address: kp.getPublicKey().toSuiAddress(),
-				packageId: TESTNET_PACKAGE_ID,
-				ttlMin: 1,
-				sessionKey: sessionKey.export().sessionKey,
-				creationTimeMs: sessionKey.export().creationTimeMs,
-				personalMessageSignature: 'invalid',
-			}),
+			SessionKey.import(
+				{
+					address: kp.getPublicKey().toSuiAddress(),
+					packageId: TESTNET_PACKAGE_ID,
+					ttlMin: 1,
+					sessionKey: sessionKey.export().sessionKey,
+					creationTimeMs: sessionKey.export().creationTimeMs,
+					personalMessageSignature: 'invalid',
+				},
+				{},
+			),
 		).rejects.toThrowError(InvalidPersonalMessageSignatureError);
+
+		// invalid signer
+		const kp2 = Ed25519Keypair.generate();
+		await expect(
+			SessionKey.import(
+				{
+					address: kp.getPublicKey().toSuiAddress(),
+					packageId: TESTNET_PACKAGE_ID,
+					ttlMin: 1,
+					sessionKey: sessionKey.export().sessionKey,
+					creationTimeMs: sessionKey.export().creationTimeMs,
+					personalMessageSignature: sig.signature,
+				},
+				{ signer: kp2 },
+			),
+		).rejects.toThrowError(UserError);
 	});
 });


### PR DESCRIPTION
## Description

add feat to import and export session key, useful to persist in web storage e.g. indexed db

## Test plan

unit test

---
