### PR TITLE
[faucet] Move to the latest faucet v2

### DIFF
--- a/packages/deepbook/test/e2e/globalSetup.ts
+++ b/packages/deepbook/test/e2e/globalSetup.ts
@@ -16,8 +16,8 @@ declare module 'vitest' {
 
 const SUI_TOOLS_TAG =
 	process.env.SUI_TOOLS_TAG || process.arch === 'arm64'
-		? '2e256a70aa0ff81972ded6ebd57f7679e2ea194d-arm64'
-		: '2e256a70aa0ff81972ded6ebd57f7679e2ea194d';
+		? '28dc33fc8fc43e50819c42c22b0d557b889c107e-arm64'
+		: '28dc33fc8fc43e50819c42c22b0d557b889c107e';
 
 export default async function setup({ provide }: GlobalSetupContext) {
 	console.log('Starting test containers');

--- a/packages/deepbook/test/e2e/setup.ts
+++ b/packages/deepbook/test/e2e/setup.ts
@@ -9,7 +9,7 @@ import type {
 	SuiTransactionBlockResponse,
 } from '@mysten/sui/client';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction } from '@mysten/sui/transactions';
 import type { ContainerRuntimeClient } from 'testcontainers';
@@ -58,7 +58,7 @@ export async function setupSuiClient() {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
 	const client = getClient();
-	await retry(() => requestSuiFromFaucetV0({ host: DEFAULT_FAUCET_URL, recipient: address }), {
+	await retry(() => requestSuiFromFaucetV2({ host: DEFAULT_FAUCET_URL, recipient: address }), {
 		backoff: 'EXPONENTIAL',
 		// overall timeout in 60 seconds
 		timeout: 1000 * 60,

--- a/packages/docs/content/typescript/faucet.mdx
+++ b/packages/docs/content/typescript/faucet.mdx
@@ -24,5 +24,5 @@ await requestSuiFromFaucetV2({
 <Callout type="info">
 	Faucets on Devnet and Testnet are rate limited. If you run the script too many times, you surpass
 	the limit and must wait to successfully run it again. For testnet,the best way to get SUI is via
-  the Web UI: `faucet.sui.io`.
+	the Web UI: `faucet.sui.io`.
 </Callout>

--- a/packages/docs/content/typescript/faucet.mdx
+++ b/packages/docs/content/typescript/faucet.mdx
@@ -5,17 +5,17 @@ title: Faucet
 Devnet, Testnet, and local networks include faucets that mint SUI. You can use the Sui TypeScript
 SDK to call a network's faucet and provide SUI to the address you provide.
 
-To request SUI from a faucet, import the `requestSuiFromFaucetV0` function from the
+To request SUI from a faucet, import the `requestSuiFromFaucetV2` function from the
 `@mysten/sui/faucet` package to your project.
 
 ```typescript
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 ```
 
-Use `requestSuiFromFaucetV0` in your TypeScript code to request SUI from the network's faucet.
+Use `requestSuiFromFaucetV2` in your TypeScript code to request SUI from the network's faucet.
 
 ```typescript
-await requestSuiFromFaucetV0({
+await requestSuiFromFaucetV2({
 	host: getFaucetHost('testnet'),
 	recipient: <RECIPIENT_ADDRESS>,
 });
@@ -23,5 +23,6 @@ await requestSuiFromFaucetV0({
 
 <Callout type="info">
 	Faucets on Devnet and Testnet are rate limited. If you run the script too many times, you surpass
-	the limit and must wait to successfully run it again.
+	the limit and must wait to successfully run it again. For testnet,the best way to get SUI is via
+  the Web UI: `faucet.sui.io`.
 </Callout>

--- a/packages/graphql-transport/src/methods.ts
+++ b/packages/graphql-transport/src/methods.ts
@@ -1380,6 +1380,9 @@ export const RPC_METHODS: {
 			max_package_dependencies: 'u32',
 			bridge_should_try_to_finalize_committee: 'bool',
 			consensus_voting_rounds: 'u32',
+			consensus_commit_rate_estimation_window_size: 'u32',
+			consensus_gc_depth: 'u32',
+			use_object_per_epoch_marker_table_v2: 'bool',
 		};
 
 		for (const { key, value } of protocolConfig.configs) {

--- a/packages/graphql-transport/test/globalSetup.ts
+++ b/packages/graphql-transport/test/globalSetup.ts
@@ -17,8 +17,8 @@ declare module 'vitest' {
 
 const SUI_TOOLS_TAG =
 	process.env.SUI_TOOLS_TAG || process.arch === 'arm64'
-		? '2e256a70aa0ff81972ded6ebd57f7679e2ea194d-arm64'
-		: '2e256a70aa0ff81972ded6ebd57f7679e2ea194d';
+		? '28dc33fc8fc43e50819c42c22b0d557b889c107e-arm64'
+		: '28dc33fc8fc43e50819c42c22b0d557b889c107e';
 
 export default async function setup({ provide }: GlobalSetupContext) {
 	console.log('Starting test containers');

--- a/packages/kiosk/test/e2e/globalSetup.ts
+++ b/packages/kiosk/test/e2e/globalSetup.ts
@@ -16,8 +16,8 @@ declare module 'vitest' {
 
 const SUI_TOOLS_TAG =
 	process.env.SUI_TOOLS_TAG || process.arch === 'arm64'
-		? '2e256a70aa0ff81972ded6ebd57f7679e2ea194d-arm64'
-		: '2e256a70aa0ff81972ded6ebd57f7679e2ea194d';
+		? '28dc33fc8fc43e50819c42c22b0d557b889c107e-arm64'
+		: '28dc33fc8fc43e50819c42c22b0d557b889c107e';
 
 export default async function setup({ provide }: GlobalSetupContext) {
 	console.log('Starting test containers');

--- a/packages/kiosk/test/e2e/setup.ts
+++ b/packages/kiosk/test/e2e/setup.ts
@@ -8,7 +8,7 @@ import type {
 	SuiTransactionBlockResponse,
 } from '@mysten/sui/client';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction } from '@mysten/sui/transactions';
 import type { ContainerRuntimeClient } from 'testcontainers';
@@ -53,7 +53,7 @@ export async function setupSuiClient() {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
 	const client = getClient();
-	await retry(() => requestSuiFromFaucetV0({ host: DEFAULT_FAUCET_URL, recipient: address }), {
+	await retry(() => requestSuiFromFaucetV2({ host: DEFAULT_FAUCET_URL, recipient: address }), {
 		backoff: 'EXPONENTIAL',
 		// overall timeout in 60 seconds
 		timeout: 1000 * 60,

--- a/packages/suins/test/toolbox.ts
+++ b/packages/suins/test/toolbox.ts
@@ -5,7 +5,7 @@ import { mkdtemp } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { FaucetRateLimitError, getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { retry } from 'ts-retry-promise';
 
@@ -48,7 +48,7 @@ export async function setupSuiClient() {
 	const keypair = Ed25519Keypair.generate();
 	const address = keypair.getPublicKey().toSuiAddress();
 	const client = getClient();
-	await retry(() => requestSuiFromFaucetV0({ host: DEFAULT_FAUCET_URL, recipient: address }), {
+	await retry(() => requestSuiFromFaucetV2({ host: DEFAULT_FAUCET_URL, recipient: address }), {
 		backoff: 'EXPONENTIAL',
 		// overall timeout in 60 seconds
 		timeout: 1000 * 60,

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -157,7 +157,8 @@ await client.getCoins({
 
 ## Getting coins from the faucet
 
-You can request sui from the faucet when running against devnet or localnet. For testnet, visit faucet.sui.io.
+You can request sui from the faucet when running against devnet or localnet. For testnet, visit
+faucet.sui.io.
 
 ```typescript
 import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -157,13 +157,13 @@ await client.getCoins({
 
 ## Getting coins from the faucet
 
-You can request sui from the faucet when running against devnet, testnet, or localnet
+You can request sui from the faucet when running against devnet or localnet. For testnet, visit faucet.sui.io.
 
 ```typescript
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 
-await requestSuiFromFaucetV0({
-	host: getFaucetHost('testnet'),
+await requestSuiFromFaucetV2({
+	host: getFaucetHost('devnet'),
 	recipient: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 });
 ```

--- a/packages/typescript/src/faucet/faucet.ts
+++ b/packages/typescript/src/faucet/faucet.ts
@@ -31,7 +31,7 @@ type BatchStatusFaucetResponse = {
 
 type FaucetResponseV2 = {
 	status: 'Success' | FaucetFailure;
-	coin_sent: FaucetCoinInfo | null;
+	coins_sent: FaucetCoinInfo[] | null;
 };
 
 type FaucetFailure = {

--- a/packages/typescript/test/e2e/utils/globalSetup.ts
+++ b/packages/typescript/test/e2e/utils/globalSetup.ts
@@ -16,8 +16,8 @@ declare module 'vitest' {
 
 const SUI_TOOLS_TAG =
 	process.env.SUI_TOOLS_TAG || process.arch === 'arm64'
-		? '2e256a70aa0ff81972ded6ebd57f7679e2ea194d-arm64'
-		: '2e256a70aa0ff81972ded6ebd57f7679e2ea194d';
+		? '28dc33fc8fc43e50819c42c22b0d557b889c107e-arm64'
+		: '28dc33fc8fc43e50819c42c22b0d557b889c107e';
 
 export default async function setup({ provide }: GlobalSetupContext) {
 	console.log('Starting test containers');
@@ -37,6 +37,7 @@ export default async function setup({ provide }: GlobalSetupContext) {
 		.start();
 
 	const localnet = await new GenericContainer(`mysten/sui-tools:${SUI_TOOLS_TAG}`)
+		// .withPullPolicy(PullPolicy.alwaysPull())
 		.withCommand([
 			'sui',
 			'start',

--- a/packages/typescript/test/e2e/utils/setup.ts
+++ b/packages/typescript/test/e2e/utils/setup.ts
@@ -14,7 +14,7 @@ import type { Keypair } from '../../../src/cryptography/index.js';
 import {
 	FaucetRateLimitError,
 	getFaucetHost,
-	requestSuiFromFaucetV1,
+	requestSuiFromFaucetV2,
 } from '../../../src/faucet/index.js';
 import { Ed25519Keypair } from '../../../src/keypairs/ed25519/index.js';
 import { Transaction, UpgradePolicy } from '../../../src/transactions/index.js';
@@ -132,7 +132,7 @@ export async function setupWithFundedAddress(
 ) {
 	const client = getClient(rpcURL ?? DEFAULT_FULLNODE_URL);
 	await retry(
-		async () => await requestSuiFromFaucetV1({ host: DEFAULT_FAUCET_URL, recipient: address }),
+		async () => await requestSuiFromFaucetV2({ host: DEFAULT_FAUCET_URL, recipient: address }),
 		{
 			backoff: 'EXPONENTIAL',
 			// overall timeout in 60 seconds

--- a/packages/walrus/examples/funded-keypair.ts
+++ b/packages/walrus/examples/funded-keypair.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { coinWithBalance, Transaction } from '@mysten/sui/transactions';
 import { MIST_PER_SUI, parseStructTag } from '@mysten/sui/utils';
@@ -24,7 +24,7 @@ export async function getFundedKeypair() {
 	});
 
 	if (BigInt(balance.totalBalance) < MIST_PER_SUI) {
-		await requestSuiFromFaucetV0({
+		await requestSuiFromFaucetV2({
 			host: getFaucetHost('testnet'),
 			recipient: keypair.toSuiAddress(),
 		});

--- a/packages/zksend/src/index.test.ts
+++ b/packages/zksend/src/index.test.ts
@@ -4,7 +4,7 @@
 import { describe } from 'node:test';
 import { getFullnodeUrl, SuiClient, SuiObjectChange } from '@mysten/sui/client';
 import { decodeSuiPrivateKey, Keypair } from '@mysten/sui/cryptography';
-import { getFaucetHost, requestSuiFromFaucetV0 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction } from '@mysten/sui/transactions';
 import { MIST_PER_SUI, toBase64 } from '@mysten/sui/utils';
@@ -45,7 +45,7 @@ beforeAll(async () => {
 
 async function getSuiFromFaucet(keypair: Keypair) {
 	const faucetHost = getFaucetHost('testnet');
-	const result = await requestSuiFromFaucetV0({
+	const result = await requestSuiFromFaucetV2({
 		host: faucetHost,
 		recipient: keypair.toSuiAddress(),
 	});

--- a/packages/zksend/src/index.test.ts
+++ b/packages/zksend/src/index.test.ts
@@ -45,17 +45,9 @@ beforeAll(async () => {
 
 async function getSuiFromFaucet(keypair: Keypair) {
 	const faucetHost = getFaucetHost('testnet');
-	const result = await requestSuiFromFaucetV2({
+	await requestSuiFromFaucetV2({
 		host: faucetHost,
 		recipient: keypair.toSuiAddress(),
-	});
-
-	if (result.error) {
-		throw new Error(result.error);
-	}
-
-	await client.waitForTransaction({
-		digest: result.transferredGasObjects[0].transferTxDigest,
 	});
 }
 


### PR DESCRIPTION
## Description

This PR updates the test suite to use the latest faucet v2. This new version includes a simplified local faucet which now uses `/v2/gas` as the standard route.

Before this can be merged/used, we need to also update the `sui-tools` image to refer to a commit that has the new local faucet changes in the main `sui-repo`.

## Test plan

How did you test the new or updated feature?

---
