### PR TITLE
fix(deepbook): Use Math.round for adjusted sizes in createPermissionlessPool

### DIFF
--- a/packages/deepbook-v3/src/transactions/deepbook.ts
+++ b/packages/deepbook-v3/src/transactions/deepbook.ts
@@ -729,9 +729,9 @@ export class DeepBookContract {
 		const baseScalar = baseCoin.scalar;
 		const quoteScalar = quoteCoin.scalar;
 
-		const adjustedTickSize = (tickSize * FLOAT_SCALAR * quoteScalar) / baseScalar;
-		const adjustedLotSize = lotSize * baseScalar;
-		const adjustedMinSize = minSize * baseScalar;
+		const adjustedTickSize = Math.round((tickSize * FLOAT_SCALAR * quoteScalar) / baseScalar);
+		const adjustedLotSize = Math.round(lotSize * baseScalar);
+		const adjustedMinSize = Math.round(minSize * baseScalar);
 
 		const deepCoinInput =
 			deepCoin ??


### PR DESCRIPTION
## Description

Calling the `createPermissionlessPool` function can lead to a runtime error:
`RangeError: The number X cannot be converted to a BigInt because it is not an integer`
(e.g., `The number 1000.0000000000001 cannot be converted to a BigInt...`)

This occurs when providing decimal inputs for `lotSize` or `minSize` that, when multiplied by the asset's `scalar` result in a number with a tiny fractional component due to precision limitations (e.g., `0.00001 * 1e8` might yield `1000.0000000000001` instead of exactly `1000`).

This non-integer float is then passed to the Sui SDK's `tx.pure.u64()` function for BCS serialization, which strictly requires an integer representation and throws the `RangeError`.

Other calculations within the same `DeepBookContract` class (like `inputQuantity` in `placeLimitOrder`, `placeMarketOrder`, etc.) already use `Math.round()` to prevent this issue.

This PR applies `Math.round()` to the internal calculations of `adjustedLotSize`,  `adjustedTickSize` and `adjustedMinSize` within the `createPermissionlessPool`

## Test plan

Discovered locally by attempting to create a pool with parameters `lotSize: 0.00001` and `minSize: 0.00001`. Without this change, the operation failed with the `RangeError`. To test just re-run the and should be sucesfull 

