### PR TITLE
[signers] fix broken message signing in the Ledger signer

### DIFF
--- a/.changeset/many-ads-drum.md
+++ b/.changeset/many-ads-drum.md
@@ -1,0 +1,5 @@
+---
+'@mysten/signers': patch
+---
+
+Fix broken message signing for the Ledger signer

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -174,12 +174,12 @@ cryptographic operations.
 import Transport from '@ledgerhq/hw-transport-node-hid';
 import SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
 import { LedgerSigner } from '@mysten/signers/ledger';
-import { SuiClient } from '@mysten/sui/client';
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 
 const transport = await Transport.open(undefined);
 const ledgerClient = new SuiLedgerClient(transport);
-const suiClient = new SuiClient({ url: getNetworkUrl('testnet') });
+const suiClient = new SuiClient({ url: getFullnodeUrl('testnet') });
 
 const signer = await LedgerSigner.fromDerivationPath({
 	derivationPath: "m/44'/784'/0'/0'/0'",

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -181,11 +181,11 @@ const transport = await Transport.open(undefined);
 const ledgerClient = new SuiLedgerClient(transport);
 const suiClient = new SuiClient({ url: getFullnodeUrl('testnet') });
 
-const signer = await LedgerSigner.fromDerivationPath({
-	derivationPath: "m/44'/784'/0'/0'/0'",
+const signer = await LedgerSigner.fromDerivationPath(
+	"m/44'/784'/0'/0'/0'",
 	ledgerClient,
 	suiClient,
-});
+);
 
 // Log the Sui address:
 console.log(signer.toSuiAddress());

--- a/packages/signers/src/ledger/index.ts
+++ b/packages/signers/src/ledger/index.ts
@@ -10,6 +10,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { toBase64 } from '@mysten/sui/utils';
 
 import { SuiMoveObject } from './bcs.js';
+import { bcs } from '@mysten/sui/bcs';
 
 /**
  * Configuration options for initializing the LedgerSigner.
@@ -92,7 +93,10 @@ export class LedgerSigner extends Signer {
 	 * @returns The signed message bytes and signature.
 	 */
 	override async signPersonalMessage(bytes: Uint8Array): Promise<SignatureWithBytes> {
-		const intentMessage = messageWithIntent('PersonalMessage', bytes);
+		const intentMessage = messageWithIntent(
+			'PersonalMessage',
+			bcs.vector(bcs.u8()).serialize(bytes).toBytes(),
+		);
 		const { signature } = await this.#ledgerClient.signTransaction(
 			this.#derivationPath,
 			intentMessage,

--- a/packages/signers/src/ledger/index.ts
+++ b/packages/signers/src/ledger/index.ts
@@ -95,7 +95,7 @@ export class LedgerSigner extends Signer {
 	override async signPersonalMessage(bytes: Uint8Array): Promise<SignatureWithBytes> {
 		const intentMessage = messageWithIntent(
 			'PersonalMessage',
-			bcs.vector(bcs.u8()).serialize(bytes).toBytes(),
+			bcs.byteVector().serialize(bytes).toBytes(),
 		);
 		const { signature } = await this.#ledgerClient.signTransaction(
 			this.#derivationPath,


### PR DESCRIPTION
## Description
 
Fixes https://github.com/MystenLabs/ts-sdks/issues/262. I forgot to serialize the messsage bytes to BCS :oops:


## Test plan
```
williamrobertson@Williams-MacBook-Pro signers % pnpm tsx src/ledger/test.ts
sig AIWgztm+twdZws6yxn+p9NBNn5aFa0lz5YBvUHIR/iaWI6Q98h7zTCjVqIpjGZE7ibnAi1HpU5kt+GReLrUdjwCFQ+ltaeiDqXcXeTh0s9p1SPNI5+eQfiUKGMOqORWGMA==
parsed address 0x1255d09304c5cc824b9ef4fd9196f5b8e96167b4fb0266f70dd36829ad519d5d
verified address 0x1255d09304c5cc824b9ef4fd9196f5b8e96167b4fb0266f70dd36829ad519d5d
```
