### PR TITLE
[walrus] add `computeBlobMetadata` method to the client

### DIFF
--- a/.changeset/rare-cougars-chew.md
+++ b/.changeset/rare-cougars-chew.md
@@ -1,0 +1,5 @@
+---
+'@mysten/walrus': minor
+---
+
+Add `computeBlobMetadata` method to the client which can be used to pre-compute the ID and other metadata given a set of bytes

--- a/packages/walrus/examples/basics/read-blob.ts
+++ b/packages/walrus/examples/basics/read-blob.ts
@@ -6,8 +6,8 @@ import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { WalrusClient } from '../../src/client.js';
 
 const client = new SuiClient({
-	url: getFullnodeUrl('testnet'),
-	network: 'testnet',
+	url: getFullnodeUrl('mainnet'),
+	network: 'mainnet',
 }).$extend(WalrusClient.experimental_asClientExtension());
 
 export async function retrieveBlob(blobId: string) {
@@ -16,10 +16,13 @@ export async function retrieveBlob(blobId: string) {
 }
 
 (async function main() {
-	const blob = await retrieveBlob('OFrKO0ofGc4inX8roHHaAB-pDHuUiIA08PW4N2B2gFk');
+	const bytes = new TextEncoder().encode(`hello world`.repeat(400_000));
 
-	const textDecoder = new TextDecoder('utf-8');
-	const resultString = textDecoder.decode(await blob.arrayBuffer());
+	console.log(bytes.length);
 
-	console.log(resultString);
+	console.time();
+	const blob = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
+	console.timeEnd();
+
+	console.log(blob.blobId);
 })();

--- a/packages/walrus/examples/basics/read-blob.ts
+++ b/packages/walrus/examples/basics/read-blob.ts
@@ -6,8 +6,8 @@ import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 import { WalrusClient } from '../../src/client.js';
 
 const client = new SuiClient({
-	url: getFullnodeUrl('mainnet'),
-	network: 'mainnet',
+	url: getFullnodeUrl('testnet'),
+	network: 'testnet',
 }).$extend(WalrusClient.experimental_asClientExtension());
 
 export async function retrieveBlob(blobId: string) {
@@ -16,22 +16,10 @@ export async function retrieveBlob(blobId: string) {
 }
 
 (async function main() {
-	const bytes = new TextEncoder().encode(`hello world`.repeat(400_000));
+	const blob = await retrieveBlob('OFrKO0ofGc4inX8roHHaAB-pDHuUiIA08PW4N2B2gFk');
 
-	console.log(bytes.length);
+	const textDecoder = new TextDecoder('utf-8');
+	const resultString = textDecoder.decode(await blob.arrayBuffer());
 
-	console.time();
-	const blob = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
-
-	console.timeEnd();
-
-	console.time('blob2');
-	const blob2 = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
-	console.timeEnd('blob2');
-
-	console.time('blob3');
-	const blob3 = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
-	console.timeEnd('blob3');
-
-	console.log(blob.blobId);
+	console.log(resultString);
 })();

--- a/packages/walrus/examples/basics/read-blob.ts
+++ b/packages/walrus/examples/basics/read-blob.ts
@@ -22,7 +22,16 @@ export async function retrieveBlob(blobId: string) {
 
 	console.time();
 	const blob = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
+
 	console.timeEnd();
+
+	console.time('blob2');
+	const blob2 = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
+	console.timeEnd('blob2');
+
+	console.time('blob3');
+	const blob3 = await client.walrus.computeBlobMetadata({ bytes, numShards: 1000 });
+	console.timeEnd('blob3');
 
 	console.log(blob.blobId);
 })();

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -311,9 +311,22 @@ export class WalrusClient {
 		return blobBytes;
 	}
 
-	async computeBlobMetadata({ bytes }: ComputeBlobMetadataOptions) {
-		const [bindings, systemState] = await Promise.all([this.#wasmBindings(), this.systemState()]);
-		const { blob_id, metadata } = bindings.computeMetadata(systemState.committee.n_shards, bytes);
+	async computeBlobMetadata({ bytes, numShards }: ComputeBlobMetadataOptions) {
+		let shardCount: number | undefined;
+		if (typeof numShards === 'number') {
+			shardCount = numShards;
+		} else {
+			const systemState = await this.systemState();
+			shardCount = systemState.committee.n_shards;
+		}
+
+		console.time('w');
+		const bindings = await this.#wasmBindings();
+		console.timeEnd('w');
+
+		console.time('m');
+		const { blob_id, metadata } = bindings.computeMetadata(shardCount, bytes);
+		console.timeEnd('m');
 
 		return {
 			blobId: blob_id,

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -320,13 +320,8 @@ export class WalrusClient {
 			shardCount = systemState.committee.n_shards;
 		}
 
-		console.time('w');
 		const bindings = await this.#wasmBindings();
-		console.timeEnd('w');
-
-		console.time('m');
 		const { blob_id, metadata } = bindings.computeMetadata(shardCount, bytes);
-		console.timeEnd('m');
 
 		return {
 			blobId: blob_id,

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -141,6 +141,7 @@ export type GetVerifiedBlobStatusOptions = ReadBlobOptions;
 
 export type ComputeBlobMetadataOptions = {
 	bytes: Uint8Array;
+	numShards?: number;
 };
 
 export interface SliversForNode {

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -139,6 +139,10 @@ export type GetSliversOptions = ReadBlobOptions;
 
 export type GetVerifiedBlobStatusOptions = ReadBlobOptions;
 
+export type ComputeBlobMetadataOptions = {
+	bytes: Uint8Array;
+};
+
 export interface SliversForNode {
 	primary: {
 		sliverIndex: number;


### PR DESCRIPTION
## Description

To compute the metadata for a blob before uploading it, you have to call `encodeBlob` which does a lot of other stuff and is really meant to be used during the write flow. This PR exposes a `computeBlobMetadata` method on the client which is about 2x faster (3s -> 1.5s) than `encodeBlob` given the fact that you don't have to make any network requests.

The real perf slowdown is with the WASM bindings so this doesn't totally fix the reported issue in https://github.com/MystenLabs/walrus/issues/2030, but eh it might still be worth shipping anyway. LMK what you think when you're back from PTO @hayes-mysten 

## Test plan
- Tested manually