### PR TITLE
[wallet-standard] expose feature name variables

### DIFF
--- a/.changeset/floppy-bobcats-stop.md
+++ b/.changeset/floppy-bobcats-stop.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-standard': minor
+---
+
+Expose variables for feature names

--- a/packages/wallet-standard/src/detect.ts
+++ b/packages/wallet-standard/src/detect.ts
@@ -1,16 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { StandardConnect, StandardEvents } from '@wallet-standard/core';
 import type { Wallet, WalletWithFeatures } from '@wallet-standard/core';
 
 import type { MinimallyRequiredFeatures } from './features/index.js';
 
 // These features are absolutely required for wallets to function in the Sui ecosystem.
 // Eventually, as wallets have more consistent support of features, we may want to extend this list.
-const REQUIRED_FEATURES: (keyof MinimallyRequiredFeatures)[] = [
-	'standard:connect',
-	'standard:events',
-];
+const REQUIRED_FEATURES: (keyof MinimallyRequiredFeatures)[] = [StandardConnect, StandardEvents];
 
 export function isWalletWithRequiredFeatureSet<AdditionalFeatures extends Wallet['features']>(
 	wallet: Wallet,

--- a/packages/wallet-standard/src/features/suiReportTransactionEffects.ts
+++ b/packages/wallet-standard/src/features/suiReportTransactionEffects.ts
@@ -3,6 +3,12 @@
 
 import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
 
+/** Name of the feature. */
+export const SuiReportTransactionEffects = 'sui:reportTransactionEffects';
+
+/** The latest API version of the reportTransactionEffects API. */
+export type SuiReportTransactionEffectsVersion = '1.0.0';
+
 /**
  * A Wallet Standard feature for reporting the effects of a transaction block executed by a dapp
  * The feature allows wallets to updated their caches using the effects of the transaction
@@ -10,9 +16,9 @@ import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
  */
 export type SuiReportTransactionEffectsFeature = {
 	/** Namespace for the feature. */
-	'sui:reportTransactionEffects': {
+	[SuiReportTransactionEffects]: {
 		/** Version of the feature API. */
-		version: '1.0.0';
+		version: SuiReportTransactionEffectsVersion;
 		reportTransactionEffects: SuiReportTransactionEffectsMethod;
 	};
 };

--- a/packages/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
+++ b/packages/wallet-standard/src/features/suiSignAndExecuteTransaction.ts
@@ -3,6 +3,9 @@
 
 import type { SignedTransaction, SuiSignTransactionInput } from './suiSignTransaction.js';
 
+/** Name of the feature. */
+export const SuiSignAndExecuteTransaction = 'sui:signAndExecuteTransaction';
+
 /** The latest API version of the signAndExecuteTransactionBlock API. */
 export type SuiSignAndExecuteTransactionVersion = '2.0.0';
 
@@ -13,7 +16,7 @@ export type SuiSignAndExecuteTransactionVersion = '2.0.0';
  */
 export type SuiSignAndExecuteTransactionFeature = {
 	/** Namespace for the feature. */
-	'sui:signAndExecuteTransaction': {
+	[SuiSignAndExecuteTransaction]: {
 		/** Version of the feature API. */
 		version: SuiSignAndExecuteTransactionVersion;
 		signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod;

--- a/packages/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
+++ b/packages/wallet-standard/src/features/suiSignAndExecuteTransactionBlock.ts
@@ -9,6 +9,9 @@ import type {
 
 import type { SuiSignTransactionBlockInput } from './suiSignTransactionBlock.js';
 
+/** Name of the feature. */
+export const SuiSignAndExecuteTransactionBlock = 'sui:signAndExecuteTransactionBlock';
+
 /** The latest API version of the signAndExecuteTransactionBlock API. */
 export type SuiSignAndExecuteTransactionBlockVersion = '1.0.0';
 
@@ -21,7 +24,7 @@ export type SuiSignAndExecuteTransactionBlockVersion = '1.0.0';
  */
 export type SuiSignAndExecuteTransactionBlockFeature = {
 	/** Namespace for the feature. */
-	'sui:signAndExecuteTransactionBlock': {
+	[SuiSignAndExecuteTransactionBlock]: {
 		/** Version of the feature API. */
 		version: SuiSignAndExecuteTransactionBlockVersion;
 		/** @deprecated Use `sui:signAndExecuteTransaction` instead. */

--- a/packages/wallet-standard/src/features/suiSignMessage.ts
+++ b/packages/wallet-standard/src/features/suiSignMessage.ts
@@ -3,6 +3,9 @@
 
 import type { WalletAccount } from '@wallet-standard/core';
 
+/** Name of the feature. */
+export const SuiSignMessage = 'sui:signMessage';
+
 /**
  * The latest API version of the signMessage API.
  * @deprecated Wallets can still implement this method for compatibility, but this has been replaced by the `sui:signPersonalMessage` feature

--- a/packages/wallet-standard/src/features/suiSignMessage.ts
+++ b/packages/wallet-standard/src/features/suiSignMessage.ts
@@ -3,7 +3,10 @@
 
 import type { WalletAccount } from '@wallet-standard/core';
 
-/** Name of the feature. */
+/**
+ * Name of the feature.
+ * @deprecated Wallets can still implement this method for compatibility, but this has been replaced by the `sui:signPersonalMessage` feature
+ **/
 export const SuiSignMessage = 'sui:signMessage';
 
 /**

--- a/packages/wallet-standard/src/features/suiSignMessage.ts
+++ b/packages/wallet-standard/src/features/suiSignMessage.ts
@@ -20,7 +20,7 @@ export type SuiSignMessageVersion = '1.0.0';
  */
 export type SuiSignMessageFeature = {
 	/** Namespace for the feature. */
-	'sui:signMessage': {
+	[SuiSignMessage]: {
 		/** Version of the feature API. */
 		version: SuiSignMessageVersion;
 		signMessage: SuiSignMessageMethod;

--- a/packages/wallet-standard/src/features/suiSignPersonalMessage.ts
+++ b/packages/wallet-standard/src/features/suiSignPersonalMessage.ts
@@ -3,6 +3,9 @@
 
 import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
 
+/** Name of the feature. */
+export const SuiSignPersonalMessage = 'sui:signPersonalMessage';
+
 /** The latest API version of the signPersonalMessage API. */
 export type SuiSignPersonalMessageVersion = '1.1.0';
 
@@ -12,7 +15,7 @@ export type SuiSignPersonalMessageVersion = '1.1.0';
  */
 export type SuiSignPersonalMessageFeature = {
 	/** Namespace for the feature. */
-	'sui:signPersonalMessage': {
+	[SuiSignPersonalMessage]: {
 		/** Version of the feature API. */
 		version: SuiSignPersonalMessageVersion;
 		signPersonalMessage: SuiSignPersonalMessageMethod;

--- a/packages/wallet-standard/src/features/suiSignTransaction.ts
+++ b/packages/wallet-standard/src/features/suiSignTransaction.ts
@@ -3,6 +3,9 @@
 
 import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
 
+/** Name of the feature. */
+export const SuiSignTransaction = 'sui:signTransaction';
+
 /** The latest API version of the signTransaction API. */
 export type SuiSignTransactionVersion = '2.0.0';
 
@@ -12,7 +15,7 @@ export type SuiSignTransactionVersion = '2.0.0';
  */
 export type SuiSignTransactionFeature = {
 	/** Namespace for the feature. */
-	'sui:signTransaction': {
+	[SuiSignTransaction]: {
 		/** Version of the feature API. */
 		version: SuiSignTransactionVersion;
 		signTransaction: SuiSignTransactionMethod;

--- a/packages/wallet-standard/src/features/suiSignTransactionBlock.ts
+++ b/packages/wallet-standard/src/features/suiSignTransactionBlock.ts
@@ -4,6 +4,9 @@
 import type { Transaction } from '@mysten/sui/transactions';
 import type { IdentifierString, WalletAccount } from '@wallet-standard/core';
 
+/** Name of the feature. */
+export const SuiSignTransactionBlock = 'sui:signTransactionBlock';
+
 /** The latest API version of the signTransactionBlock API. */
 export type SuiSignTransactionBlockVersion = '1.0.0';
 
@@ -15,7 +18,7 @@ export type SuiSignTransactionBlockVersion = '1.0.0';
  */
 export type SuiSignTransactionBlockFeature = {
 	/** Namespace for the feature. */
-	'sui:signTransactionBlock': {
+	[SuiSignTransactionBlock]: {
 		/** Version of the feature API. */
 		version: SuiSignTransactionBlockVersion;
 		/** @deprecated Use `sui:signTransaction` instead. */


### PR DESCRIPTION
## Description

This is a super tiny PR to expose the names of features so you can just use variables in wallet implementations and libraries which matches what the core standard exposes.

## Test plan
- CI
- 👁️ 
