### PR TITLE
[seal] Fix handling of weighted key servers

### DIFF
--- a/.changeset/blue-mangos-float.md
+++ b/.changeset/blue-mangos-float.md
@@ -1,0 +1,5 @@
+---
+'@mysten/seal': patch
+---
+
+Better handling of weighted/duplicate key servers.

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -13,7 +13,7 @@ import {
 	InvalidKeyServerError,
 	InvalidThresholdError,
 	toMajorityError,
-	TooManyFailedFetchKeysError as TooManyFailedFetchKeyRequestsError,
+	TooManyFailedFetchKeyRequestsError,
 } from './error.js';
 import { BonehFranklinBLS12381Services, DST } from './ibe.js';
 import {

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -211,7 +211,7 @@ export class SealClient {
 
 	async #loadKeyServers(): Promise<Map<string, KeyServer>> {
 		const keyServers = await retrieveKeyServers({
-			objectIds: this.#weights.keys().toArray(),
+			objectIds: [...this.#weights].map(([objectId]) => objectId),
 			client: this.#suiClient,
 		});
 

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -254,19 +254,18 @@ export class SealClient {
 		sessionKey: SessionKey;
 		threshold: number;
 	}) {
-		const keyServers = await this.getKeyServers();
 		if (threshold > this.#totalWeight || threshold < 1) {
 			throw new InvalidThresholdError(
 				`Invalid threshold ${threshold} servers with weights ${this.#weights}`,
 			);
 		}
-
-		let completedWeight = 0;
-		const remainingKeyServers = [];
+		const keyServers = await this.getKeyServers();
 		const fullIds = ids.map((id) => createFullId(DST, sessionKey.getPackageId(), id));
 
 		// Count a server as completed if it has keys for all fullIds.
 		// Duplicated key server ids will be counted towards the threshold.
+		let completedWeight = 0;
+		const remainingKeyServers = [];
 		let remainingKeyServersWeight = 0;
 		for (const objectId of keyServers.keys()) {
 			if (fullIds.every((fullId) => this.#cachedKeys.has(`${fullId}:${objectId}`))) {

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -345,7 +345,7 @@ export class SealClient {
 
 				// Check if all the receivedIds are consistent with the requested fullIds.
 				// If so, consider the key server got all keys and mark as completed.
-				if (fullIds.every((fullIds) => receivedIds.has(fullIds))) {
+				if (fullIds.every((fullId) => receivedIds.has(fullId))) {
 					completedWeight += this.#weight(objectId)!;
 
 					// Return early if the completed servers is more than the threshold.

--- a/packages/seal/src/error.ts
+++ b/packages/seal/src/error.ts
@@ -145,7 +145,7 @@ export class InvalidThresholdError extends UserError {}
 export class InconsistentKeyServersError extends UserError {}
 export class DecryptionError extends UserError {}
 export class InvalidClientOptionsError extends UserError {}
-export class TooManyFailedFetchKeysError extends UserError {}
+export class TooManyFailedFetchKeyRequestsError extends UserError {}
 
 export function toMajorityError(errors: Error[]): Error {
 	let maxCount = 0;

--- a/packages/seal/src/error.ts
+++ b/packages/seal/src/error.ts
@@ -144,6 +144,8 @@ export class InvalidCiphertextError extends UserError {}
 export class InvalidThresholdError extends UserError {}
 export class InconsistentKeyServersError extends UserError {}
 export class DecryptionError extends UserError {}
+export class InvalidClientOptionsError extends UserError {}
+export class TooManyFailedFetchKeysError extends UserError {}
 
 export function toMajorityError(errors: Error[]): Error {
 	let maxCount = 0;

--- a/packages/seal/test/unit/integration.test.ts
+++ b/packages/seal/test/unit/integration.test.ts
@@ -461,8 +461,8 @@ describe('Integration test', () => {
 		global.fetch = globalFetch;
 
 		const serverObjectIds: [string, number][] = [
-			['0x5ff11892a21430921fa7b1e3e0eb63d6d25dff2e0c8eeb6b5a79b37c974e355e', 3],
-			['0xe015d62f26a7877de22e6d3c763e97c1aa9a8d064cd79a1bf8fc6b435f7a50b4', 2],
+			[objectIds[0][0], 3],
+			[objectIds[1][0], 2],
 		];
 		const client = new SealClient({
 			suiClient,

--- a/packages/seal/test/unit/integration.test.ts
+++ b/packages/seal/test/unit/integration.test.ts
@@ -55,43 +55,58 @@ async function constructTxBytes(
 const pk = fromBase64(
 	'oEC1VIuwQo+6FZiVwHCAy/3HbvAbuIyiztXIWwd4LgmXCh9WhOKg3T0+Mb62y9fqAsSaN5SybG09n/3JnkmEzJgdDXLpM8KvMwkha/cBHp6Cx7aCdogvGLoOp/RadyHb',
 );
-const MOCK_KEY_SERVERS = [
-	{
-		name: 'server1',
-		objectId: 'server1',
-		url: 'url1',
-		keyType: KeyServerType.BonehFranklinBLS12381,
-		pk,
-	},
-	{
-		name: 'server2',
-		objectId: 'server2',
-		url: 'url2',
-		keyType: KeyServerType.BonehFranklinBLS12381,
-		pk,
-	},
-	{
-		name: 'server3',
-		objectId: 'server3',
-		url: 'url3',
-		keyType: KeyServerType.BonehFranklinBLS12381,
-		pk,
-	},
-	{
-		name: 'server4',
-		objectId: 'server4',
-		url: 'url4',
-		keyType: KeyServerType.BonehFranklinBLS12381,
-		pk,
-	},
-	{
-		name: 'server5',
-		objectId: 'server5',
-		url: 'url5',
-		keyType: KeyServerType.BonehFranklinBLS12381,
-		pk,
-	},
-];
+const MOCK_KEY_SERVERS = new Map([
+	[
+		'server1',
+		{
+			name: 'server1',
+			objectId: 'server1',
+			url: 'url1',
+			keyType: KeyServerType.BonehFranklinBLS12381,
+			pk,
+		},
+	],
+	[
+		'server2',
+		{
+			name: 'server2',
+			objectId: 'server2',
+			url: 'url2',
+			keyType: KeyServerType.BonehFranklinBLS12381,
+			pk,
+		},
+	],
+	[
+		'server3',
+		{
+			name: 'server3',
+			objectId: 'server3',
+			url: 'url3',
+			keyType: KeyServerType.BonehFranklinBLS12381,
+			pk,
+		},
+	],
+	[
+		'server4',
+		{
+			name: 'server4',
+			objectId: 'server4',
+			url: 'url4',
+			keyType: KeyServerType.BonehFranklinBLS12381,
+			pk,
+		},
+	],
+	[
+		'server5',
+		{
+			name: 'server5',
+			objectId: 'server5',
+			url: 'url5',
+			keyType: KeyServerType.BonehFranklinBLS12381,
+			pk,
+		},
+	],
+]);
 describe('Integration test', () => {
 	let keypair: Ed25519Keypair;
 	let suiAddress: string;
@@ -446,12 +461,13 @@ describe('Integration test', () => {
 		global.fetch = globalFetch;
 
 		const serverObjectIds: [string, number][] = [
-			[objectIds[0][0], 3],
-			[objectIds[1][0], 2],
+			['0x5ff11892a21430921fa7b1e3e0eb63d6d25dff2e0c8eeb6b5a79b37c974e355e', 3],
+			['0xe015d62f26a7877de22e6d3c763e97c1aa9a8d064cd79a1bf8fc6b435f7a50b4', 2],
 		];
 		const client = new SealClient({
 			suiClient,
 			serverObjectIds,
+			verifyKeyServers: false,
 		});
 		vi.spyOn(client as any, 'getKeyServers').mockResolvedValue(MOCK_KEY_SERVERS);
 

--- a/packages/seal/test/unit/integration.test.ts
+++ b/packages/seal/test/unit/integration.test.ts
@@ -356,8 +356,12 @@ describe('Integration test', () => {
 			}),
 		).rejects.toThrow(InvalidThresholdError);
 
-		// client with servers not a subset of the objects'
-		objectIds = [['0xe015d62f26a7877de22e6d3c763e97c1aa9a8d064cd79a1bf8fc6b435f7a50b4', 2]];
+
+		// client with different weights should fail even though the threshold could be achieved
+		objectIds = [
+			['0x5ff11892a21430921fa7b1e3e0eb63d6d25dff2e0c8eeb6b5a79b37c974e355e', 1],
+			['0xe015d62f26a7877de22e6d3c763e97c1aa9a8d064cd79a1bf8fc6b435f7a50b4', 1],
+		];
 		const clientDifferentWeight = new SealClient({
 			suiClient,
 			serverObjectIds: objectIds,

--- a/packages/seal/test/unit/integration.test.ts
+++ b/packages/seal/test/unit/integration.test.ts
@@ -356,7 +356,6 @@ describe('Integration test', () => {
 			}),
 		).rejects.toThrow(InvalidThresholdError);
 
-
 		// client with different weights should fail even though the threshold could be achieved
 		objectIds = [
 			['0x5ff11892a21430921fa7b1e3e0eb63d6d25dff2e0c8eeb6b5a79b37c974e355e', 1],


### PR DESCRIPTION
## Description

Handle weighted/repeated key servers better in the client. Currently, fetch is called multiple times per key server because the `Set<KeyServer>` does not enforce uniqueness since `KeyServer` is a custom object.

## Test plan

Unit tests.

---
