### PR TITLE
Refactor: Use direct WalrusClient instantiation instead of experimental SuiClient extension

### DIFF
--- a/packages/walrus/examples/basics/read-blob.ts
+++ b/packages/walrus/examples/basics/read-blob.ts
@@ -5,13 +5,18 @@ import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
 
 import { WalrusClient } from '../../src/client.js';
 
-const client = new SuiClient({
+const suiClient = new SuiClient({
 	url: getFullnodeUrl('testnet'),
 	network: 'testnet',
-}).$extend(WalrusClient.experimental_asClientExtension());
+});
+
+const walrusClient = new WalrusClient({
+	network: 'testnet',
+	suiClient,
+});
 
 export async function retrieveBlob(blobId: string) {
-	const blobBytes = await client.walrus.readBlob({ blobId });
+	const blobBytes = await walrusClient.readBlob({ blobId });
 	return new Blob([new Uint8Array(blobBytes)]);
 }
 

--- a/packages/walrus/examples/basics/write-blob.ts
+++ b/packages/walrus/examples/basics/write-blob.ts
@@ -15,23 +15,25 @@ setGlobalDispatcher(
 	}),
 );
 
-const client = new SuiClient({
+const suiClient = new SuiClient({
 	url: getFullnodeUrl('testnet'),
 	network: 'testnet',
-}).$extend(
-	WalrusClient.experimental_asClientExtension({
-		storageNodeClientOptions: {
-			timeout: 60_000,
-		},
-	}),
-);
+});
+const walrusClient = new WalrusClient({
+	network: 'testnet',
+	suiClient,
+	storageNodeClientOptions: {
+		timeout: 60_000,
+	},
+});
+
 
 async function uploadFile() {
 	const keypair = await getFundedKeypair();
 
 	const file = new TextEncoder().encode('Hello from the TS SDK!!!\n');
 
-	const { blobId } = await client.walrus.writeBlob({
+	const { blobId } = await walrusClient.writeBlob({
 		blob: file,
 		deletable: false,
 		epochs: 3,


### PR DESCRIPTION
Changes Made:
Refactored retrieveBlob and uploadFile scripts to use explicit instantiation of WalrusClient rather than extending SuiClient with the experimental API.

Injected suiClient and network into WalrusClient constructor for better separation of concerns and improved modularity.

Preserved timeout configuration (60_000ms) for both network and storage client to handle potential delays from Walrus nodes.