### PR TITLE
docs: update request SUI from faucet section in hello-sui.mdx 

### DIFF
--- a/packages/docs/content/typescript/hello-sui.mdx
+++ b/packages/docs/content/typescript/hello-sui.mdx
@@ -53,7 +53,7 @@ Create a new `index.js` file in the root of your project with the following code
 
 ```js
 import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
-import { getFaucetHost, requestSuiFromFaucetV1 } from '@mysten/sui/faucet';
+import { getFaucetHost, requestSuiFromFaucetV2 } from '@mysten/sui/faucet';
 import { MIST_PER_SUI } from '@mysten/sui/utils';
 
 // replace <YOUR_SUI_ADDRESS> with your actual address, which is in the form 0x123...
@@ -72,7 +72,7 @@ const suiBefore = await suiClient.getBalance({
 	owner: MY_ADDRESS,
 });
 
-await requestSuiFromFaucetV1({
+await requestSuiFromFaucetV2({
 	// use getFaucetHost to make sure you're using correct faucet address
 	// you can also just use the address (see Sui TypeScript SDK Quick Start for values)
 	host: getFaucetHost('devnet'),
@@ -98,7 +98,7 @@ Save the file, then use Node.js to run it in your Console or Terminal:
 node index.js
 ```
 
-The code imports the `requestSuiFromFaucetV1` function from the SDK and calls it to mint SUI for the
+The code imports the `requestSuiFromFaucetV2` function from the SDK and calls it to mint SUI for the
 provided address. The code also imports `SuiClient` to create a new client on the Sui network that
 it uses to query the address and output the amount of SUI the address owns before and after using
 the faucet. You can check the total SUI for your address using the Sui Wallet or Sui Client CLI.


### PR DESCRIPTION
Function requestSuiFromFaucetV1 has been deprecated in https://github.com/MystenLabs/ts-sdks/pull/214 but hello-sui.mdx still use it.

This PR is for updating this. And would it be better to keep only one requestSuiFromFaucet function to prevent other versions like requestSuiFromFaucetV3 or requestSuiFromFaucetV4 from appearing?