### PR TITLE
[slush-wallet] authorize previously saved accounts without requiring a call to `connect`

### DIFF
--- a/.changeset/lemon-rice-cover.md
+++ b/.changeset/lemon-rice-cover.md
@@ -1,0 +1,5 @@
+---
+'@mysten/slush-wallet': patch
+---
+
+Authorize previously saved accounts without needing to call `connect`


### PR DESCRIPTION
## Description

Wallet standard wallets should hydrate their previously authorized accounts in the constructor without requiring a call to `connect` (the `silent` flag will be deprecated eventually JFYI).

## Test plan
- Tested that auto-connecting works with the new and old versions of dApp Kit