### PR TITLE
[dapp-kit-next] fix bad type narrowing check returning the wrong wallet ID

### DIFF
--- a/packages/dapp-kit-next/src/core/initializers/sync-state-to-storage.ts
+++ b/packages/dapp-kit-next/src/core/initializers/sync-state-to-storage.ts
@@ -5,7 +5,6 @@ import { onMount } from 'nanostores';
 import type { DAppKitStores } from '../store.js';
 import type { StateStorage } from '../../utils/storage.js';
 import type { UiWalletAccount } from '@wallet-standard/ui';
-import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle } from '@wallet-standard/ui-registry';
 import { getWalletUniqueIdentifier } from '../../utils/wallets.js';
 
 /**
@@ -32,7 +31,6 @@ export function syncStateToStorage({
 }
 
 export function getSavedAccountStorageKey(account: UiWalletAccount) {
-	const underlyingWallet = getWalletForHandle(account);
-	const walletIdentifier = getWalletUniqueIdentifier(underlyingWallet);
+	const walletIdentifier = getWalletUniqueIdentifier(account);
 	return `${walletIdentifier.replace(':', '_')}:${account.address}`;
 }

--- a/packages/dapp-kit-next/src/index.ts
+++ b/packages/dapp-kit-next/src/index.ts
@@ -7,3 +7,5 @@ export { createDAppKit, getDefaultInstance } from './core/index.js';
 export type { DAppKit } from './core/index.js';
 
 export type { StateStorage } from './utils/storage.js';
+
+export { getWalletUniqueIdentifier } from './utils/wallets.js';

--- a/packages/dapp-kit-next/src/utils/wallets.ts
+++ b/packages/dapp-kit-next/src/utils/wallets.ts
@@ -9,8 +9,7 @@ import {
 	WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
 	WalletStandardError,
 } from '@mysten/wallet-standard';
-import type { Wallet } from '@mysten/wallet-standard';
-import type { UiWallet, UiWalletAccount } from '@wallet-standard/ui';
+import type { UiWallet, UiWalletAccount, UiWalletHandle } from '@wallet-standard/ui';
 import { getWalletAccountFeature, uiWalletAccountBelongsToUiWallet } from '@wallet-standard/ui';
 import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle } from '@wallet-standard/ui-registry';
 import { ChainNotSupportedError, DAppKitError, FeatureNotSupportedError } from './errors.js';
@@ -30,8 +29,8 @@ export function getAssociatedWalletOrThrow(account: UiWalletAccount, wallets: Ui
 	return wallet;
 }
 
-export function getWalletUniqueIdentifier(wallet: UiWallet | Wallet) {
-	const underlyingWallet = '~uiWalletHandle' in wallet ? getWalletForHandle(wallet) : wallet;
+export function getWalletUniqueIdentifier(walletHandle: UiWalletHandle) {
+	const underlyingWallet = getWalletForHandle(walletHandle);
 	return underlyingWallet.id ?? underlyingWallet.name;
 }
 


### PR DESCRIPTION
## Description
The auto-connection functionality for Slush Web wasn't working because `getWalletUniqueIdentifier` was returning the `name` instead of the `id` for `UiWallets` since I had a busted conditional check on the wallet symbol (which you obviously can't do lol). This PR fixes that issue by just requiring a handle (wallet account or wallet) to be passed in, since that is what external consumers will be working with on the UI side.

## Test plan
<img width="458" alt="image" src="https://github.com/user-attachments/assets/58fb4507-4bcd-487a-bf77-11165f5c8703" />