### PR TITLE
[dapp-kit-next] fix client typings for optional SuiNS name resolution in the components

### DIFF
--- a/packages/dapp-kit-next/src/core/actions/sign-and-execute-transaction.ts
+++ b/packages/dapp-kit-next/src/core/actions/sign-and-execute-transaction.ts
@@ -47,9 +47,9 @@ export function signAndExecuteTransactionCreator({ $connection, $currentClient }
 						return transaction;
 					}
 
-					// TODO: Fix passing through the client and supported intents for plugins.
+					// TODO: Fix passing through the supported intents for plugins.
 					transaction.setSenderIfNotSet(account.address);
-					return await transaction.toJSON();
+					return await transaction.toJSON({ client: suiClient });
 				},
 			},
 			account: getWalletAccountForUiWalletAccount(account),

--- a/packages/dapp-kit-next/src/core/actions/sign-transaction.ts
+++ b/packages/dapp-kit-next/src/core/actions/sign-transaction.ts
@@ -41,9 +41,9 @@ export function signTransactionCreator({ $connection, $currentClient }: DAppKitS
 						return transaction;
 					}
 
-					// TODO: Fix passing through the client and supported intents for plugins.
+					// TODO: Fix passing through supported intents for plugins.
 					transaction.setSenderIfNotSet(account.address);
-					return await transaction.toJSON();
+					return await transaction.toJSON({ client: suiClient });
 				},
 			},
 			account: getWalletAccountForUiWalletAccount(account),

--- a/packages/dapp-kit-next/src/core/index.ts
+++ b/packages/dapp-kit-next/src/core/index.ts
@@ -10,8 +10,7 @@ import { createInMemoryStorage, DEFAULT_STORAGE_KEY, getDefaultStorage } from '.
 import { syncStateToStorage } from './initializers/sync-state-to-storage.js';
 import { manageWalletConnection } from './initializers/manage-connection.js';
 import type { Networks } from '../utils/networks.js';
-import type { CreateDAppKitOptions } from './types.js';
-import type { Experimental_BaseClient } from '@mysten/sui/experimental';
+import type { CreateDAppKitOptions, DAppKitCompatibleClient } from './types.js';
 import { switchNetworkCreator } from './actions/switch-network.js';
 import { connectWalletCreator } from './actions/connect-wallet.js';
 import { disconnectWalletCreator } from './actions/disconnect-wallet.js';
@@ -56,7 +55,7 @@ export function createDAppKitInstance<TNetworks extends Networks>({
 		throw new DAppKitError('You must specify at least one Sui network for your application.');
 	}
 
-	const networkConfig = new Map<TNetworks[number], Experimental_BaseClient>();
+	const networkConfig = new Map<TNetworks[number], DAppKitCompatibleClient>();
 	const getClient = (network: TNetworks[number]) => {
 		if (networkConfig.has(network)) {
 			return networkConfig.get(network)!;

--- a/packages/dapp-kit-next/src/core/index.ts
+++ b/packages/dapp-kit-next/src/core/index.ts
@@ -11,7 +11,7 @@ import { syncStateToStorage } from './initializers/sync-state-to-storage.js';
 import { manageWalletConnection } from './initializers/manage-connection.js';
 import { createNetworkConfig } from '../utils/networks.js';
 import type { Networks } from '../utils/networks.js';
-import type { CreateDAppKitOptions, DAppKitCompatibleClient } from './types.js';
+import type { CreateDAppKitOptions } from './types.js';
 import { switchNetworkCreator } from './actions/switch-network.js';
 import { connectWalletCreator } from './actions/connect-wallet.js';
 import { disconnectWalletCreator } from './actions/disconnect-wallet.js';

--- a/packages/dapp-kit-next/src/core/store.ts
+++ b/packages/dapp-kit-next/src/core/store.ts
@@ -7,7 +7,7 @@ import { getChain } from '../utils/networks.js';
 import type { Networks } from '../utils/networks.js';
 import { getAssociatedWalletOrThrow, requiredWalletFeatures } from '../utils/wallets.js';
 import { publicKeyFromSuiBytes } from '@mysten/sui/verify';
-import type { Experimental_BaseClient } from '@mysten/sui/experimental';
+import type { DAppKitCompatibleClient } from './types.js';
 
 type WalletConnection =
 	| {
@@ -28,7 +28,7 @@ export function createStores<TNetworks extends Networks>({
 	getClient,
 }: {
 	defaultNetwork: TNetworks[number];
-	getClient: (network: TNetworks[number]) => Experimental_BaseClient;
+	getClient: (network: TNetworks[number]) => DAppKitCompatibleClient;
 }) {
 	const $baseConnection = map<WalletConnection>({
 		status: 'disconnected',

--- a/packages/dapp-kit-next/src/core/types.ts
+++ b/packages/dapp-kit-next/src/core/types.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Experimental_BaseClient } from '@mysten/sui/experimental';
+import type { ClientWithExtensions, Experimental_SuiClientTypes } from '@mysten/sui/experimental';
 import type { Networks } from '../utils/networks.js';
 import type { StateStorage } from '../utils/storage.js';
+
+export type DAppKitCompatibleClient = ClientWithExtensions<{
+	core: {
+		resolveNameServiceNames: Experimental_SuiClientTypes.TransportMethods['resolveNameServiceNames'];
+	};
+}>;
 
 export type CreateDAppKitOptions<TNetworks extends Networks> = {
 	/**
@@ -21,9 +27,9 @@ export type CreateDAppKitOptions<TNetworks extends Networks> = {
 	 * Creates a new client instance for the given network.
 	 *
 	 * @param network - A supported network identifier as defined by the `networks` field.
-	 * @returns An `Experimental_BaseClient` that’s pre-configured to interact with the specified network.
+	 * @returns A `DAppKitCompatibleClient` that’s pre-configured to interact with the specified network.
 	 */
-	createClient: (network: TNetworks[number]) => Experimental_BaseClient;
+	createClient: (network: TNetworks[number]) => DAppKitCompatibleClient;
 
 	/**
 	 * The name of the network to use by default.

--- a/packages/dapp-kit-next/src/index.ts
+++ b/packages/dapp-kit-next/src/index.ts
@@ -6,6 +6,7 @@ import './components/dapp-kit-connect-modal.js';
 export { createDAppKit, getDefaultInstance } from './core/index.js';
 export type { DAppKit } from './core/index.js';
 
+export type { DAppKitCompatibleClient } from './core/types.js';
 export type { StateStorage } from './utils/storage.js';
 
 export { getWalletUniqueIdentifier } from './utils/wallets.js';

--- a/packages/dapp-kit-next/src/utils/networks.ts
+++ b/packages/dapp-kit-next/src/utils/networks.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-	Experimental_BaseClient,
-	Experimental_SuiClientTypes,
-} from '@mysten/sui/experimental';
+import type { Experimental_SuiClientTypes } from '@mysten/sui/experimental';
 import type { IdentifierString } from '@mysten/wallet-standard';
 import { DAppKitError } from './errors.js';
+import type { DAppKitCompatibleClient } from '../core/types.js';
 
 type NonEmptyArray<T> = readonly [T, ...T[]] | readonly [...T[], T] | readonly [T, ...T[], T];
 
@@ -18,13 +16,13 @@ export function getChain(network: Experimental_SuiClientTypes.Network): Identifi
 
 export function createNetworkConfig<TNetworks extends Networks>(
 	networks: TNetworks,
-	createClient: (network: TNetworks[number]) => Experimental_BaseClient,
+	createClient: (network: TNetworks[number]) => DAppKitCompatibleClient,
 ) {
 	if (networks.length === 0) {
 		throw new DAppKitError('You must specify at least one Sui network for your application.');
 	}
 
-	const networkConfig = new Map<TNetworks[number], Experimental_BaseClient>();
+	const networkConfig = new Map<TNetworks[number], DAppKitCompatibleClient>();
 	function getClient<T extends TNetworks[number]>(network: T | TNetworks[number]) {
 		if (networkConfig.has(network)) {
 			return networkConfig.get(network)!;


### PR DESCRIPTION
## Description

This PR changes the client type from the base client to the core client with an optional method for resolving SuiNS names (this is used in the connected account dropdown / button for the pre-built UI components).

## Test plan
<img width="906" alt="image" src="https://github.com/user-attachments/assets/536eaa41-4261-4dfb-8778-1bfb8f92a466" />