### PR TITLE
[dapp-kit-next] document the web components

### DIFF
--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/components/dapp-kit-connect-button.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/components/dapp-kit-connect-button.ts
@@ -14,6 +14,37 @@ import { Button } from './internal/button.js';
 import { sharedStyles } from './styles/index.js';
 import type { RegisteredDAppKit } from '../types.js';
 
+/**
+ * A button component for connecting to a Sui wallet.
+ *
+ * Displays a "Connect Wallet" button when no wallet is connected or a connected account menu when a wallet is active.
+ *
+ * @element mysten-dapp-kit-connect-button
+ *
+ * @prop {DAppKitConnectModalOptions} modalOptions - Options to configure the connect modal.
+ * @prop {RegisteredDAppKit} instance - The dApp Kit instance used for state management.
+ *
+ * @slot - The default slot used to customize the button content (shown when not connected).
+ *
+ * @cssprop --background - Background color of the component. Used as the default background for UI elements.
+ * @cssprop --foreground - Foreground color of the component. Used as the default text color.
+ * @cssprop --primary - Primary color used for interactive elements such as buttons and links.
+ * @cssprop --primary-foreground - Text or icon color placed on top of primary elements.
+ * @cssprop --secondary - Secondary color used for less prominent interactive elements.
+ * @cssprop --secondary-foreground - Text or icon color placed on top of secondary elements.
+ * @cssprop --border - Border color for UI elements.
+ * @cssprop --accent - Accent color used for highlights and decorative elements.
+ * @cssprop --accent-foreground - Text or icon color placed on top of accent elements.
+ * @cssprop --muted - Background color for subtle or muted UI elements (e.g., placeholders, disabled states).
+ * @cssprop --muted-foreground - Text or icon color for muted UI elements.
+ * @cssprop --popover - Background color for floating elements such as popovers, dropdowns, or tooltips.
+ * @cssprop --popover-foreground - Text or icon color inside popover elements.
+ * @cssprop --ring - Color used for focus rings (visible focus indicators on interactive elements).
+ * @cssprop --radius - Border radius used for UI elements.
+ * @cssprop --font-sans - Font family used for text content.
+ * @cssprop --font-weight-medium - Medium font weight for text (typically used for buttons and interactive elements).
+ * @cssprop --font-weight-semibold - Semibold font weight for text (typically used for headings or emphasized text).
+ */
 @customElement('mysten-dapp-kit-connect-button')
 export class DAppKitConnectButton extends ScopedRegistryHost(LitElement) {
 	static elementDefinitions = {
@@ -28,9 +59,15 @@ export class DAppKitConnectButton extends ScopedRegistryHost(LitElement) {
 
 	static override styles = sharedStyles;
 
+	/**
+	 * Options to configure the connect modal.
+	 */
 	@property({ type: Object })
 	modalOptions?: DAppKitConnectModalOptions;
 
+	/**
+	 * The dApp Kit instance used for state management.
+	 */
 	@storeProperty()
 	instance?: RegisteredDAppKit;
 

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/components/dapp-kit-connect-modal.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/components/dapp-kit-connect-modal.ts
@@ -34,6 +34,43 @@ export type DAppKitConnectModalOptions = {
 	sortFn?: (a: UiWallet, b: UiWallet) => number;
 };
 
+/**
+ * A modal component for connecting to a Sui wallet, meant to be opened via a trigger button.
+ *
+ * Opens a modal to let the user select and connect to a wallet.
+ *
+ * @element mysten-dapp-kit-connect-modal
+ *
+ * @fires open - Fired *before* the dialog opens (cancelable).
+ * @fires opened - Fired *after* the dialog has fully opened.
+ * @fires close - Fired *before* the dialog closes (cancelable).
+ * @fires closed - Fired *after* the dialog has fully closed.
+ * @fires cancel - Fired when clicking the backdrop or pressing Escape (cancelable).
+ *
+ * @prop {Boolean} open - Programmatic access to the open state of the dialog.
+ * @prop {DAppKitConnectModalOptions['filterFn']} filterFn - Function to filter the list of shown wallets (optional).
+ * @prop {DAppKitConnectModalOptions['sortFn']} sortFn - Function to sort the list of available wallets (optional).
+ * @prop {RegisteredDAppKit} instance - The dApp Kit instance used for state management.
+ *
+ * @cssprop --background - Background color of the component. Used as the default background for UI elements.
+ * @cssprop --foreground - Foreground color of the component. Used as the default text color.
+ * @cssprop --primary - Primary color used for interactive elements such as buttons and links.
+ * @cssprop --primary-foreground - Text or icon color placed on top of primary elements.
+ * @cssprop --secondary - Secondary color used for less prominent interactive elements.
+ * @cssprop --secondary-foreground - Text or icon color placed on top of secondary elements.
+ * @cssprop --border - Border color for UI elements.
+ * @cssprop --accent - Accent color used for highlights and decorative elements.
+ * @cssprop --accent-foreground - Text or icon color placed on top of accent elements.
+ * @cssprop --muted - Background color for subtle or muted UI elements (e.g., placeholders, disabled states).
+ * @cssprop --muted-foreground - Text or icon color for muted UI elements.
+ * @cssprop --popover - Background color for floating elements such as popovers, dropdowns, or tooltips.
+ * @cssprop --popover-foreground - Text or icon color inside popover elements.
+ * @cssprop --ring - Color used for focus rings (visible focus indicators on interactive elements).
+ * @cssprop --radius - Border radius used for UI elements.
+ * @cssprop --font-sans - Font family used for text content.
+ * @cssprop --font-weight-medium - Medium font weight for text (typically used for buttons and interactive elements).
+ * @cssprop --font-weight-semibold - Semibold font weight for text (typically used for headings or emphasized text).
+ */
 @customElement('mysten-dapp-kit-connect-modal')
 export class DAppKitConnectModal
 	extends ScopedRegistryHost(BaseModal)
@@ -47,17 +84,26 @@ export class DAppKitConnectModal
 		'connection-status': ConnectionStatus,
 	};
 
+	/**
+	 * The dApp Kit instance used for state management.
+	 */
 	@storeProperty()
 	instance?: RegisteredDAppKit;
 
 	@state()
 	private _state: ModalViewState = { view: 'wallet-selection' };
 
+	/**
+	 * Function to filter the list of shown wallets.
+	 */
 	@property({ attribute: false })
 	filterFn: DAppKitConnectModalOptions['filterFn'];
 
+	/**
+	 * Function to sort the list of shown wallets.
+	 */
 	@property({ attribute: false })
-	sortFn?: DAppKitConnectModalOptions['sortFn'];
+	sortFn: DAppKitConnectModalOptions['sortFn'];
 
 	#abortController?: AbortController;
 


### PR DESCRIPTION
## Description

We'll use https://www.npmjs.com/package/web-component-analyzer to autogen docs for the new dApp Kit SDK, so this gets some baseline documentation in. I need to fix some of the event propagation and update the `@fire` related pieces but this is a start 😄 