### PR TITLE
[enoki] revert small change that made `getWalletMetadata` throw an error

### DIFF
--- a/.changeset/true-queens-rule.md
+++ b/.changeset/true-queens-rule.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': minor
+---
+
+Revert small change that made `getWalletMetadata` throw an error instead of returning null

--- a/packages/enoki/src/wallet/utils.ts
+++ b/packages/enoki/src/wallet/utils.ts
@@ -17,19 +17,23 @@ export function isEnokiWallet(wallet: Wallet | UiWallet) {
 	return EnokiGetMetadata in wallet.features;
 }
 
-export function getWalletMetadata(enokiWallet: Wallet | UiWallet) {
-	if (isWalletHandle(enokiWallet)) {
-		const { getMetadata } = getWalletFeature(
-			enokiWallet,
-			EnokiGetMetadata,
-		) as EnokiGetMetadataFeature[typeof EnokiGetMetadata];
+export function getWalletMetadata(wallet: Wallet | UiWallet) {
+	if (isWalletHandle(wallet)) {
+		try {
+			const { getMetadata } = getWalletFeature(
+				wallet,
+				EnokiGetMetadata,
+			) as EnokiGetMetadataFeature[typeof EnokiGetMetadata];
 
-		return getMetadata();
-	} else if (EnokiGetMetadata in enokiWallet.features) {
-		const walletWithFeature = enokiWallet as WalletWithFeatures<EnokiGetMetadataFeature>;
+			return getMetadata();
+		} catch (error) {
+			return null;
+		}
+	} else if (EnokiGetMetadata in wallet.features) {
+		const walletWithFeature = wallet as WalletWithFeatures<EnokiGetMetadataFeature>;
 		return walletWithFeature.features[EnokiGetMetadata].getMetadata();
 	}
-	throw new Error("The specified wallet isn't an Enoki wallet.");
+	return null;
 }
 
 export function isGoogleWallet(wallet: Wallet | UiWallet) {


### PR DESCRIPTION
## Description

Eh I realized as soon as I landed https://github.com/MystenLabs/ts-sdks/pull/382/files#r2153182218 that I made `getWalletMetadata` return null instead of throw originally so you could use `isGoogleWallet` XX type methods directly (am working on getting docs ready for this)

Before this would throw, now it works as expected:

```
const wallets = useWallets();
const googleWallet = wallets.find(isGoogleWallet);
```

## Test plan
- Manual testing
