### PR TITLE
[enoki] fix creating idb stores for multiple networks

### DIFF
--- a/.changeset/lazy-dragons-smell.md
+++ b/.changeset/lazy-dragons-smell.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+fix error creating idb for multiple networks

--- a/packages/enoki/src/wallet/state.ts
+++ b/packages/enoki/src/wallet/state.ts
@@ -66,7 +66,7 @@ export class INTERNAL_ONLY_EnokiFlow {
 		this.#encryption = createDefaultEncryption();
 		this.#store = createSessionStorage();
 		this.#storageKeys = createStorageKeys(config.apiKey, this.#network);
-		this.#idbStore = createStore('enoki', `${config.apiKey}_${this.#network}`);
+		this.#idbStore = createStore(`enoki_${config.apiKey}_${this.#network}`, 'enoki');
 
 		let storedState = null;
 		try {


### PR DESCRIPTION
## Description
* fixes logging in to a network (mainnet) and then to another (testnet) failing because `createStore`
* now it creates different dbs per `network` and `apiKey`

## Test plan

How did you test the new or updated feature?

before

https://github.com/user-attachments/assets/f79683d3-aa26-4444-a4d1-125f8c8cad82

after

https://github.com/user-attachments/assets/123e3701-2b66-406e-889e-5a0ee2d40edf |
