### PR TITLE
[dapp-kit-next] add backwards compatibility for old signing/executing features

### DIFF
--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/store.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/store.ts
@@ -6,7 +6,11 @@ import type { StoreValue } from 'nanostores';
 import { atom, computed, map } from 'nanostores';
 import { getChain } from '../utils/networks.js';
 import type { Networks } from '../utils/networks.js';
-import { getAssociatedWalletOrThrow, requiredWalletFeatures } from '../utils/wallets.js';
+import {
+	getAssociatedWalletOrThrow,
+	requiredWalletFeatures,
+	signingFeatures,
+} from '../utils/wallets.js';
 import { publicKeyFromSuiBytes } from '@mysten/sui/verify';
 import type { DAppKitCompatibleClient } from './types.js';
 
@@ -49,11 +53,15 @@ export function createStores<TNetworks extends Networks>({
 					(chain) => getChain(currentNetwork) === chain,
 				);
 
-				const areFeaturesCompatible = requiredWalletFeatures.every((featureName) =>
+				const hasRequiredFeatures = requiredWalletFeatures.every((featureName) =>
 					wallet.features.includes(featureName),
 				);
 
-				return areChainsCompatible && areFeaturesCompatible;
+				const canSignTransactions = signingFeatures.some((featureName) =>
+					wallet.features.includes(featureName),
+				);
+
+				return areChainsCompatible && hasRequiredFeatures && canSignTransactions;
 			});
 		},
 	);

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
@@ -4,8 +4,6 @@
 import {
 	StandardConnect,
 	StandardEvents,
-	SuiSignAndExecuteTransaction,
-	SuiSignAndExecuteTransactionBlock,
 	SuiSignTransaction,
 	SuiSignTransactionBlock,
 	WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
@@ -16,13 +14,7 @@ import { getWalletAccountFeature, uiWalletAccountBelongsToUiWallet } from '@wall
 import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle } from '@wallet-standard/ui-registry';
 import { ChainNotSupportedError, DAppKitError, FeatureNotSupportedError } from './errors.js';
 
-export const requiredWalletFeatures = [
-	StandardConnect,
-	StandardEvents,
-	SuiSignTransaction,
-	SuiSignAndExecuteTransaction,
-	SuiSignAndExecuteTransactionBlock,
-] as const;
+export const requiredWalletFeatures = [StandardConnect, StandardEvents] as const;
 
 export const signingFeatures = [SuiSignTransaction, SuiSignTransactionBlock] as const;
 

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
@@ -5,7 +5,9 @@ import {
 	StandardConnect,
 	StandardEvents,
 	SuiSignAndExecuteTransaction,
+	SuiSignAndExecuteTransactionBlock,
 	SuiSignTransaction,
+	SuiSignTransactionBlock,
 	WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
 	WalletStandardError,
 } from '@mysten/wallet-standard';
@@ -19,7 +21,10 @@ export const requiredWalletFeatures = [
 	StandardEvents,
 	SuiSignTransaction,
 	SuiSignAndExecuteTransaction,
+	SuiSignAndExecuteTransactionBlock,
 ] as const;
+
+export const signingFeatures = [SuiSignTransaction, SuiSignTransactionBlock] as const;
 
 export function getAssociatedWalletOrThrow(account: UiWalletAccount, wallets: UiWallet[]) {
 	const wallet = wallets.find((wallet) => uiWalletAccountBelongsToUiWallet(account, wallet));

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/utils/wallets.ts
@@ -70,3 +70,16 @@ export function getAccountFeature<TAccount extends UiWalletAccount>({
 		);
 	}
 }
+
+export function tryGetAccountFeature<TAccount extends UiWalletAccount>(
+	...args: Parameters<typeof getAccountFeature<TAccount>>
+) {
+	try {
+		return getAccountFeature(...args);
+	} catch (error) {
+		if (error instanceof FeatureNotSupportedError) {
+			return null;
+		}
+		throw error;
+	}
+}

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/wallets/index.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/wallets/index.ts
@@ -49,6 +49,8 @@ export async function registerAdditionalWallets(
 		if (settledResult.status === 'fulfilled') {
 			const { initializer, result } = settledResult.value;
 			initializerMap.set(initializer.id, result.unregister);
+		} else {
+			console.warn(`Skipping wallet initializer: "${settledResult.reason}".`);
 		}
 	}
 }


### PR DESCRIPTION
## Description

This PR adds backward compatibility for old signing/executing features just to save a little headache down the road (came around on this) 😛 

## Test plan
- Testing with burner wallet
