### PR TITLE
Redacted + improved privacy of private keys

### DIFF
--- a/packages/typescript/src/cryptography/keypair.ts
+++ b/packages/typescript/src/cryptography/keypair.ts
@@ -13,6 +13,7 @@ import type { SignatureScheme } from './signature-scheme.js';
 import { toSerializedSignature } from './signature.js';
 import type { Transaction } from '../transactions/Transaction.js';
 import type { ClientWithCoreApi, Experimental_SuiClientTypes } from '../experimental/index.js';
+import { Redacted } from '../utils/redacted.js';
 
 export const PRIVATE_KEY_SIZE = 32;
 export const LEGACY_PRIVATE_KEY_SIZE = 64;
@@ -112,8 +113,15 @@ export abstract class Signer {
 export abstract class Keypair extends Signer {
 	/**
 	 * This returns the Bech32 secret key string for this keypair.
+	 *
+	 * We recommend using `getSecretKeyRedacted()` instead, to ensure the secret key is not logged.
 	 */
 	abstract getSecretKey(): string;
+
+	/**
+	 * Get the secret key for this keypair, with the value redacted so that it cannot be logged.
+	 */
+	abstract getSecretKeyRedacted(): Redacted<string>;
 }
 
 /**

--- a/packages/typescript/src/keypairs/secp256k1/keypair.ts
+++ b/packages/typescript/src/keypairs/secp256k1/keypair.ts
@@ -12,6 +12,8 @@ import { isValidBIP32Path, mnemonicToSeed } from '../../cryptography/mnemonics.j
 import type { PublicKey } from '../../cryptography/publickey.js';
 import type { SignatureScheme } from '../../cryptography/signature-scheme.js';
 import { Secp256k1PublicKey } from './publickey.js';
+import type { Redacted } from '../../utils/redacted.js';
+import { getRedactedOrPlainValue, redacted } from '../../utils/redacted.js';
 
 export const DEFAULT_SECP256K1_DERIVATION_PATH = "m/54'/784'/0'/0/0";
 
@@ -20,14 +22,17 @@ export const DEFAULT_SECP256K1_DERIVATION_PATH = "m/54'/784'/0'/0/0";
  */
 export interface Secp256k1KeypairData {
 	publicKey: Uint8Array;
-	secretKey: Uint8Array;
+	secretKey: Uint8Array | Redacted<Uint8Array>;
 }
 
 /**
  * An Secp256k1 Keypair used for signing transactions.
  */
 export class Secp256k1Keypair extends Keypair {
-	private keypair: Secp256k1KeypairData;
+	#keypair: {
+		publicKey: Uint8Array;
+		secretKey: Uint8Array;
+	};
 
 	/**
 	 * Create a new keypair instance.
@@ -38,12 +43,15 @@ export class Secp256k1Keypair extends Keypair {
 	constructor(keypair?: Secp256k1KeypairData) {
 		super();
 		if (keypair) {
-			this.keypair = keypair;
+			this.#keypair = {
+				publicKey: keypair.publicKey,
+				secretKey: getRedactedOrPlainValue(keypair.secretKey),
+			};
 		} else {
 			const secretKey: Uint8Array = secp256k1.utils.randomPrivateKey();
 			const publicKey: Uint8Array = secp256k1.getPublicKey(secretKey, true);
 
-			this.keypair = { publicKey, secretKey };
+			this.#keypair = { publicKey, secretKey };
 		}
 	}
 
@@ -115,13 +123,20 @@ export class Secp256k1Keypair extends Keypair {
 	 * The public key for this keypair
 	 */
 	getPublicKey(): PublicKey {
-		return new Secp256k1PublicKey(this.keypair.publicKey);
+		return new Secp256k1PublicKey(this.#keypair.publicKey);
 	}
 	/**
 	 * The Bech32 secret key string for this Secp256k1 keypair
 	 */
 	getSecretKey(): string {
-		return encodeSuiPrivateKey(this.keypair.secretKey, this.getKeyScheme());
+		return encodeSuiPrivateKey(this.#keypair.secretKey, this.getKeyScheme());
+	}
+
+	/**
+	 * The Bech32 secret key string for this Secp256k1 keypair, with the value redacted so that it cannot be logged.
+	 */
+	getSecretKeyRedacted(): Redacted<string> {
+		return redacted(this.getSecretKey());
 	}
 
 	/**
@@ -129,7 +144,7 @@ export class Secp256k1Keypair extends Keypair {
 	 */
 	async sign(data: Uint8Array) {
 		const msgHash = sha256(data);
-		const sig = secp256k1.sign(msgHash, this.keypair.secretKey, {
+		const sig = secp256k1.sign(msgHash, this.#keypair.secretKey, {
 			lowS: true,
 		});
 		return sig.toCompactRawBytes();

--- a/packages/typescript/src/utils/index.ts
+++ b/packages/typescript/src/utils/index.ts
@@ -42,3 +42,5 @@ export {
 export { isValidNamedPackage, isValidNamedType } from './move-registry.js';
 
 export { deriveDynamicFieldID } from './dynamic-fields.js';
+
+export { redacted, isRedacted, getRedactedValue } from './redacted.js';

--- a/packages/typescript/src/utils/redacted.ts
+++ b/packages/typescript/src/utils/redacted.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+type RedactedRegistry = WeakMap<Redacted<any>, any>;
+
+const moduleRedactedRegistry: RedactedRegistry = new WeakMap();
+
+const REDACTED_REGISTRY_KEY = Symbol.for('@mysten/redacted/registry');
+function getRedactedRegistry() {
+	try {
+		const target = globalThis as {
+			[REDACTED_REGISTRY_KEY]?: RedactedRegistry;
+		};
+
+		if (!target[REDACTED_REGISTRY_KEY]) {
+			target[REDACTED_REGISTRY_KEY] = moduleRedactedRegistry;
+		}
+
+		return target[REDACTED_REGISTRY_KEY];
+	} catch (e) {
+		return moduleRedactedRegistry;
+	}
+}
+
+const RedactedType: unique symbol = Symbol.for('@mysten/redacted');
+export interface Redacted<T> {
+	[RedactedType]: T;
+}
+
+export function getRedactedValue<T>(redacted: Redacted<T>): T {
+	const redactedRegistry = getRedactedRegistry();
+
+	if (redactedRegistry.has(redacted)) {
+		return redactedRegistry.get(redacted) as T;
+	} else {
+		throw new Error('Unable to get redacted value');
+	}
+}
+
+export function redacted<T>(value: T): Redacted<T> {
+	const redactedRegistry = getRedactedRegistry();
+
+	const redacted = {
+		[RedactedType]: true,
+		[Symbol.toStringTag]: 'Redacted',
+		[Symbol.for('nodejs.util.inspect.custom')]: () => '<redacted>',
+		toString() {
+			return '<redacted>';
+		},
+		toJSON() {
+			return '<redacted>';
+		},
+	};
+
+	redactedRegistry.set(redacted, value);
+
+	return redacted as never;
+}
+
+export function isRedacted(value: any): value is Redacted<any> {
+	return typeof value === 'object' && Object.hasOwn(value, RedactedType);
+}
+
+/** @internal */
+export function getRedactedOrPlainValue<T>(value: T | Redacted<T>): T {
+	if (isRedacted(value)) {
+		return getRedactedValue(value);
+	}
+
+	return value;
+}


### PR DESCRIPTION
## Description

Taking inspiration from how Effect handles Redacted values, this introduces our own `redacted` function, which creates a value that is stored via a weakmap on a global registry. This has some neat properties:
- You need a reference to the redacted to get it out of the registry, so this should be plenty safe (weakmaps don't allow enumeration, or reading values without the keys).
- Logging the redacted identifier is completely safe, because the actual underlying value is stored completely distinctly
- You can kinda improve debugging of these values since we can add the debug tags that denote that this is a redacted value when it does get logged.


I originally wanted this to be exposed in a create-only way, so that outside of the package you couldn't read reacted values, but I realized that we probably want methods like `getSecretKey` to return redacted values by default.

While I was here, I realized we were using fake private for the data in keypairs, which kind of scares the shit out of me because if you log a keypair (which IMO seems like an operation that should be plenty safe) it means that all of the secret values are exposed:
<img width="785" alt="Screenshot 2025-06-27 at 12 35 11 PM" src="https://github.com/user-attachments/assets/278c535a-e776-4902-ae5a-afc98f5136ab" />

I made this a true private which _shouldn't_ be a breaking change unless people are depending on undocumented properties. I thought about changing this to store as a redacted internally, but just using true privates felt like a better solution here.

## Test plan

I will test it + update docs before merging.

---
