### PR TITLE
fix(codegen): move to next arg when resolved sui std arg in `normalizeMoveArguments`

### DIFF
--- a/.changeset/real-wolves-hide.md
+++ b/.changeset/real-wolves-hide.md
@@ -1,0 +1,6 @@
+---
+'@mysten/codegen': patch
+'@mysten/walrus': patch
+---
+
+Update codegen args' normalization

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -30,6 +30,7 @@
 		"build": "build-package",
 		"codegen": "pnpm tsx src/bin/cli.ts generate && pnpm lint:fix",
 		"prepublishOnly": "pnpm turbo build",
+		"test": "vitest run",
 		"test:watch": "vitest",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -72,18 +72,22 @@ export function normalizeMoveArguments(args: unknown[] | object, argTypes: strin
 	for (const [i, argType] of argTypes.entries()) {
 		if (argType === \`\${SUI_FRAMEWORK_ADDRESS}::deny_list::DenyList\`) {
 			normalizedArgs.push((tx) => tx.object.denyList());
+			continue;
 		}
 
 		if (argType === \`\${SUI_FRAMEWORK_ADDRESS}::random::Random\`) {
 			normalizedArgs.push((tx) => tx.object.random());
+			continue;
 		}
 
 		if (argType === \`\${SUI_FRAMEWORK_ADDRESS}::clock::Clock\`) {
 			normalizedArgs.push((tx) => tx.object.clock());
+			continue;
 		}
 
 		if (argType === \`\${SUI_SYSTEM_ADDRESS}::sui_system::SuiSystemState\`) {
 			normalizedArgs.push((tx) => tx.object.system());
+			continue;
 		}
 
 		let arg

--- a/packages/codegen/tests/generated/utils/index.ts
+++ b/packages/codegen/tests/generated/utils/index.ts
@@ -73,18 +73,22 @@ export function normalizeMoveArguments(
 	for (const [i, argType] of argTypes.entries()) {
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::deny_list::DenyList`) {
 			normalizedArgs.push((tx) => tx.object.denyList());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::random::Random`) {
 			normalizedArgs.push((tx) => tx.object.random());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::clock::Clock`) {
 			normalizedArgs.push((tx) => tx.object.clock());
+			continue;
 		}
 
 		if (argType === `${SUI_SYSTEM_ADDRESS}::sui_system::SuiSystemState`) {
 			normalizedArgs.push((tx) => tx.object.system());
+			continue;
 		}
 
 		let arg;

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -2,44 +2,186 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest';
 import { normalizeMoveArguments } from './generated/utils';
-
-const MOCK_TX = {
-	object: {
-		clock: () => 'CLOCK',
-	},
-};
+import { Transaction } from '@mysten/sui/transactions';
 
 const CLOCK_TYPE_ARG =
 	'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock';
 
 describe('normalizeMoveArguments', () => {
-	it('should handle resolved sui objects for `object` args', () => {
-		const res = normalizeMoveArguments(
-			{ arbitraryValue: 42 }, // args
-			['u32', CLOCK_TYPE_ARG], // arg types
-			['arbitraryValue', 'clock'], // parameters' names
-		);
+	it('should handle resolved sui objects for `object` args', async () => {
+		const tx = new Transaction();
+		tx.moveCall({
+			target: '0x0::test:test',
+			arguments: normalizeMoveArguments(
+				{ arbitraryValue: 42 }, // args
+				['u32', CLOCK_TYPE_ARG], // arg types
+				['arbitraryValue', 'clock'], // parameters' names
+			),
+		});
 
-		// Clock should be resolved under the hood - shouldn't throw
-		// the "Parameter clock is required" error.
-		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`
+			"{
+			  "version": 2,
+			  "sender": null,
+			  "expiration": null,
+			  "gasData": {
+			    "budget": null,
+			    "price": null,
+			    "owner": null,
+			    "payment": null
+			  },
+			  "inputs": [
+			    {
+			      "Pure": {
+			        "bytes": "KgAAAA=="
+			      }
+			    },
+			    {
+			      "UnresolvedObject": {
+			        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
+			      }
+			    }
+			  ],
+			  "commands": [
+			    {
+			      "MoveCall": {
+			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+			        "module": "test:test",
+			        "function": "",
+			        "typeArguments": [],
+			        "arguments": [
+			          {
+			            "Input": 0
+			          },
+			          {
+			            "Input": 1
+			          }
+			        ]
+			      }
+			    }
+			  ]
+			}"
+		`);
 	});
 
-	it('should handle resolved sui objects for `Array` args', () => {
-		const res = normalizeMoveArguments(
-			[42], // args
-			['u32', CLOCK_TYPE_ARG], // arg types
-			['arbitraryValue', 'clock'], // parameters' names
-		);
-		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+	it('should handle resolved sui objects for `Array` args', async () => {
+		const tx = new Transaction();
+		tx.moveCall({
+			target: '0x0::test:test',
+			arguments: normalizeMoveArguments(
+				[42], // args
+				['u32', CLOCK_TYPE_ARG], // arg types
+				['arbitraryValue', 'clock'], // parameters' names
+			),
+		});
+
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`
+			"{
+			  "version": 2,
+			  "sender": null,
+			  "expiration": null,
+			  "gasData": {
+			    "budget": null,
+			    "price": null,
+			    "owner": null,
+			    "payment": null
+			  },
+			  "inputs": [
+			    {
+			      "Pure": {
+			        "bytes": "KgAAAA=="
+			      }
+			    },
+			    {
+			      "UnresolvedObject": {
+			        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
+			      }
+			    }
+			  ],
+			  "commands": [
+			    {
+			      "MoveCall": {
+			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+			        "module": "test:test",
+			        "function": "",
+			        "typeArguments": [],
+			        "arguments": [
+			          {
+			            "Input": 0
+			          },
+			          {
+			            "Input": 1
+			          }
+			        ]
+			      }
+			    }
+			  ]
+			}"
+		`);
 	});
 
-	it('should handle resolved sui objects for `Array` args with extra trailing args', () => {
-		const res = normalizeMoveArguments(
-			[42, 999], // args
-			['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
-			['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
-		);
-		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+	it('should handle resolved sui objects for `Array` args with extra trailing args', async () => {
+		const tx = new Transaction();
+
+		tx.moveCall({
+			target: '0x0::test:test',
+			arguments: normalizeMoveArguments(
+				[42, 999], // args
+				['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
+				['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
+			),
+		});
+
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`
+			"{
+			  "version": 2,
+			  "sender": null,
+			  "expiration": null,
+			  "gasData": {
+			    "budget": null,
+			    "price": null,
+			    "owner": null,
+			    "payment": null
+			  },
+			  "inputs": [
+			    {
+			      "Pure": {
+			        "bytes": "KgAAAA=="
+			      }
+			    },
+			    {
+			      "UnresolvedObject": {
+			        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006"
+			      }
+			    },
+			    {
+			      "Pure": {
+			        "bytes": "5wMAAA=="
+			      }
+			    }
+			  ],
+			  "commands": [
+			    {
+			      "MoveCall": {
+			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+			        "module": "test:test",
+			        "function": "",
+			        "typeArguments": [],
+			        "arguments": [
+			          {
+			            "Input": 0
+			          },
+			          {
+			            "Input": 1
+			          },
+			          {
+			            "Input": 2
+			          }
+			        ]
+			      }
+			    }
+			  ]
+			}"
+		`);
 	});
 });

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import { normalizeMoveArguments } from './generated/utils';
+
+const MOCK_TX = {
+	object: {
+		clock: () => 'CLOCK',
+	},
+};
+
+const CLOCK_TYPE_ARG =
+	'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock';
+
+describe('normalizeMoveArguments', () => {
+	it('should handle resolved sui objects for `object` args', () => {
+		const res = normalizeMoveArguments(
+			{ arbitraryValue: 42 }, // args
+			['u32', CLOCK_TYPE_ARG], // arg types
+			['arbitraryValue', 'clock'], // parameters' names
+		);
+
+		// Clock should be resolved under the hood - shouldn't throw
+		// the "Parameter clock is required" error.
+		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+	});
+
+	it('should handle resolved sui objects for `Array` args', () => {
+		const res = normalizeMoveArguments(
+			[42], // args
+			['u32', CLOCK_TYPE_ARG], // arg types
+			['arbitraryValue', 'clock'], // parameters' names
+		);
+		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+	});
+
+	it('should handle resolved sui objects for `Array` args with extra trailing args', () => {
+		const res = normalizeMoveArguments(
+			[42, 999], // args
+			['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
+			['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
+		);
+		expect((res[1] as any)(MOCK_TX)).toEqual('CLOCK');
+	});
+});

--- a/packages/mvr-static/tests/parsing.test.ts
+++ b/packages/mvr-static/tests/parsing.test.ts
@@ -77,7 +77,7 @@ describe.concurrent('Parsing of project files', () => {
 			mainnet: {
 				packages: {
 					'@mvr/core/1': '0x62c1f5b1cb9e3bfc3dd1f73c95066487b662048a6358eabdbf67f6cdeca6db4b',
-					'@mvr/metadata': '0x0f6b71233780a3f362137b44ac219290f4fd34eb81e0cb62ddf4bb38d1f9a3a1',
+					'@mvr/metadata': '0xc88768f8b26581a8ee1bf71e6a6ec0f93d4cc6460ebb66a31b94d64de8105c98',
 					'@mvr/core/2': '0x0bde14ccbabe5328c867e82495a4c39a3688c69943a5dc333f79029f966f0354',
 					'@mvr/subnames-proxy':
 						'0x096c9bed5a312b888603f462f22084e470cc8555a275ef61cc12dd83ecf23a04',

--- a/packages/suins-v2/src/contracts/utils/index.ts
+++ b/packages/suins-v2/src/contracts/utils/index.ts
@@ -77,18 +77,22 @@ export function normalizeMoveArguments(
 	for (const [i, argType] of argTypes.entries()) {
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::deny_list::DenyList`) {
 			normalizedArgs.push((tx) => tx.object.denyList());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::random::Random`) {
 			normalizedArgs.push((tx) => tx.object.random());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::clock::Clock`) {
 			normalizedArgs.push((tx) => tx.object.clock());
+			continue;
 		}
 
 		if (argType === `${SUI_SYSTEM_ADDRESS}::sui_system::SuiSystemState`) {
 			normalizedArgs.push((tx) => tx.object.system());
+			continue;
 		}
 
 		let arg;

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -77,18 +77,22 @@ export function normalizeMoveArguments(
 	for (const [i, argType] of argTypes.entries()) {
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::deny_list::DenyList`) {
 			normalizedArgs.push((tx) => tx.object.denyList());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::random::Random`) {
 			normalizedArgs.push((tx) => tx.object.random());
+			continue;
 		}
 
 		if (argType === `${SUI_FRAMEWORK_ADDRESS}::clock::Clock`) {
 			normalizedArgs.push((tx) => tx.object.clock());
+			continue;
 		}
 
 		if (argType === `${SUI_SYSTEM_ADDRESS}::sui_system::SuiSystemState`) {
 			normalizedArgs.push((tx) => tx.object.system());
+			continue;
 		}
 
 		let arg;


### PR DESCRIPTION
## Description

Small fix for the codegen's `normalizeMoveArguments` util to fix args' resolution, when a Sui std arg object is present (i.e. `Clock`, `Random`, `DenyList` or `SuiSystemState`).

Previously, the function would not move on to the next argType after pushing the correct value into the `normalizedArgs` array for that Sui type, but would continue the iteration, trying to process the arg as if it were an arbitrary arg, which would eventually result in errors like "Parameter clock is required".

## Test plan

- Added test cases
- ensured they were failing for the previous code, indicating the issue
- added the fix
- made sure the tests were passing after.
