### PR TITLE
w

### DIFF
--- a/.changeset/legal-signs-exist.md
+++ b/.changeset/legal-signs-exist.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': minor
+---
+
+Return the full set of session data from `getWalletMetadata`

--- a/packages/enoki/src/wallet/feature.ts
+++ b/packages/enoki/src/wallet/feature.ts
@@ -3,6 +3,7 @@
 
 import type { decodeJwt } from '@mysten/sui/zklogin';
 import type { AuthProvider } from '../EnokiClient/type.js';
+import type { ZkLoginSession } from './types.js';
 
 /** Name of the feature. */
 export const EnokiGetMetadata = 'enoki:getMetadata';
@@ -34,7 +35,11 @@ export interface EnokiGetMetadataOutput {
 
 	/** Metadata pertaining to the active session. */
 	activeSession?: {
-		/** The decoded JWT for the session. */
+		/**
+		 * The decoded JWT for the session.
+		 **/
 		decodedJwt: ReturnType<typeof decodeJwt>;
-	};
+
+		jwt: string;
+	} & ZkLoginSession;
 }

--- a/packages/enoki/src/wallet/wallet.ts
+++ b/packages/enoki/src/wallet/wallet.ts
@@ -226,12 +226,17 @@ export class EnokiWallet implements Wallet {
 
 	#getMetadata: EnokiGetMetadataMethod = () => {
 		const sessionContext = this.#state.getSessionContext(this.#getCurrentNetwork());
-		const session = sessionContext?.$zkLoginSession.get();
-		const decodedJwt = session?.value?.jwt ? decodeJwt(session.value.jwt) : undefined;
+		const session = sessionContext.$zkLoginSession.get();
 
 		return {
 			provider: this.#provider,
-			activeSession: decodedJwt ? { decodedJwt } : undefined,
+			activeSession: session.value?.jwt
+				? {
+						...session.value,
+						jwt: session.value.jwt,
+						decodedJwt: decodeJwt(session.value.jwt),
+					}
+				: undefined,
 		};
 	};
 


### PR DESCRIPTION
## Description

Addresses https://github.com/MystenLabs/ts-sdks/issues/414. Folks aren't able to make certain calls to the Enoki API using the wallet standard implementation because we don't expose a way to grab the JWT for the current session. I didn't deprecate `decodedJwt` for now, it'll just be left for convienence sake.

Need to write docs at some point but usage pattern is like:

```
const googleWallet = useWallets().find(isGoogleWallet);
const walletMetadata = googleWallet ? getWalletMetadata(googleWallet) : null;

console.log('JWT', walletMetadata?.activeSession?.jwt);
```

## Test plan
- Manual testing
