### PR TITLE
[walrus] minor alignment to Rust SDK

### DIFF
--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -985,7 +985,8 @@ export class WalrusClient {
 			'const' in kind
 				? kind.const
 				: BigInt(kind.linear.base) +
-					BigInt(kind.linear.perEncodedKb) * (BigInt(encodedSize) / 1024n);
+					BigInt(kind.linear.perEncodedKiB) * 
+          ((BigInt(encodedSize) + 1023n) / 1024n); // Compute the ceiling of the division.
 
 		if (max != null && amount > max) {
 			throw new WalrusClientError(

--- a/packages/walrus/src/fan-out-proxy/client.ts
+++ b/packages/walrus/src/fan-out-proxy/client.ts
@@ -100,7 +100,7 @@ export class FanOutProxyClient {
 			kind: {
 				linear: {
 					base: data.send_tip.kind.base,
-					perEncodedKb: data.send_tip.kind.encoded_size_mul_per_kb,
+					perEncodedKb: data.send_tip.kind.encoded_size_mul_per_kib,
 				},
 			},
 		};


### PR DESCRIPTION
## Description

Tracks two minor changes in the Rust SDK:

- The computation of the number of KiBs in the encoded data now uses the _ceiling_.
- The field in the config has been slightly renamed `encoded_size_mul_per_kb -> encoded_size_mul_per_kib`

## Test plan

How did you test the new or updated feature?

---
