### PR TITLE
Export BCS types for Deepbook structs

### DIFF
--- a/packages/deepbook-v3/src/client.ts
+++ b/packages/deepbook-v3/src/client.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import { bcs } from '@mysten/sui/bcs';
+import { Account, ID, Order, OrderDeepPrice, VecSet } from './types/bcs.js';
 import type { SuiClient } from '@mysten/sui/client';
 import { Transaction } from '@mysten/sui/transactions';
 import { normalizeSuiAddress } from '@mysten/sui/utils';
@@ -228,9 +229,6 @@ export class DeepBookClient {
 		});
 
 		const order_ids = res.results![0].returnValues![0][0];
-		const VecSet = bcs.struct('VecSet', {
-			constants: bcs.vector(bcs.U128),
-		});
 
 		return VecSet.parse(new Uint8Array(order_ids)).constants;
 	}
@@ -248,26 +246,6 @@ export class DeepBookClient {
 		const res = await this.client.devInspectTransactionBlock({
 			sender: normalizeSuiAddress(this.#address),
 			transactionBlock: tx,
-		});
-
-		const ID = bcs.struct('ID', {
-			bytes: bcs.Address,
-		});
-		const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
-			asset_is_base: bcs.bool(),
-			deep_per_asset: bcs.u64(),
-		});
-		const Order = bcs.struct('Order', {
-			balance_manager_id: ID,
-			order_id: bcs.u128(),
-			client_order_id: bcs.u64(),
-			quantity: bcs.u64(),
-			filled_quantity: bcs.u64(),
-			fee_is_deep: bcs.bool(),
-			order_deep_price: OrderDeepPrice,
-			epoch: bcs.u64(),
-			status: bcs.u8(),
-			expire_timestamp: bcs.u64(),
 		});
 
 		try {
@@ -290,26 +268,6 @@ export class DeepBookClient {
 		const res = await this.client.devInspectTransactionBlock({
 			sender: normalizeSuiAddress(this.#address),
 			transactionBlock: tx,
-		});
-
-		const ID = bcs.struct('ID', {
-			bytes: bcs.Address,
-		});
-		const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
-			asset_is_base: bcs.bool(),
-			deep_per_asset: bcs.u64(),
-		});
-		const Order = bcs.struct('Order', {
-			balance_manager_id: ID,
-			order_id: bcs.u128(),
-			client_order_id: bcs.u64(),
-			quantity: bcs.u64(),
-			filled_quantity: bcs.u64(),
-			fee_is_deep: bcs.bool(),
-			order_deep_price: OrderDeepPrice,
-			epoch: bcs.u64(),
-			status: bcs.u8(),
-			expire_timestamp: bcs.u64(),
 		});
 
 		try {
@@ -358,26 +316,6 @@ export class DeepBookClient {
 		const res = await this.client.devInspectTransactionBlock({
 			sender: normalizeSuiAddress(this.#address),
 			transactionBlock: tx,
-		});
-
-		const ID = bcs.struct('ID', {
-			bytes: bcs.Address,
-		});
-		const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
-			asset_is_base: bcs.bool(),
-			deep_per_asset: bcs.u64(),
-		});
-		const Order = bcs.struct('Order', {
-			balance_manager_id: ID,
-			order_id: bcs.u128(),
-			client_order_id: bcs.u64(),
-			quantity: bcs.u64(),
-			filled_quantity: bcs.u64(),
-			fee_is_deep: bcs.bool(),
-			order_deep_price: OrderDeepPrice,
-			epoch: bcs.u64(),
-			status: bcs.u8(),
-			expire_timestamp: bcs.u64(),
 		});
 
 		try {
@@ -513,9 +451,6 @@ export class DeepBookClient {
 			transactionBlock: tx,
 		});
 
-		const ID = bcs.struct('ID', {
-			bytes: bcs.Address,
-		});
 		const address = ID.parse(new Uint8Array(res.results![0].returnValues![0][0]))['bytes'];
 
 		return address;
@@ -620,34 +555,6 @@ export class DeepBookClient {
 			transactionBlock: tx,
 		});
 
-		const ID = bcs.struct('ID', {
-			bytes: bcs.Address,
-		});
-
-		const Balances = bcs.struct('Balances', {
-			base: bcs.u64(),
-			quote: bcs.u64(),
-			deep: bcs.u64(),
-		});
-
-		const VecSet = bcs.struct('VecSet', {
-			constants: bcs.vector(bcs.U128),
-		});
-
-		const Account = bcs.struct('Account', {
-			epoch: bcs.u64(),
-			open_orders: VecSet,
-			taker_volume: bcs.u128(),
-			maker_volume: bcs.u128(),
-			active_stake: bcs.u64(),
-			inactive_stake: bcs.u64(),
-			created_proposal: bcs.bool(),
-			voted_proposal: bcs.option(ID),
-			unclaimed_rebates: Balances,
-			settled_balances: Balances,
-			owed_balances: Balances,
-		});
-
 		const accountInformation = res.results![0].returnValues![0][0];
 		const accountInfo = Account.parse(new Uint8Array(accountInformation));
 
@@ -725,11 +632,6 @@ export class DeepBookClient {
 		const res = await this.client.devInspectTransactionBlock({
 			sender: normalizeSuiAddress(this.#address),
 			transactionBlock: tx,
-		});
-
-		const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
-			asset_is_base: bcs.bool(),
-			deep_per_asset: bcs.u64(),
 		});
 
 		const poolDeepPriceBytes = res.results![0].returnValues![0][0];

--- a/packages/deepbook-v3/src/index.ts
+++ b/packages/deepbook-v3/src/index.ts
@@ -8,5 +8,6 @@ export { DeepBookAdminContract } from './transactions/deepbookAdmin.js';
 export { FlashLoanContract } from './transactions/flashLoans.js';
 export { GovernanceContract } from './transactions/governance.js';
 export { DeepBookConfig } from './utils/config.js';
+export { Account, Balances, ID, Order, OrderDeepPrice, VecSet } from './types/bcs.js';
 export type { BalanceManager, Coin, Pool } from './types/index.js';
 export type { CoinMap, PoolMap } from './utils/constants.js';

--- a/packages/deepbook-v3/src/types/bcs.ts
+++ b/packages/deepbook-v3/src/types/bcs.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { bcs } from '@mysten/sui/bcs';
+
+/**
+ * BCS struct for ID type
+ */
+export const ID = bcs.struct('ID', {
+	bytes: bcs.Address,
+});
+
+/**
+ * BCS struct for VecSet type
+ */
+export const VecSet = bcs.struct('VecSet', {
+	constants: bcs.vector(bcs.U128),
+});
+
+/**
+ * BCS struct for OrderDeepPrice type
+ */
+export const OrderDeepPrice = bcs.struct('OrderDeepPrice', {
+	asset_is_base: bcs.bool(),
+	deep_per_asset: bcs.u64(),
+});
+
+/**
+ * BCS struct for Order type
+ */
+export const Order = bcs.struct('Order', {
+	balance_manager_id: ID,
+	order_id: bcs.u128(),
+	client_order_id: bcs.u64(),
+	quantity: bcs.u64(),
+	filled_quantity: bcs.u64(),
+	fee_is_deep: bcs.bool(),
+	order_deep_price: OrderDeepPrice,
+	epoch: bcs.u64(),
+	status: bcs.u8(),
+	expire_timestamp: bcs.u64(),
+});
+
+/**
+ * BCS struct for Balances type
+ */
+export const Balances = bcs.struct('Balances', {
+	base: bcs.u64(),
+	quote: bcs.u64(),
+	deep: bcs.u64(),
+});
+
+/**
+ * BCS struct for Account type
+ */
+export const Account = bcs.struct('Account', {
+	epoch: bcs.u64(),
+	open_orders: VecSet,
+	taker_volume: bcs.u128(),
+	maker_volume: bcs.u128(),
+	active_stake: bcs.u64(),
+	inactive_stake: bcs.u64(),
+	created_proposal: bcs.bool(),
+	voted_proposal: bcs.option(ID),
+	unclaimed_rebates: Balances,
+	settled_balances: Balances,
+	owed_balances: Balances,
+});


### PR DESCRIPTION
## Description

Export BCS types for Deepbook structs for use by other clients (e.g. gRPC), and remove redundant definitions

## Test plan

`pnpm build && pnpm lint`

---
