### PR TITLE
Next.js example for dapp-kit-next

### DIFF
--- a/packages/dapp-kit-next/examples/next-js/simple/README.md
+++ b/packages/dapp-kit-next/examples/next-js/simple/README.md
@@ -1,0 +1,6 @@
+# Example
+
+To run this example:
+
+- `pnpm install`
+- `pnpm run dev`

--- a/packages/dapp-kit-next/examples/next-js/simple/app/ClientOnlyConnectButton.tsx
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/ClientOnlyConnectButton.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { dAppKit } from './dApp-kit';
+
+export default function ClientOnlyConnectButton() {
+	return (
+		<DAppKitProvider dAppKit={dAppKit}>
+			<ConnectButton />
+		</DAppKitProvider>
+	);
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/app/dApp-kit.ts
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/dApp-kit.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createDAppKit } from '@mysten/dapp-kit-react';
+import { getFullnodeUrl, SuiClient } from '@mysten/sui/client';
+
+export const dAppKit = createDAppKit({
+	enableBurnerWallet: process.env.NODE_ENV === 'development',
+	networks: ['mainnet', 'testnet'],
+	defaultNetwork: 'testnet',
+	createClient(network) {
+		return new SuiClient({ network, url: getFullnodeUrl(network) });
+	},
+});
+
+declare module '@mysten/dapp-kit-react' {
+	interface Register {
+		dAppKit: typeof dAppKit;
+	}
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/app/globals.css
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/globals.css
@@ -1,0 +1,13 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+
+  color: #213547;
+  background-color: #ffffff;
+
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/app/layout.tsx
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/layout.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+	title: 'DApp Next Kit - Next.js Simple Example',
+};
+
+export default function RootLayout({
+	children,
+}: Readonly<{
+	children: React.ReactNode;
+}>) {
+	return (
+		<html lang="en">
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/app/page.tsx
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/page.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const ClientApp = dynamic(() => import('././ClientOnlyConnectButton'), {
+	ssr: false,
+	loading: () => <div>ClientOnlyConnectButton is not rendered on server</div>,
+});
+
+export default function Home() {
+	return <ClientApp />;
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/app/page.tsx
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/page.tsx
@@ -5,7 +5,7 @@
 
 import dynamic from 'next/dynamic';
 
-const ClientApp = dynamic(() => import('././ClientOnlyConnectButton'), {
+const ClientApp = dynamic(() => import('./ClientOnlyConnectButton'), {
 	ssr: false,
 	loading: () => <div>ClientOnlyConnectButton is not rendered on server</div>,
 });

--- a/packages/dapp-kit-next/examples/next-js/simple/eslint.config.mjs
+++ b/packages/dapp-kit-next/examples/next-js/simple/eslint.config.mjs
@@ -1,0 +1,13 @@
+import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({
+	baseDirectory: import.meta.dirname,
+})
+
+const eslintConfig = [
+	...compat.config({
+		extends: ['next'],
+	}),
+]
+
+export default eslintConfig;

--- a/packages/dapp-kit-next/examples/next-js/simple/next.config.ts
+++ b/packages/dapp-kit-next/examples/next-js/simple/next.config.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+	/* config options here */
+};
+
+export default nextConfig;

--- a/packages/dapp-kit-next/examples/next-js/simple/package.json
+++ b/packages/dapp-kit-next/examples/next-js/simple/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "next-js-simple-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack",
+    "build": "next build --turbopack",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@mysten/dapp-kit-react": "workspace:*",
+    "@mysten/sui": "workspace:*",
+    "next": "15.4.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
+    "@types/node": "^22.15.29",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/dapp-kit-next/examples/next-js/simple/tsconfig.json
+++ b/packages/dapp-kit-next/examples/next-js/simple/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,40 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.5)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.4(@types/node@22.16.5)(typescript@5.8.3))(tsx@4.20.3)(yaml@2.8.0)
 
+  packages/dapp-kit-next/examples/next-js/simple:
+    dependencies:
+      '@mysten/dapp-kit-react':
+        specifier: workspace:*
+        version: link:../../../packages/dapp-kit-react
+      '@mysten/sui':
+        specifier: workspace:*
+        version: link:../../../../typescript
+      next:
+        specifier: 15.4.2
+        version: 15.4.2(@babel/core@7.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
+      '@types/node':
+        specifier: ^22.15.29
+        version: 22.16.5
+      '@types/react':
+        specifier: ^18.3.3
+        version: 18.3.18
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.5(@types/react@18.3.18)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
   packages/dapp-kit-next/examples/react/simple:
     dependencies:
       '@mysten/dapp-kit-react':
@@ -2854,6 +2888,10 @@ packages:
 
   '@eslint/eslintrc@3.2.0':
     resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@8.57.1':
@@ -12420,6 +12458,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.1
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.17.0': {}
@@ -17946,9 +17998,9 @@ snapshots:
 
   espree@10.3.0:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
-      eslint-visitor-keys: 4.2.0
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -18727,7 +18779,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -19774,7 +19826,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0
+      debug: 4.4.1
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2


### PR DESCRIPTION
## Description

Added Next.js example for `dapp-kit-next` -- it requires client-side rendering for the components. Used `npx create-next-app@latest` to create the project.

## Test plan

- ran the example and played around with the button

---

### AI Assistance Notice

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [X] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
