### PR TITLE
Lock poseidon-lite version

### DIFF
--- a/.changeset/smooth-games-stick.md
+++ b/.changeset/smooth-games-stick.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Lock version of poseidon-lite used

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -170,7 +170,7 @@
 		"@scure/bip39": "^1.6.0",
 		"gql.tada": "^1.8.12",
 		"graphql": "^16.11.0",
-		"poseidon-lite": "^0.2.0",
+		"poseidon-lite": "0.2.1",
 		"valibot": "^0.36.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1415,7 +1415,7 @@ importers:
         specifier: ^16.11.0
         version: 16.11.0
       poseidon-lite:
-        specifier: ^0.2.0
+        specifier: 0.2.1
         version: 0.2.1
       valibot:
         specifier: ^0.36.0


### PR DESCRIPTION
## Description

I'm looking a little bit looking into TS SDK hardening, and I think right now we have one dep that's "high risk": `poseidon-lite`. Some things I looked into:

- Locking the version to a known good version that has no dependencies (this PR). This should prevent any attacks, as new published versions won't automatically get picked up, and there's no "more vulnerable" downstream dependencies we need to worry about.
- Vendoring in the library. This is a lot more work, and can feel like it's taking away from the original creator.
- Bundling the dependency during builds. Most of the available tooling only seems to make this work if we actually bundle our packages (a whole separate discussion, but we currently do not bundle dependencies).

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
