### PR TITLE
fix(codegen): skip system args in `parameterNames` used for normalization

### DIFF
--- a/.changeset/gold-cooks-pay.md
+++ b/.changeset/gold-cooks-pay.md
@@ -1,0 +1,7 @@
+---
+'@mysten/deepbook-v3': patch
+'@mysten/codegen': patch
+'@mysten/walrus': patch
+---
+
+Update codegen arg normalization for object args

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -100,7 +100,7 @@ export function normalizeMoveArguments(args: unknown[] | object, argTypes: strin
 			if (!parameterNames) {
 				throw new Error(\`Expected arguments to be passed as an array\`);
 			}
-			const name = parameterNames[index];
+			const name = parameterNames[i];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -61,9 +61,11 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 }
 
 export function normalizeMoveArguments(args: unknown[] | object, argTypes: string[], parameterNames?: string[]) {
-
-	if (parameterNames && argTypes.length !== parameterNames.length) {
-		throw new Error(\`Invalid number of parameterNames, expected \${argTypes.length}, got \${parameterNames.length}\`);
+	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
+	if (parameterNames && argLen !== parameterNames.length) {
+		throw new Error(
+			\`Invalid number of arguments, expected \${parameterNames.length}, got \${argLen}\`,
+		);
 	}
 
 	const normalizedArgs: TransactionArgument[] = [];
@@ -100,7 +102,7 @@ export function normalizeMoveArguments(args: unknown[] | object, argTypes: strin
 			if (!parameterNames) {
 				throw new Error(\`Expected arguments to be passed as an array\`);
 			}
-			const name = parameterNames[i];
+			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -537,7 +537,7 @@ export class MoveModuleBuilder extends FileBuilder {
 							.join(',\n')}
 					] satisfies string[]\n`
 							: ''
-					}${hasAllParameterNames ? `const parameterNames = ${JSON.stringify(parameters.map((param) => camelCase(param.name!)))}\n` : ''}
+					}${hasAllParameterNames ? `const parameterNames = ${JSON.stringify(requiredParameters.map((param) => camelCase(param.name!)))}\n` : ''}
 					return (tx: Transaction) => tx.moveCall({
 						package: packageAddress,
 						module: '${this.summary.id.name}',

--- a/packages/codegen/tests/generated/utils/index.ts
+++ b/packages/codegen/tests/generated/utils/index.ts
@@ -69,9 +69,10 @@ export function normalizeMoveArguments(
 	argTypes: string[],
 	parameterNames?: string[],
 ) {
-	if (parameterNames && argTypes.length !== parameterNames.length) {
+	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
+	if (parameterNames && argLen !== parameterNames.length) {
 		throw new Error(
-			`Invalid number of parameterNames, expected ${argTypes.length}, got ${parameterNames.length}`,
+			`Invalid number of arguments, expected ${parameterNames.length}, got ${argLen}`,
 		);
 	}
 
@@ -111,7 +112,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[i];
+			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/codegen/tests/generated/utils/index.ts
+++ b/packages/codegen/tests/generated/utils/index.ts
@@ -111,7 +111,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[index];
+			const name = parameterNames[i];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/codegen/tests/generated/utils/index.ts
+++ b/packages/codegen/tests/generated/utils/index.ts
@@ -51,7 +51,7 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const type = getPureBcsSchema(structTag.typeParams[0]!);
 				return type ? bcs.vector(type) : null;
 			}
 		}
@@ -127,7 +127,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
+		const type = argTypes[i]!;
 		const bcsType = getPureBcsSchema(type);
 
 		if (bcsType) {

--- a/packages/codegen/tests/generated/walrus/init.ts
+++ b/packages/codegen/tests/generated/walrus/init.ts
@@ -64,7 +64,6 @@ export function initializeWalrus(options: InitializeWalrusOptions) {
 		'epochDuration',
 		'nShards',
 		'maxEpochsAhead',
-		'clock',
 	];
 	return (tx: Transaction) =>
 		tx.moveCall({

--- a/packages/codegen/tests/generated/walrus/staking.ts
+++ b/packages/codegen/tests/generated/walrus/staking.ts
@@ -555,7 +555,7 @@ export function votingEnd(options: VotingEndOptions) {
 		`${packageAddress}::staking::Staking`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 	] satisfies string[];
-	const parameterNames = ['staking', 'clock'];
+	const parameterNames = ['staking'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -585,7 +585,7 @@ export function initiateEpochChange(options: InitiateEpochChangeOptions) {
 		`${packageAddress}::system::System`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 	] satisfies string[];
-	const parameterNames = ['staking', 'system', 'clock'];
+	const parameterNames = ['staking', 'system'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -621,7 +621,7 @@ export function epochSyncDone(options: EpochSyncDoneOptions) {
 		'u32',
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 	] satisfies string[];
-	const parameterNames = ['staking', 'cap', 'epoch', 'clock'];
+	const parameterNames = ['staking', 'cap', 'epoch'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -36,14 +36,14 @@ describe('normalizeMoveArguments', () => {
       }
     },
     {
-			"Object": {
-				"SharedObject": {
-					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-					"initialSharedVersion": 1,
-					"mutable": false
-				}
-			}
-		}
+      "Object": {
+        "SharedObject": {
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+          "initialSharedVersion": 1,
+          "mutable": false
+        }
+      }
+    }
   ],
   "commands": [
     {
@@ -94,14 +94,14 @@ describe('normalizeMoveArguments', () => {
       }
     },
     {
-			"Object": {
-				"SharedObject": {
-					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-					"initialSharedVersion": 1,
-					"mutable": false
-				}
-			}
-		},
+      "Object": {
+        "SharedObject": {
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+          "initialSharedVersion": 1,
+          "mutable": false
+        }
+      }
+    },
     {
       "Pure": {
         "bytes": "5wMAAA=="
@@ -160,14 +160,14 @@ describe('normalizeMoveArguments', () => {
       }
     },
     {
-			"Object": {
-				"SharedObject": {
-					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-					"initialSharedVersion": 1,
-					"mutable": false
-				}
-			}
-		}
+      "Object": {
+        "SharedObject": {
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+          "initialSharedVersion": 1,
+          "mutable": false
+        }
+      }
+    }
   ],
   "commands": [
     {
@@ -219,14 +219,14 @@ describe('normalizeMoveArguments', () => {
       }
     },
     {
-			"Object": {
-				"SharedObject": {
-					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-					"initialSharedVersion": 1,
-					"mutable": false
-				}
-			}
-		},
+      "Object": {
+        "SharedObject": {
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+          "initialSharedVersion": 1,
+          "mutable": false
+        }
+      }
+    },
     {
       "Pure": {
         "bytes": "5wMAAA=="

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -19,53 +19,117 @@ describe('normalizeMoveArguments', () => {
 			),
 		});
 
-		expect(await tx.toJSON()).toMatchInlineSnapshot(`
-			"{
-			  "version": 2,
-			  "sender": null,
-			  "expiration": null,
-			  "gasData": {
-			    "budget": null,
-			    "price": null,
-			    "owner": null,
-			    "payment": null
-			  },
-			  "inputs": [
-			    {
-			      "Pure": {
-			        "bytes": "KgAAAA=="
-			      }
-			    },
-			    {
-			      "Object": {
-			        "SharedObject": {
-			          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-			          "initialSharedVersion": 1,
-			          "mutable": false
-			        }
-			      }
-			    }
-			  ],
-			  "commands": [
-			    {
-			      "MoveCall": {
-			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
-			        "module": "test:test",
-			        "function": "",
-			        "typeArguments": [],
-			        "arguments": [
-			          {
-			            "Input": 0
-			          },
-			          {
-			            "Input": 1
-			          }
-			        ]
-			      }
-			    }
-			  ]
-			}"
-		`);
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`"{
+  "version": 2,
+  "sender": null,
+  "expiration": null,
+  "gasData": {
+    "budget": null,
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "KgAAAA=="
+      }
+    },
+    {
+			"Object": {
+				"SharedObject": {
+					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+					"initialSharedVersion": 1,
+					"mutable": false
+				}
+			}
+		}
+  ],
+  "commands": [
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "module": "test:test",
+        "function": "",
+        "typeArguments": [],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          }
+        ]
+      }
+    }
+  ]
+}"`);
+	});
+
+	it('should handle resolved sui objects for `object` args with extra trailing args', async () => {
+		const tx = new Transaction();
+		tx.moveCall({
+			target: '0x0::test:test',
+			arguments: normalizeMoveArguments(
+				{ arbitraryValue: 42, anotherArbitraryValue: 999 }, // args
+				['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
+				['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
+			),
+		});
+
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`"{
+  "version": 2,
+  "sender": null,
+  "expiration": null,
+  "gasData": {
+    "budget": null,
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "KgAAAA=="
+      }
+    },
+    {
+			"Object": {
+				"SharedObject": {
+					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+					"initialSharedVersion": 1,
+					"mutable": false
+				}
+			}
+		},
+    {
+      "Pure": {
+        "bytes": "5wMAAA=="
+      }
+    }
+  ],
+  "commands": [
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "module": "test:test",
+        "function": "",
+        "typeArguments": [],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          },
+          {
+            "Input": 2
+          }
+        ]
+      }
+    }
+  ]
+}"`);
 	});
 
 	it('should handle resolved sui objects for `Array` args', async () => {
@@ -79,53 +143,51 @@ describe('normalizeMoveArguments', () => {
 			),
 		});
 
-		expect(await tx.toJSON()).toMatchInlineSnapshot(`
-			"{
-			  "version": 2,
-			  "sender": null,
-			  "expiration": null,
-			  "gasData": {
-			    "budget": null,
-			    "price": null,
-			    "owner": null,
-			    "payment": null
-			  },
-			  "inputs": [
-			    {
-			      "Pure": {
-			        "bytes": "KgAAAA=="
-			      }
-			    },
-			    {
-			      "Object": {
-			        "SharedObject": {
-			          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-			          "initialSharedVersion": 1,
-			          "mutable": false
-			        }
-			      }
-			    }
-			  ],
-			  "commands": [
-			    {
-			      "MoveCall": {
-			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
-			        "module": "test:test",
-			        "function": "",
-			        "typeArguments": [],
-			        "arguments": [
-			          {
-			            "Input": 0
-			          },
-			          {
-			            "Input": 1
-			          }
-			        ]
-			      }
-			    }
-			  ]
-			}"
-		`);
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`"{
+  "version": 2,
+  "sender": null,
+  "expiration": null,
+  "gasData": {
+    "budget": null,
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "KgAAAA=="
+      }
+    },
+    {
+			"Object": {
+				"SharedObject": {
+					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+					"initialSharedVersion": 1,
+					"mutable": false
+				}
+			}
+		}
+  ],
+  "commands": [
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "module": "test:test",
+        "function": "",
+        "typeArguments": [],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          }
+        ]
+      }
+    }
+  ]
+}"`);
 	});
 
 	it('should handle resolved sui objects for `Array` args with extra trailing args', async () => {
@@ -140,60 +202,58 @@ describe('normalizeMoveArguments', () => {
 			),
 		});
 
-		expect(await tx.toJSON()).toMatchInlineSnapshot(`
-			"{
-			  "version": 2,
-			  "sender": null,
-			  "expiration": null,
-			  "gasData": {
-			    "budget": null,
-			    "price": null,
-			    "owner": null,
-			    "payment": null
-			  },
-			  "inputs": [
-			    {
-			      "Pure": {
-			        "bytes": "KgAAAA=="
-			      }
-			    },
-			    {
-			      "Object": {
-			        "SharedObject": {
-			          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
-			          "initialSharedVersion": 1,
-			          "mutable": false
-			        }
-			      }
-			    },
-			    {
-			      "Pure": {
-			        "bytes": "5wMAAA=="
-			      }
-			    }
-			  ],
-			  "commands": [
-			    {
-			      "MoveCall": {
-			        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
-			        "module": "test:test",
-			        "function": "",
-			        "typeArguments": [],
-			        "arguments": [
-			          {
-			            "Input": 0
-			          },
-			          {
-			            "Input": 1
-			          },
-			          {
-			            "Input": 2
-			          }
-			        ]
-			      }
-			    }
-			  ]
-			}"
-		`);
+		expect(await tx.toJSON()).toMatchInlineSnapshot(`"{
+  "version": 2,
+  "sender": null,
+  "expiration": null,
+  "gasData": {
+    "budget": null,
+    "price": null,
+    "owner": null,
+    "payment": null
+  },
+  "inputs": [
+    {
+      "Pure": {
+        "bytes": "KgAAAA=="
+      }
+    },
+    {
+			"Object": {
+				"SharedObject": {
+					"objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+					"initialSharedVersion": 1,
+					"mutable": false
+				}
+			}
+		},
+    {
+      "Pure": {
+        "bytes": "5wMAAA=="
+      }
+    }
+  ],
+  "commands": [
+    {
+      "MoveCall": {
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "module": "test:test",
+        "function": "",
+        "typeArguments": [],
+        "arguments": [
+          {
+            "Input": 0
+          },
+          {
+            "Input": 1
+          },
+          {
+            "Input": 2
+          }
+        ]
+      }
+    }
+  ]
+}"`);
 	});
 });

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -15,7 +15,7 @@ describe('normalizeMoveArguments', () => {
 			arguments: normalizeMoveArguments(
 				{ arbitraryValue: 42 }, // args
 				['u32', CLOCK_TYPE_ARG], // arg types
-				['arbitraryValue', 'clock'], // parameters' names
+				['arbitraryValue'], // parameters' names
 			),
 		});
 
@@ -73,7 +73,7 @@ describe('normalizeMoveArguments', () => {
 			arguments: normalizeMoveArguments(
 				{ arbitraryValue: 42, anotherArbitraryValue: 999 }, // args
 				['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
-				['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
+				['arbitraryValue', 'anotherArbitraryValue'], // parameters' names
 			),
 		});
 
@@ -139,7 +139,7 @@ describe('normalizeMoveArguments', () => {
 			arguments: normalizeMoveArguments(
 				[42], // args
 				['u32', CLOCK_TYPE_ARG], // arg types
-				['arbitraryValue', 'clock'], // parameters' names
+				['arbitraryValue'], // parameters' names
 			),
 		});
 
@@ -198,7 +198,7 @@ describe('normalizeMoveArguments', () => {
 			arguments: normalizeMoveArguments(
 				[42, 999], // args
 				['u32', CLOCK_TYPE_ARG, 'u32'], // arg types
-				['arbitraryValue', 'clock', 'anotherArbitraryValue'], // parameters' names
+				['arbitraryValue', 'anotherArbitraryValue'], // parameters' names
 			),
 		});
 

--- a/packages/deepbook-v3/src/contracts/utils/index.ts
+++ b/packages/deepbook-v3/src/contracts/utils/index.ts
@@ -107,7 +107,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[index];
+			const name = parameterNames[i];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/deepbook-v3/src/contracts/utils/index.ts
+++ b/packages/deepbook-v3/src/contracts/utils/index.ts
@@ -65,9 +65,10 @@ export function normalizeMoveArguments(
 	argTypes: string[],
 	parameterNames?: string[],
 ) {
-	if (parameterNames && argTypes.length !== parameterNames.length) {
+	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
+	if (parameterNames && argLen !== parameterNames.length) {
 		throw new Error(
-			`Invalid number of parameterNames, expected ${argTypes.length}, got ${parameterNames.length}`,
+			`Invalid number of arguments, expected ${parameterNames.length}, got ${argLen}`,
 		);
 	}
 
@@ -107,7 +108,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[i];
+			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/suins-v2/src/contracts/utils/index.ts
+++ b/packages/suins-v2/src/contracts/utils/index.ts
@@ -107,7 +107,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[index];
+			const name = parameterNames[i];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/suins-v2/src/contracts/utils/index.ts
+++ b/packages/suins-v2/src/contracts/utils/index.ts
@@ -65,9 +65,10 @@ export function normalizeMoveArguments(
 	argTypes: string[],
 	parameterNames?: string[],
 ) {
-	if (parameterNames && argTypes.length !== parameterNames.length) {
+	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
+	if (parameterNames && argLen !== parameterNames.length) {
 		throw new Error(
-			`Invalid number of parameterNames, expected ${argTypes.length}, got ${parameterNames.length}`,
+			`Invalid number of arguments, expected ${parameterNames.length}, got ${argLen}`,
 		);
 	}
 
@@ -107,7 +108,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[i];
+			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -107,7 +107,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[index];
+			const name = parameterNames[i];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -65,9 +65,10 @@ export function normalizeMoveArguments(
 	argTypes: string[],
 	parameterNames?: string[],
 ) {
-	if (parameterNames && argTypes.length !== parameterNames.length) {
+	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
+	if (parameterNames && argLen !== parameterNames.length) {
 		throw new Error(
-			`Invalid number of parameterNames, expected ${argTypes.length}, got ${parameterNames.length}`,
+			`Invalid number of arguments, expected ${parameterNames.length}, got ${argLen}`,
 		);
 	}
 
@@ -107,7 +108,7 @@ export function normalizeMoveArguments(
 			if (!parameterNames) {
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
-			const name = parameterNames[i];
+			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg == null) {


### PR DESCRIPTION
## Description

Skip system args in codegen's arg names list.

## Test plan

Added the missing test for args as `object` WITH trailing arg after the system one (we had 'object & no trailing', 'array & trailing' and 'array & no trailing' before ._. )

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
