### PR TITLE
fix(codegen): omit .js in imports of generated files

### DIFF
--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -203,7 +203,7 @@ export class MoveModuleBuilder extends FileBuilder {
 		{ fields }: Fields,
 		typeParameters: TypeParameter[] = [],
 	) {
-		this.addImport('~root/../utils/index.js', 'MoveStruct');
+		this.addImport('~root/../utils', 'MoveStruct');
 		const fieldObject = await mapToObject({
 			items: Object.entries(fields),
 			getComment: ([_name, field]) => field.doc,
@@ -221,8 +221,8 @@ export class MoveModuleBuilder extends FileBuilder {
 						if (address !== this.summary.id.address || mod !== this.summary.id.name) {
 							return this.addStarImport(
 								address === this.summary.id.address
-									? `./${mod}.js`
-									: join(`~root`, this.#depsDir, `${address}/${mod}.js`),
+									? `./${mod}`
+									: join(`~root`, this.#depsDir, `${address}/${mod}`),
 								mod,
 							);
 						}
@@ -241,7 +241,7 @@ export class MoveModuleBuilder extends FileBuilder {
 		{ fields }: Fields,
 		typeParameters: TypeParameter[] = [],
 	) {
-		this.addImport('~root/../utils/index.js', 'MoveTuple');
+		this.addImport('~root/../utils', 'MoveTuple');
 		const values = Object.values(fields).map((field) =>
 			renderTypeSignature(field.type_, {
 				format: 'bcs',
@@ -255,8 +255,8 @@ export class MoveModuleBuilder extends FileBuilder {
 					if (address !== this.summary.id.address || mod !== this.summary.id.name) {
 						return this.addStarImport(
 							address === this.summary.id.address
-								? `./${mod}.js`
-								: join(`~root`, this.#depsDir, `${address}/${mod}.js`),
+								? `./${mod}`
+								: join(`~root`, this.#depsDir, `${address}/${mod}`),
 							mod,
 						);
 					}
@@ -338,7 +338,7 @@ export class MoveModuleBuilder extends FileBuilder {
 			);
 		}
 
-		this.addImport('~root/../utils/index.js', 'MoveEnum');
+		this.addImport('~root/../utils', 'MoveEnum');
 		this.exports.push(name);
 
 		const enumName = `\${$moduleName}::${name}`;
@@ -364,8 +364,8 @@ export class MoveModuleBuilder extends FileBuilder {
 										if (address !== this.summary.id.address || mod !== this.summary.id.name) {
 											return this.addStarImport(
 												address === this.summary.id.address
-													? `./${mod}.js`
-													: `~root/deps/${address}/${mod}.js`,
+													? `./${mod}`
+													: `~root/deps/${address}/${mod}`,
 												mod,
 											);
 										}
@@ -440,7 +440,7 @@ export class MoveModuleBuilder extends FileBuilder {
 			);
 
 			if (parameters.length > 0) {
-				this.addImport('~root/../utils/index.js', 'normalizeMoveArguments');
+				this.addImport('~root/../utils', 'normalizeMoveArguments');
 			}
 
 			names.push(fnName);
@@ -465,7 +465,7 @@ export class MoveModuleBuilder extends FileBuilder {
 				.join(',\n');
 
 			if (argumentsTypes.length > 0) {
-				this.addImport('~root/../utils/index.js', 'type RawTransactionArgument');
+				this.addImport('~root/../utils', 'type RawTransactionArgument');
 			}
 
 			if (usedTypeParameters.size > 0) {


### PR DESCRIPTION
## Description

Removal of `.js` extension in imports of generated files.

## Why I raised this PR

I'm using this library within a Next.js project with TypeScript, which uses a strict compiler configuration. Files generated by codegen are TypeScript-based (so do they have extension `.ts`) but imports have `.js` extension so after running the project complier raises following error:

```
./src/__generated__/xyz/xyz_nft.ts:12:0
Module not found: Can't resolve '../utils/index.js'
```

## Test plan

By manually editing generated files and then running the project again.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
