### PR TITLE
Fix: extendBlobTransaction

### DIFF
--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -779,11 +779,7 @@ export class WalrusClient {
 
 			const result = await fn(coin, tx);
 
-			tx.moveCall({
-				target: '0x2::coin::destroy_zero',
-				typeArguments: [walType],
-				arguments: [coin],
-			});
+			tx.transferObjects([coin], tx.getData().sender);
 
 			return result;
 		};


### PR DESCRIPTION
## Description

In the extendBlobTransaction function, an error always appears because it is destroying a coin that has value. I made the local patch changing it to send to the user and it solved it.

## Test plan

just try to execute a extendBlobTransaction on frontend.
