### PR TITLE
[enoki-wallet] reuse existing proof when available

### DIFF
--- a/.changeset/fuzzy-bats-repair.md
+++ b/.changeset/fuzzy-bats-repair.md
@@ -1,0 +1,5 @@
+---
+'@mysten/enoki': patch
+---
+
+reuse existing proof when available


### PR DESCRIPTION
## Description

Avoids calling Enoki API to create a new proof when one is already available

## Test plan

👀 

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
