### PR TITLE
[dapp-kit-next] add backward compatible auto-connect functionality

### DIFF
--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
@@ -13,7 +13,8 @@ import {
 	getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle,
 } from '@wallet-standard/ui-registry';
 import { WalletAccountNotFoundError, WalletNoAccountsConnectedError } from '../../utils/errors.js';
-import { getChain, Networks } from '../../utils/networks.js';
+import { getChain } from '../../utils/networks.js';
+import type { Networks } from '../../utils/networks.js';
 
 export type ConnectWalletArgs = {
 	/** The wallet to connect to. */

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
@@ -13,8 +13,7 @@ import {
 	getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle,
 } from '@wallet-standard/ui-registry';
 import { WalletAccountNotFoundError, WalletNoAccountsConnectedError } from '../../utils/errors.js';
-import type { Experimental_SuiClientTypes } from '@mysten/sui/experimental';
-import { getChain } from '../../utils/networks.js';
+import { getChain, Networks } from '../../utils/networks.js';
 
 export type ConnectWalletArgs = {
 	/** The wallet to connect to. */
@@ -29,7 +28,7 @@ export type ConnectWalletArgs = {
 
 export function connectWalletCreator(
 	{ $baseConnection }: DAppKitStores,
-	supportedNetworks: readonly Experimental_SuiClientTypes.Network[],
+	supportedNetworks: Networks,
 ) {
 	/**
 	 * Prompts the specified wallet to connect and authorize new accounts for the current domain.
@@ -46,19 +45,11 @@ export function connectWalletCreator(
 			try {
 				$baseConnection.setKey('status', isAlreadyConnected ? 'reconnecting' : 'connecting');
 
-				const { connect } = getWalletFeature(
+				const suiAccounts = await internalConnectWallet(
 					wallet,
-					StandardConnect,
-				) as StandardConnectFeature[typeof StandardConnect];
-
-				const result = await connect(standardConnectArgs);
-
-				const underlyingWallet = getWalletForHandle(wallet);
-				const supportedChains = supportedNetworks.map(getChain);
-
-				const suiAccounts = result.accounts
-					.filter((account) => account.chains.some((chain) => supportedChains.includes(chain)))
-					.map(getOrCreateUiWalletAccountForStandardWalletAccount.bind(null, underlyingWallet));
+					supportedNetworks,
+					standardConnectArgs,
+				);
 
 				if (!isAlreadyConnected && suiAccounts.length === 0) {
 					throw new WalletNoAccountsConnectedError('No accounts were authorized.');
@@ -82,4 +73,24 @@ export function connectWalletCreator(
 			}
 		});
 	};
+}
+
+export async function internalConnectWallet(
+	wallet: UiWallet,
+	supportedNetworks: Networks,
+	args: StandardConnectInput,
+) {
+	const { connect } = getWalletFeature(
+		wallet,
+		StandardConnect,
+	) as StandardConnectFeature[typeof StandardConnect];
+
+	const result = await connect(args);
+
+	const underlyingWallet = getWalletForHandle(wallet);
+	const supportedChains = supportedNetworks.map(getChain);
+
+	return result.accounts
+		.filter((account) => account.chains.some((chain) => supportedChains.includes(chain)))
+		.map(getOrCreateUiWalletAccountForStandardWalletAccount.bind(null, underlyingWallet));
 }

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
@@ -18,7 +18,7 @@ export function disconnectWalletCreator({ $baseConnection, $connection }: DAppKi
 	 */
 	return async function disconnectWallet(...standardDisconnectArgs: DisconnectWalletArgs) {
 		return await task(async () => {
-			const { wallet } = $connection.get();
+			const { wallet, account } = $connection.get();
 			if (!wallet) {
 				throw new WalletNotConnectedError('No wallet is connected.');
 			}

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
@@ -18,7 +18,7 @@ export function disconnectWalletCreator({ $baseConnection, $connection }: DAppKi
 	 */
 	return async function disconnectWallet(...standardDisconnectArgs: DisconnectWalletArgs) {
 		return await task(async () => {
-			const { wallet, account } = $connection.get();
+			const { wallet } = $connection.get();
 			if (!wallet) {
 				throw new WalletNotConnectedError('No wallet is connected.');
 			}

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/index.ts
@@ -88,7 +88,7 @@ export function createDAppKit<
 	manageWalletConnection(stores);
 
 	if (autoConnect) {
-		autoConnectWallet({ stores, storageKey, storage });
+		autoConnectWallet({ networks, stores, storageKey, storage });
 	}
 
 	registerAdditionalWallets(

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -8,15 +8,18 @@ import { type UiWallet } from '@wallet-standard/ui';
 import { getWalletUniqueIdentifier } from '../../utils/wallets.js';
 
 import { internalConnectWallet } from '../actions/connect-wallet.js';
+import { Networks } from '../../utils/networks.js';
 
 /**
  * Attempts to connect to a previously authorized wallet account on mount and when new wallets are registered.
  */
 export function autoConnectWallet({
+	networks,
 	stores: { $baseConnection, $compatibleWallets },
 	storage,
 	storageKey,
 }: {
+	networks: Networks;
 	stores: DAppKitStores;
 	storage: StateStorage;
 	storageKey: string;
@@ -31,6 +34,7 @@ export function autoConnectWallet({
 
 				const savedWalletAccount = await task(() => {
 					return getSavedWalletAccount({
+						networks,
 						storage,
 						storageKey,
 						wallets,
@@ -49,10 +53,12 @@ export function autoConnectWallet({
 }
 
 async function getSavedWalletAccount({
+	networks,
 	storage,
 	storageKey,
 	wallets,
 }: {
+	networks: Networks;
 	storage: StateStorage;
 	storageKey: string;
 	wallets: readonly UiWallet[];
@@ -85,7 +91,7 @@ async function getSavedWalletAccount({
 
 	// For wallets that don't pre-populate the accounts array on page load,
 	// we need to silently request authorization and get the account directly.
-	const alreadyAuthorizedAccounts = await internalConnectWallet(targetWallet, [], {
+	const alreadyAuthorizedAccounts = await internalConnectWallet(targetWallet, networks, {
 		silent: true,
 	});
 

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -4,11 +4,11 @@
 import { onMount, task } from 'nanostores';
 import type { DAppKitStores } from '../store.js';
 import type { StateStorage } from '../../utils/storage.js';
-import { type UiWallet } from '@wallet-standard/ui';
+import type { UiWallet } from '@wallet-standard/ui';
 import { getWalletUniqueIdentifier } from '../../utils/wallets.js';
 
 import { internalConnectWallet } from '../actions/connect-wallet.js';
-import { Networks } from '../../utils/networks.js';
+import type { Networks } from '../../utils/networks.js';
 
 /**
  * Attempts to connect to a previously authorized wallet account on mount and when new wallets are registered.

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/sync-state-to-storage.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/sync-state-to-storage.ts
@@ -20,7 +20,9 @@ export function syncStateToStorage({
 	storageKey: string;
 }) {
 	onMount($connection, () => {
-		return $connection.listen((connection) => {
+		return $connection.listen((connection, oldConnection) => {
+			if (!oldConnection || oldConnection.status === connection.status) return;
+
 			if (connection.account) {
 				storage.setItem(storageKey, getSavedAccountStorageKey(connection.account));
 			} else {


### PR DESCRIPTION
## Description
I had a little extra time, so I figured I'd try to get the remaining dApp Kit work out of the way. This PR adds the backward compatible auto-connect functionality for wallets that don't pre-populate the accounts array.


## Test plan
- Auto-connect works normally with all wallets (e.g. Phantom which doesn't populate accounts on load and Backpack which does)

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [X] I did not use AI for this PR.
