### PR TITLE
Exported DemType in the Seal SDK

### DIFF
--- a/packages/seal/src/index.ts
+++ b/packages/seal/src/index.ts
@@ -15,3 +15,4 @@ export type {
 	FetchKeysOptions,
 	GetDerivedKeysOptions,
 } from './types.js';
+export { DemType } from "./encrypt.js";


### PR DESCRIPTION
## Description

This PR aims to export DemType in the Seal SDK, to perform Hmac256Ctr encryption. This is mandatory as on-chain decryption is only supported with Hmac256Ctr.

## Test plan

This is just an export added

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
