### PR TITLE
[Codegen]  Use `bcs.option` instead of `bcs.vector`

### DIFF
--- a/.changeset/sad-showers-pay.md
+++ b/.changeset/sad-showers-pay.md
@@ -1,0 +1,5 @@
+---
+'@mysten/codegen': patch
+---
+
+Optional struct generation should be bcs.option instead of bcs.vector

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -48,7 +48,7 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
 				const type = getPureBcsSchema(structTag.typeParams[0]!);
-				return type ? bcs.vector(type) : null;
+				return type ? bcs.option(type) : null;
 			}
 		}
 

--- a/packages/codegen/tests/generated/utils/index.ts
+++ b/packages/codegen/tests/generated/utils/index.ts
@@ -52,7 +52,7 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
 				const type = getPureBcsSchema(structTag.typeParams[0]!);
-				return type ? bcs.vector(type) : null;
+				return type ? bcs.option(type) : null;
 			}
 		}
 

--- a/packages/suins-v2/src/calls.ts
+++ b/packages/suins-v2/src/calls.ts
@@ -241,6 +241,7 @@ export class SuiNsCalls {
 			arguments: {
 				suins: this.#objectIds.suins,
 				intent: options.arguments.intent,
+				bbbVault: options.arguments.bbbVault,
 				payment: options.arguments.payment,
 			},
 			typeArguments: options.typeArguments,
@@ -253,6 +254,7 @@ export class SuiNsCalls {
 			arguments: {
 				suins: this.#objectIds.suins,
 				intent: options.arguments.intent,
+				bbbVault: options.arguments.bbbVault,
 				payment: options.arguments.payment,
 				priceInfoObject: options.arguments.priceInfoObject,
 				userPriceGuard: options.arguments.userPriceGuard,

--- a/packages/suins-v2/src/contracts/suins_payments/payments.ts
+++ b/packages/suins-v2/src/contracts/suins_payments/payments.ts
@@ -27,10 +27,13 @@ export const PaymentsConfig = new MoveStruct({
 		currencies: vec_map.VecMap(type_name.TypeName, CoinTypeData),
 		base_currency: type_name.TypeName,
 		max_age: bcs.u64(),
+		/** The percentage of the payment that gets burned, in basis points. */
+		burn_bps: bcs.u64(),
 	},
 });
 export interface HandleBasePaymentArguments {
 	suins: RawTransactionArgument<string>;
+	bbbVault: RawTransactionArgument<string>;
 	intent: RawTransactionArgument<string>;
 	payment: RawTransactionArgument<string>;
 }
@@ -40,6 +43,7 @@ export interface HandleBasePaymentOptions {
 		| HandleBasePaymentArguments
 		| [
 				suins: RawTransactionArgument<string>,
+				bbbVault: RawTransactionArgument<string>,
 				intent: RawTransactionArgument<string>,
 				payment: RawTransactionArgument<string>,
 		  ];
@@ -54,10 +58,11 @@ export function handleBasePayment(options: HandleBasePaymentOptions) {
 	const packageAddress = options.package ?? '@suins/payments';
 	const argumentsTypes = [
 		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::bbb_vault::BBBVault`,
 		`${packageAddress}::payment::PaymentIntent`,
 		`0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${options.typeArguments[0]}>`,
 	] satisfies string[];
-	const parameterNames = ['suins', 'intent', 'payment'];
+	const parameterNames = ['suins', 'bbbVault', 'intent', 'payment'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -69,6 +74,7 @@ export function handleBasePayment(options: HandleBasePaymentOptions) {
 }
 export interface HandlePaymentArguments {
 	suins: RawTransactionArgument<string>;
+	bbbVault: RawTransactionArgument<string>;
 	intent: RawTransactionArgument<string>;
 	payment: RawTransactionArgument<string>;
 	priceInfoObject: RawTransactionArgument<string>;
@@ -80,6 +86,7 @@ export interface HandlePaymentOptions {
 		| HandlePaymentArguments
 		| [
 				suins: RawTransactionArgument<string>,
+				bbbVault: RawTransactionArgument<string>,
 				intent: RawTransactionArgument<string>,
 				payment: RawTransactionArgument<string>,
 				priceInfoObject: RawTransactionArgument<string>,
@@ -103,13 +110,21 @@ export function handlePayment(options: HandlePaymentOptions) {
 	const packageAddress = options.package ?? '@suins/payments';
 	const argumentsTypes = [
 		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::bbb_vault::BBBVault`,
 		`${packageAddress}::payment::PaymentIntent`,
 		`0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<${options.typeArguments[0]}>`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 		'0x8d97f1cd6ac663735be08d1d2b6d02a159e711586461306ce60a2b7a6a565a9e::price_info::PriceInfoObject',
 		'u64',
 	] satisfies string[];
-	const parameterNames = ['suins', 'intent', 'payment', 'priceInfoObject', 'userPriceGuard'];
+	const parameterNames = [
+		'suins',
+		'bbbVault',
+		'intent',
+		'payment',
+		'priceInfoObject',
+		'userPriceGuard',
+	];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -228,6 +243,7 @@ export interface NewPaymentsConfigArguments {
 	setups: RawTransactionArgument<string[]>;
 	baseCurrency: RawTransactionArgument<string>;
 	maxAge: RawTransactionArgument<number | bigint>;
+	burnBps: RawTransactionArgument<number | bigint>;
 }
 export interface NewPaymentsConfigOptions {
 	package?: string;
@@ -237,6 +253,7 @@ export interface NewPaymentsConfigOptions {
 				setups: RawTransactionArgument<string[]>,
 				baseCurrency: RawTransactionArgument<string>,
 				maxAge: RawTransactionArgument<number | bigint>,
+				burnBps: RawTransactionArgument<number | bigint>,
 		  ];
 }
 /**
@@ -249,8 +266,9 @@ export function newPaymentsConfig(options: NewPaymentsConfigOptions) {
 		`vector<${packageAddress}::payments::CoinTypeData>`,
 		'0x0000000000000000000000000000000000000000000000000000000000000001::type_name::TypeName',
 		'u64',
+		'u64',
 	] satisfies string[];
-	const parameterNames = ['setups', 'baseCurrency', 'maxAge'];
+	const parameterNames = ['setups', 'baseCurrency', 'maxAge', 'burnBps'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,

--- a/packages/suins-v2/src/contracts/suins_temp_subdomain_proxy/subdomain_proxy.ts
+++ b/packages/suins-v2/src/contracts/suins_temp_subdomain_proxy/subdomain_proxy.ts
@@ -38,8 +38,8 @@ export interface NewOptions {
 export function _new(options: NewOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'u64',
@@ -82,8 +82,8 @@ export interface NewLeafOptions {
 export function newLeaf(options: NewLeafOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'address',
@@ -115,8 +115,8 @@ export interface RemoveLeafOptions {
 export function removeLeaf(options: RemoveLeafOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 	] satisfies string[];
@@ -126,6 +126,79 @@ export function removeLeaf(options: RemoveLeafOptions) {
 			package: packageAddress,
 			module: 'subdomain_proxy',
 			function: 'remove_leaf',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface AddLeafMetadataArguments {
+	suins: RawTransactionArgument<string>;
+	parent: RawTransactionArgument<string>;
+	subdomainName: RawTransactionArgument<string>;
+	key: RawTransactionArgument<string>;
+	value: RawTransactionArgument<string>;
+}
+export interface AddLeafMetadataOptions {
+	package?: string;
+	arguments:
+		| AddLeafMetadataArguments
+		| [
+				suins: RawTransactionArgument<string>,
+				parent: RawTransactionArgument<string>,
+				subdomainName: RawTransactionArgument<string>,
+				key: RawTransactionArgument<string>,
+				value: RawTransactionArgument<string>,
+		  ];
+}
+export function addLeafMetadata(options: AddLeafMetadataOptions) {
+	const packageAddress = options.package ?? '@suins/subdomain-proxy';
+	const argumentsTypes = [
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
+		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
+		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
+		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
+		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
+	] satisfies string[];
+	const parameterNames = ['suins', 'parent', 'subdomainName', 'key', 'value'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'subdomain_proxy',
+			function: 'add_leaf_metadata',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface RemoveLeafMetadataArguments {
+	suins: RawTransactionArgument<string>;
+	parent: RawTransactionArgument<string>;
+	subdomainName: RawTransactionArgument<string>;
+	key: RawTransactionArgument<string>;
+}
+export interface RemoveLeafMetadataOptions {
+	package?: string;
+	arguments:
+		| RemoveLeafMetadataArguments
+		| [
+				suins: RawTransactionArgument<string>,
+				parent: RawTransactionArgument<string>,
+				subdomainName: RawTransactionArgument<string>,
+				key: RawTransactionArgument<string>,
+		  ];
+}
+export function removeLeafMetadata(options: RemoveLeafMetadataOptions) {
+	const packageAddress = options.package ?? '@suins/subdomain-proxy';
+	const argumentsTypes = [
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
+		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
+		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
+		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
+	] satisfies string[];
+	const parameterNames = ['suins', 'parent', 'subdomainName', 'key'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'subdomain_proxy',
+			function: 'remove_leaf_metadata',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
 		});
 }
@@ -151,8 +224,8 @@ export interface EditSetupOptions {
 export function editSetup(options: EditSetupOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'bool',
@@ -191,8 +264,8 @@ export interface SetTargetAddressOptions {
 export function setTargetAddress(options: SetTargetAddressOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000001::option::Option<address>',
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 	] satisfies string[];
@@ -225,8 +298,8 @@ export interface SetUserDataOptions {
 export function setUserData(options: SetUserDataOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
@@ -258,8 +331,8 @@ export interface UnsetUserDataOptions {
 export function unsetUserData(options: UnsetUserDataOptions) {
 	const packageAddress = options.package ?? '@suins/subdomain-proxy';
 	const argumentsTypes = [
-		'0x0000000000000000000000000000000000000000000000000000000000000000::suins::SuiNS',
-		'0x0000000000000000000000000000000000000000000000000000000000000000::subdomain_registration::SubDomainRegistration',
+		`${packageAddress}::suins::SuiNS`,
+		`${packageAddress}::subdomain_registration::SubDomainRegistration`,
 		'0x0000000000000000000000000000000000000000000000000000000000000001::string::String',
 		'0x0000000000000000000000000000000000000000000000000000000000000002::clock::Clock',
 	] satisfies string[];

--- a/packages/suins-v2/src/contracts/utils/index.ts
+++ b/packages/suins-v2/src/contracts/utils/index.ts
@@ -48,7 +48,7 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
 				const type = getPureBcsSchema(structTag.typeParams[0]!);
-				return type ? bcs.vector(type) : null;
+				return type ? bcs.option(type) : null;
 			}
 		}
 

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -48,7 +48,7 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
 				const type = getPureBcsSchema(structTag.typeParams[0]!);
-				return type ? bcs.vector(type) : null;
+				return type ? bcs.option(type) : null;
 			}
 		}
 


### PR DESCRIPTION
## Description

Optional structs should return `bcs.option` instead of `bcs.vector`

## Test plan

This was tested by using `codegen` for `payment-kit`

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [X] I did not use AI for this PR.
