### PR TITLE
Update link README.md

### DIFF
--- a/packages/move-bytecode-template/README.md
+++ b/packages/move-bytecode-template/README.md
@@ -19,7 +19,7 @@ This package is a perfect fit for the following applications:
 ## Example of a Template Module
 
 The following code is a close-copy of the `Coin` example from the
-[Coins and Tokens](https://docs.sui.io/guides/developer/coin).
+[Coins and Tokens](https://docs.sui.io/standards/currency).
 
 ```move
 module 0x0::template {
@@ -160,7 +160,7 @@ await init({ module_or_path: url });
 ## Build locally
 
 To build the binary, you need to have Rust installed and then the `wasm-pack`. The installation
-script [can be found here](https://rustwasm.github.io/wasm-pack/).
+script [can be found here](https://github.com/rustwasm/wasm-pack).
 
 ```
 pnpm build:wasm


### PR DESCRIPTION


## Description

This PR updates two outdated external documentation links in the **`packages/move-bytecode-template/README.md`** file:

* Replaced the broken Sui docs link
  `https://docs.sui.io/guides/developer/coin` → **`https://docs.sui.io/standards/currency`**
  (current location of the Coin standard documentation in Sui Docs).
* Replaced the deprecated wasm-pack link
  `https://rustwasm.github.io/wasm-pack/` → **`https://github.com/rustwasm/wasm-pack`**
  (official and maintained source for wasm-pack installation and documentation).

These updates ensure that all external references are live and direct users to the canonical, actively maintained resources.

---

## Test plan

* Verified both new URLs resolve successfully (HTTP 200).
* Checked that each page contains the same or equivalent content as the old reference (Sui Coin → Currency standard; wasm-pack installation guide).
* Ran `pnpm build:wasm` locally to confirm no README formatting or reference issues.

---

### AI Assistance Notice

* [x] I used AI for docs / tests, but manually wrote the source code.
* [ ] This PR was primarily written by AI.
* [ ] I used AI to understand the problem space / repository.
* [ ] I did not use AI for this PR.



