### PR TITLE
refactor: replace SuiClient with ClientWithCoreApi in Transaction class

### DIFF
--- a/packages/typescript/src/transactions/Transaction.ts
+++ b/packages/typescript/src/transactions/Transaction.ts
@@ -6,7 +6,6 @@ import { fromBase64, isSerializedBcs } from '@mysten/bcs';
 import type { InferInput } from 'valibot';
 import { is, parse } from 'valibot';
 
-import type { SuiClient } from '../client/index.js';
 import type { SignatureWithBytes, Signer } from '../cryptography/index.js';
 import { normalizeSuiAddress } from '../utils/sui-types.js';
 import type { TransactionArgument } from './Commands.js';
@@ -32,6 +31,7 @@ import { createPure } from './pure.js';
 import { TransactionDataBuilder } from './TransactionData.js';
 import { getIdFromCallArg } from './utils.js';
 import { namedPackagesPlugin } from './plugins/NamedPackagesPlugin.js';
+import type { ClientWithCoreApi } from '../experimental/core.js';
 
 export type TransactionObjectArgument =
 	| Exclude<InferInput<typeof ArgumentSchema>, { Input: unknown; type?: 'pure' }>
@@ -744,7 +744,7 @@ export class Transaction {
 	/** Derive transaction digest */
 	async getDigest(
 		options: {
-			client?: SuiClient;
+			client?: ClientWithCoreApi;
 		} = {},
 	): Promise<string> {
 		await this.prepareForSerialization(options);


### PR DESCRIPTION
## Description

Change the client type of `getDigest` method in `TransactionClass` from `SuiClient` to `ClientWithCoreApi`

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
