### PR TITLE
[bcs] work around turbopack bug that breaks uleb128 in next@16

### DIFF
--- a/.changeset/rich-clowns-pump.md
+++ b/.changeset/rich-clowns-pump.md
@@ -1,0 +1,5 @@
+---
+'@mysten/bcs': patch
+---
+
+Work around bug in turbopack thatbreaks uleb128 encoding in next@16

--- a/packages/bcs/src/uleb.ts
+++ b/packages/bcs/src/uleb.ts
@@ -14,7 +14,8 @@ export function ulebEncode(num: number | bigint): number[] {
 
 	while (bigNum > 0) {
 		arr[len] = Number(bigNum & 0x7fn);
-		if ((bigNum >>= 7n)) {
+		bigNum >>= 7n;
+		if (bigNum > 0n) {
 			arr[len] |= 0x80;
 		}
 		len += 1;


### PR DESCRIPTION
## Description

fixes #635 

related issue: https://github.com/vercel/next.js/issues/85474

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
