### PR TITLE
fix(codegen): Generate modules with only private entry functions

### DIFF
--- a/.changeset/fix-entry-functions-generation.md
+++ b/.changeset/fix-entry-functions-generation.md
@@ -1,0 +1,7 @@
+---
+"@mysten/codegen": patch
+---
+
+Fix hasFunctions() to respect privateMethods configuration
+
+This change fixes a bug where modules with only entry functions (no types or public functions) were not being generated even when privateMethods was set to 'entry'. The hasFunctions() method now checks the #includedFunctions set instead of only looking for public functions, ensuring consistency with the privateMethods option added in version 0.5.0.

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -205,9 +205,7 @@ export class MoveModuleBuilder extends FileBuilder {
 	}
 
 	hasFunctions() {
-		return Object.values(this.summary.functions).some(
-			(func) => func.visibility === 'Public' && !func.macro_,
-		);
+		return this.#includedFunctions.size > 0;
 	}
 
 	hasTypesOrFunctions() {


### PR DESCRIPTION
## Description

Fix module generation for entry-only functions when using privateMethods: 'entry'

This PR fixes a bug where modules containing only private entry functions (with no types or public functions) were not being generated, even when privateMethods was set to 'entry'.

The issue was in the hasFunctions() method, which only checked for public functions (visibility === 'Public'), ignoring the #includedFunctions set that was already populated by includeAllFunctions() based on the privateMethods configuration.

**Changes:**
- Updated hasFunctions() to check this.#includedFunctions.size > 0 instead of only checking for public functions
- This ensures consistency between includeAllFunctions() and hasFunctions(), making the privateMethods option work as documented

**Impact:**
- Modules with only private entry functions (like access_policy.move) will now be generated correctly when privateMethods: 'entry' (the default)
- No breaking changes - only fixes previously broken behavior

## Test plan
- Existing unit tests pass (pnpm --filter @mysten/codegen test)
- Build succeeds (pnpm turbo build --filter=@mysten/codegen)
- Code generation works correctly (pnpm --filter @mysten/codegen codegen)
- Lint and format checks pass

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

