### PR TITLE
fix(wallet-sdk): divide by decimals in applyTransactionEffects

### DIFF
--- a/.changeset/eleven-tips-buy.md
+++ b/.changeset/eleven-tips-buy.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-sdk': patch
+---
+
+fix coin calculation in AutoApprovalManager.applyTransactionEffects

--- a/packages/wallet-sdk/src/auto-approvals/manager.ts
+++ b/packages/wallet-sdk/src/auto-approvals/manager.ts
@@ -361,7 +361,8 @@ export class AutoApprovalManager {
 					throw new Error('No value available for coin type ' + change.coinType);
 				}
 
-				const convertedChange = Number(change.amount) / 10 ** coinValue.decimals * coinValue.price;
+				const convertedChange =
+					(Number(change.amount) / 10 ** coinValue.decimals) * coinValue.price;
 
 				this.#state.settings.sharedBudget += convertedChange;
 			}


### PR DESCRIPTION
## Description
Tiny fix to divide coin amount by decimals rather than multiplying in `AutoApprovalManager`

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [X] I did not use AI for this PR.
