### PR TITLE
[suins] getPriceInfoObject feeCoin param

### DIFF
--- a/.changeset/better-toes-poke.md
+++ b/.changeset/better-toes-poke.md
@@ -1,0 +1,6 @@
+---
+'@mysten/suins': patch
+---
+
+- getPriceInfoObject feeCoin param
+- expose Pyth update fee from suins client (getPythBaseUpdateFee)

--- a/packages/suins/src/suins-client.ts
+++ b/packages/suins/src/suins-client.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 import type { SuiClient } from '@mysten/sui/client';
-import type { Transaction } from '@mysten/sui/transactions';
+import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
 import { isValidSuiNSName, normalizeSuiNSName } from '@mysten/sui/utils';
 
 import { mainPackage } from './constants.js';
@@ -317,7 +317,7 @@ export class SuinsClient {
 		return price;
 	}
 
-	async getPriceInfoObject(tx: Transaction, feed: string) {
+	async getPriceInfoObject(tx: Transaction, feed: string, feeCoin?: TransactionObjectArgument) {
 		// Initialize connection to the Sui Price Service
 		const endpoint =
 			this.network === 'testnet'
@@ -339,7 +339,15 @@ export class SuinsClient {
 
 		const client = new SuiPythClient(this.client, pythStateId, wormholeStateId);
 
-		return await client.updatePriceFeeds(tx, priceUpdateData, priceIDs); // returns priceInfoObjectIds
+		return await client.updatePriceFeeds(tx, priceUpdateData, priceIDs, feeCoin); // returns priceInfoObjectIds
+	}
+
+	async getPythBaseUpdateFee(): Promise<number> {
+		const pythStateId = this.config.pyth.pythStateId;
+		const wormholeStateId = this.config.pyth.wormholeStateId;
+
+		const client = new SuiPythClient(this.client, pythStateId, wormholeStateId);
+		return await client.getBaseUpdateFee();
 	}
 
 	async getObjectType(objectId: string) {


### PR DESCRIPTION
## Description

* allows passing a coin to pay for the pyth fee instead using the gas coin
* useful when the transaction is sponsored

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [x] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
