### PR TITLE
feat(deepbook-v3): add custom network support via packageIds

### DIFF
--- a/.changeset/custom-network-support.md
+++ b/.changeset/custom-network-support.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook-v3': minor
+---
+
+Add support for custom networks (localnet, devnet) via optional `packageIds` parameter

--- a/packages/deepbook-v3/src/client.ts
+++ b/packages/deepbook-v3/src/client.ts
@@ -23,7 +23,7 @@ import {
 	FLOAT_SCALAR,
 	PRICE_INFO_OBJECT_MAX_AGE_MS,
 } from './utils/config.js';
-import type { CoinMap, PoolMap } from './utils/constants.js';
+import type { CoinMap, PoolMap, DeepbookPackageIds } from './utils/constants.js';
 import { MarginAdminContract } from './transactions/marginAdmin.js';
 import { MarginMaintainerContract } from './transactions/marginMaintainer.js';
 import { MarginPoolContract } from './transactions/marginPool.js';
@@ -47,6 +47,8 @@ export interface DeepBookOptions<Name = 'deepbook'> {
 	adminCap?: string;
 	marginAdminCap?: string;
 	marginMaintainerCap?: string;
+	packageIds?: DeepbookPackageIds;
+	pyth?: { pythStateId: string; wormholeStateId: string };
 	name?: Name;
 }
 
@@ -106,6 +108,8 @@ export class DeepBookClient {
 		adminCap,
 		marginAdminCap,
 		marginMaintainerCap,
+		packageIds,
+		pyth,
 	}: DeepBookClientOptions) {
 		this.#client = client;
 		this.#address = normalizeSuiAddress(address);
@@ -119,6 +123,8 @@ export class DeepBookClient {
 			adminCap,
 			marginAdminCap,
 			marginMaintainerCap,
+			packageIds,
+			pyth,
 		});
 		this.balanceManager = new BalanceManagerContract(this.#config);
 		this.deepBook = new DeepBookContract(this.#config);


### PR DESCRIPTION
## Description

The DeepBook V3 SDK currently hard-rejects any network that isn't `'mainnet'` or `'testnet'` in `DeepBookConfig`, even though the Sui SDK's `Network` type already accepts `'localnet'` and arbitrary strings. This blocks developers building on localnet/devnet from using the SDK.

This PR adds optional `packageIds` and `pyth` parameters to `DeepBookConfig` and `DeepBookClient`. When provided, they bypass the network restriction and use the caller-supplied package IDs directly. Existing `mainnet`/`testnet` behavior is completely unchanged.

**Changes:**
- `config.ts`: Accept optional `packageIds` and `pyth` constructor params; use them when provided, fall back to existing mainnet/testnet logic otherwise
- `client.ts`: Thread `packageIds` and `pyth` through `DeepBookOptions` and `DeepBookClient` constructor to `DeepBookConfig`
- No changes needed to `constants.ts` (`DeepbookPackageIds` was already exported)

**Usage example (localnet):**
```typescript
const client = new DeepBookClient({
  client: suiClient,
  network: 'localnet',
  address: myAddress,
  packageIds: {
    DEEPBOOK_PACKAGE_ID: '0x...',
    REGISTRY_ID: '0x...',
    DEEP_TREASURY_ID: '0x...',
    MARGIN_PACKAGE_ID: '0x...',
    MARGIN_REGISTRY_ID: '0x...',
    LIQUIDATION_PACKAGE_ID: '0x...',
  },
  coins: { /* custom coin definitions */ },
  pools: { /* custom pool definitions */ },
});
```

## Test plan

- `pnpm turbo build --filter=@mysten/deepbook-v3` — builds successfully (5/5 tasks pass)
- `pnpm --filter @mysten/deepbook-v3 lint` — 0 warnings, 0 errors, Prettier clean
- Backward compatibility: existing mainnet/testnet usage unchanged (no new required params)
- Unsupported network without `packageIds` still throws a clear error

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.