### PR TITLE
Fix parseStructTag to reject malformed inputs

### DIFF
--- a/.changeset/harden-parse-struct-tag.md
+++ b/.changeset/harden-parse-struct-tag.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Fix `parseStructTag` to reject malformed inputs: empty address/module/name components (e.g. `::foo::Bar`) and trailing content after type parameters (e.g. `Coin<u8>GARBAGE`).

--- a/packages/sui/src/utils/sui-types.ts
+++ b/packages/sui/src/utils/sui-types.ts
@@ -125,10 +125,20 @@ export function parseStructTag(type: string): StructTag {
 	}
 
 	const [address, module] = parts;
+
+	if (!address || !module) {
+		throw new Error(`Invalid struct tag: ${type}`);
+	}
+
 	const isMvrPackage = isValidNamedPackage(address);
 
 	const rest = type.slice(address.length + module.length + 4);
 	const name = rest.includes('<') ? rest.slice(0, rest.indexOf('<')) : rest;
+
+	if (!name || (rest.includes('<') && !rest.endsWith('>'))) {
+		throw new Error(`Invalid struct tag: ${type}`);
+	}
+
 	const typeParams = rest.includes('<')
 		? splitGenericParameters(rest.slice(rest.indexOf('<') + 1, rest.lastIndexOf('>'))).map(
 				(typeParam) => parseTypeTag(typeParam.trim()),

--- a/packages/sui/test/unit/types/common.test.ts
+++ b/packages/sui/test/unit/types/common.test.ts
@@ -116,6 +116,18 @@ describe('parseStructTag', () => {
 		expect(() => parseStructTag('0x2::foo::Bar<vector<u8>')).toThrow('Invalid type tag');
 	});
 
+	it('rejects struct tags with empty components', () => {
+		expect(() => parseStructTag('::foo::Bar')).toThrow('Invalid struct tag');
+		expect(() => parseStructTag('0x2::::Bar')).toThrow('Invalid struct tag');
+		expect(() => parseStructTag('0x2::foo::')).toThrow('Invalid struct tag');
+	});
+
+	it('rejects struct tags with trailing content after type parameters', () => {
+		expect(() => parseStructTag('0x2::coin::Coin<u8>GARBAGE')).toThrow('Invalid struct tag');
+		expect(() => parseStructTag('0x2::foo::Bar<bool> ')).toThrow('Invalid struct tag');
+		expect(() => parseStructTag('0x2::foo::Bar<u64>xyz')).toThrow('Invalid struct tag');
+	});
+
 	it('parses named struct tags correctly', () => {
 		expect(parseStructTag('@mvr/demo::foo::bar')).toMatchInlineSnapshot(`
       {


### PR DESCRIPTION
## Description

`parseStructTag` silently accepted inputs with empty components (e.g. `::foo::Bar`, where the empty address normalized to `0x0`) and inputs with trailing content after type parameters (e.g. `Coin<u8>GARBAGE`). Both cases produced structurally incorrect `StructTag` objects without raising an error.

This adds two validation guards:

1. **Empty component rejection**: After splitting on `::`, validate that `address` and `module` are non-empty strings. Previously, `::foo::Bar` would silently have its empty address padded to `0x0` by `normalizeSuiAddress("")`.

2. **Trailing content rejection**: After extracting `name`, validate that if type parameters exist (`<...>`), the string ends with `>`. Previously, `Coin<u8>GARBAGE` would silently drop the trailing content.

Both throw `Error('Invalid struct tag: ${type}')`, consistent with the existing error for inputs with fewer than 3 `::` segments.

## Test plan

Added 6 test cases to `test/unit/types/common.test.ts`:

**Empty component rejection:**
- `::foo::Bar` — empty address
- `0x2::::Bar` — empty module
- `0x2::foo::` — empty name

**Trailing content rejection:**
- `0x2::coin::Coin<u8>GARBAGE` — trailing characters
- `0x2::foo::Bar<bool> ` — trailing space
- `0x2::foo::Bar<u64>xyz` — trailing alphanumeric

All 290 unit tests pass. Full e2e suite (722 tests) verified against local Sui network via Testcontainers — zero regressions.