### PR TITLE
feat(dapp-kit-react): separate UI components into /ui subpath export

### DIFF
--- a/packages/create-dapp/templates/react-client-dapp/src/App.tsx
+++ b/packages/create-dapp/templates/react-client-dapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { ConnectButton } from "@mysten/dapp-kit-react";
+import { ConnectButton } from "@mysten/dapp-kit-react/ui";
 import { WalletStatus } from "./WalletStatus";
 
 function App() {

--- a/packages/create-dapp/templates/react-e2e-counter/src/App.tsx
+++ b/packages/create-dapp/templates/react-e2e-counter/src/App.tsx
@@ -1,4 +1,5 @@
-import { ConnectButton, useCurrentAccount } from "@mysten/dapp-kit-react";
+import { useCurrentAccount } from "@mysten/dapp-kit-react";
+import { ConnectButton } from "@mysten/dapp-kit-react/ui";
 import { isValidSuiObjectId } from "@mysten/sui/utils";
 import { useState } from "react";
 import { Counter } from "./Counter";

--- a/packages/dapp-kit-next/examples/next-js/simple/app/ClientOnlyConnectButton.tsx
+++ b/packages/dapp-kit-next/examples/next-js/simple/app/ClientOnlyConnectButton.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { dAppKit } from './dApp-kit.ts';
 
 export default function ClientOnlyConnectButton() {

--- a/packages/dapp-kit-next/examples/react/simple/src/App.tsx
+++ b/packages/dapp-kit-next/examples/react/simple/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConnectButton } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 
 function App() {
 	return <ConnectButton />;

--- a/packages/dapp-kit-next/packages/dapp-kit-react/package.json
+++ b/packages/dapp-kit-next/packages/dapp-kit-react/package.json
@@ -18,6 +18,11 @@
 			"types": "./dist/index.d.mts",
 			"import": "./dist/index.mjs",
 			"default": "./dist/index.mjs"
+		},
+		"./ui": {
+			"types": "./dist/ui.d.mts",
+			"import": "./dist/ui.mjs",
+			"default": "./dist/ui.mjs"
 		}
 	},
 	"scripts": {

--- a/packages/dapp-kit-next/packages/dapp-kit-react/src/index.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-react/src/index.ts
@@ -3,12 +3,6 @@
 
 export * from '@mysten/dapp-kit-core';
 
-export { ConnectButton } from './components/ConnectButton.js';
-export type { ConnectButtonProps } from './components/ConnectButton.js';
-
-export { ConnectModal } from './components/ConnectModal.js';
-export type { ConnectModalProps } from './components/ConnectModal.js';
-
 export { DAppKitProvider, DAppKitContext } from './components/DAppKitProvider.js';
 export type { DAppKitProviderProps } from './components/DAppKitProvider.js';
 

--- a/packages/dapp-kit-next/packages/dapp-kit-react/src/ui.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-react/src/ui.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+export { ConnectButton } from './components/ConnectButton.js';
+export type { ConnectButtonProps } from './components/ConnectButton.js';
+
+export { ConnectModal } from './components/ConnectModal.js';
+export type { ConnectModalProps } from './components/ConnectModal.js';

--- a/packages/dapp-kit-next/packages/dapp-kit-react/tsdown.config.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-react/tsdown.config.ts
@@ -4,7 +4,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-	entry: ['src/index.ts'],
+	entry: ['src/index.ts', 'src/ui.ts'],
 	format: ['esm'],
 	dts: true,
 	sourcemap: true,

--- a/packages/docs/content/dapp-kit/getting-started/next-js.mdx
+++ b/packages/docs/content/dapp-kit/getting-started/next-js.mdx
@@ -45,7 +45,8 @@ Wallet detection only works in the browser, so dApp Kit components must be clien
 // app/DAppKitClientProvider.tsx
 'use client';
 
-import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { dAppKit } from './dapp-kit';
 
 export function DAppKitClientProvider({ children }: { children: React.ReactNode }) {
@@ -93,12 +94,8 @@ For simpler apps, create a single client component:
 // app/WalletApp.tsx
 'use client';
 
-import {
-	DAppKitProvider,
-	ConnectButton,
-	useCurrentAccount,
-	useDAppKit,
-} from '@mysten/dapp-kit-react';
+import { DAppKitProvider, useCurrentAccount, useDAppKit } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { Transaction, coinWithBalance } from '@mysten/sui/transactions';
 import { dAppKit } from './dapp-kit';
 

--- a/packages/docs/content/dapp-kit/getting-started/react.mdx
+++ b/packages/docs/content/dapp-kit/getting-started/react.mdx
@@ -68,7 +68,8 @@ Wrap your application with `DAppKitProvider`:
 
 ```tsx
 // App.tsx
-import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { dAppKit } from './dapp-kit';
 
 export default function App() {

--- a/packages/docs/content/dapp-kit/react/components/connect-modal.mdx
+++ b/packages/docs/content/dapp-kit/react/components/connect-modal.mdx
@@ -6,7 +6,7 @@ title: Connect Modal
 
 ```tsx
 import { useState } from 'react';
-import { ConnectModal } from '@mysten/dapp-kit-react';
+import { ConnectModal } from '@mysten/dapp-kit-react/ui';
 
 export function App() {
 	const [open, setOpen] = useState(false);

--- a/packages/docs/content/dapp-kit/theming.mdx
+++ b/packages/docs/content/dapp-kit/theming.mdx
@@ -166,7 +166,7 @@ Here's a complete theme example matching a custom design system:
 ### React
 
 ```tsx
-import { ConnectButton } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import './theme.css'; // Your theme CSS file
 
 export function App() {

--- a/packages/enoki/demo/App.tsx
+++ b/packages/enoki/demo/App.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConnectButton, useCurrentAccount, useDAppKit, useWallets } from '@mysten/dapp-kit-react';
+import { useCurrentAccount, useDAppKit, useWallets } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { Transaction } from '@mysten/sui/transactions';
 import { useState } from 'react';
 

--- a/packages/walrus/examples/benchmark/main.tsx
+++ b/packages/walrus/examples/benchmark/main.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createRoot } from 'react-dom/client';
-import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { dAppKit } from './dapp-kit.js';

--- a/packages/walrus/examples/write-from-wallet/main.tsx
+++ b/packages/walrus/examples/write-from-wallet/main.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createRoot } from 'react-dom/client';
-import { DAppKitProvider, ConnectButton } from '@mysten/dapp-kit-react';
+import { DAppKitProvider } from '@mysten/dapp-kit-react';
+import { ConnectButton } from '@mysten/dapp-kit-react/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { FileUpload } from './upload.js';


### PR DESCRIPTION
## Description

- Add new @mysten/dapp-kit-react/ui subpath exporting ConnectButton and ConnectModal
- Remove UI component re-exports from the main entry point
- Update all examples, templates, and docs to use the new import path

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [x] I used AI for docs / tests, but manually wrote the source code.
- [x] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
