### PR TITLE
fix(enoki): resolve deadlock in EnokiWallet connect with dapp-kit-next

### DIFF
--- a/packages/enoki/src/wallet/wallet.ts
+++ b/packages/enoki/src/wallet/wallet.ts
@@ -50,7 +50,6 @@ import type { EnokiNetwork } from '../EnokiClient/type.js';
 import { EnokiKeypair } from '../EnokiKeypair.js';
 
 import { EnokiWalletState } from './state.js';
-import { allTasks } from 'nanostores';
 
 const pkceFlowProviders: Partial<Record<AuthProvider, { tokenEndpoint: string }>> = {
 	playtron: {
@@ -262,11 +261,11 @@ export class EnokiWallet implements Wallet {
 	};
 
 	#connect: StandardConnectMethod = async (input) => {
-		// NOTE: This is a hackfix for the old version of dApp Kit where auto-connection logic
-		// only fires on initial mount of the WalletProvider component. Since hydrating the
-		// zkLogin state from IndexedDB is an asynchronous process, we need to make sure it
-		// is populated before the connect logic runs.
-		await allTasks();
+		// Wait for the zkLogin state to be hydrated from IndexedDB before checking accounts.
+		// This must be a targeted wait rather than allTasks() because connect() may be called
+		// from within a nanostore task() (e.g. dapp-kit-next's connectWallet), and allTasks()
+		// would deadlock by waiting for the calling task to complete.
+		await this.#state.whenReady();
 
 		if (input?.silent || this.#accounts.length > 0) {
 			return { accounts: this.#accounts };


### PR DESCRIPTION
## Summary

- Replace `await allTasks()` with a targeted `whenReady()` promise in `EnokiWallet.#connect` to fix a deadlock when used with dapp-kit-next
- Add `whenReady()` to `EnokiWalletState` that resolves once IndexedDB hydration of zkLogin state completes

### Problem

When using `<DappKitProvider>` (dapp-kit-next) with `enokiWalletsInitializer`, clicking a social login button (e.g. Google) causes the UI to freeze — the OAuth popup never opens.

**Root cause:** dapp-kit-next's `connectWallet` and `autoConnectWallet` wrap their work in nanostore `task()`. EnokiWallet's `#connect` called `await allTasks()`, which waits for ALL pending tasks — including the calling `task()` itself. This creates a circular wait (deadlock).

### Fix

Replace the broad `await allTasks()` with `await this.#state.whenReady()`, which only waits for the specific IndexedDB hydration that `allTasks()` was originally intended for. This works correctly for both old dApp Kit and dapp-kit-next.

## Test plan

- [ ] Verify Enoki ZK login (Google) works with `<DappKitProvider>` and `enokiWalletsInitializer`
- [ ] Verify auto-reconnect works on page reload with a saved Enoki session
- [ ] Verify Enoki ZK login still works with old `<SuiClientProvider>` + `registerEnokiWallets`

### AI Assistance Notice

- [x] This PR was primarily written by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)