### PR TITLE
[dapp-kit-core] fix autoconnect crash from computed store subscribe

### DIFF
--- a/.changeset/fix-autoconnect-undefined.md
+++ b/.changeset/fix-autoconnect-undefined.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit-core': patch
+---
+
+Fix autoconnect crash when computed store value is undefined during subscribe

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -30,6 +30,9 @@ export function autoConnectWallet({
 	onMount($compatibleWallets, () => {
 		return $compatibleWallets.subscribe(
 			async (wallets, oldWallets: readonly UiWallet[] | undefined) => {
+				// subscribe on a computed store may fire with undefined due to nanostores
+				// reading the underlying atom's uninitialized value instead of computing it.
+				if (!wallets) return;
 				if (oldWallets && oldWallets.length > wallets.length) return;
 
 				const connection = $baseConnection.get();


### PR DESCRIPTION
## Description

Fixes a crash in `autoconnect-wallet.ts` where `subscribe` on a nanostores `computed` store fires its immediate callback with `undefined` instead of the computed value.

**Root cause:** nanostores `computed` stores wrap an `atom(undefined)` internally. The `subscribe` method calls `listener($atom.value)` directly (which is `undefined`) rather than `listener($atom.get())` (which would trigger lazy computation). This means the first callback from `subscribe` receives `undefined` as the wallets array, causing `wallets.find(...)` to throw.

## Test plan

- No more error in the console

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.