### PR TITLE
docs: clarify content vs objectBcs in include options

### DIFF
--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -360,31 +360,32 @@ tx.add(
 
 ### Parsing BCS Data
 
-Use generated BCS types to parse on-chain object data with the core API:
+Use generated BCS types to parse on-chain object data. Fetch the object with
+`include: { content: true }` and pass `object.content` to the generated type's `.parse()` method:
 
 ```typescript
 import { Counter as CounterStruct } from './contracts/counter/counter';
 
-async function readCounter(id: string) {
-	const { response } = await client.ledgerService.getObject({
+async function readCounter(client: ClientWithCoreApi, id: string) {
+	const { object } = await client.core.getObject({
 		objectId: id,
-		readMask: {
-			paths: ['*'],
-		},
+		include: { content: true },
 	});
 
-	if (!response.object?.contents?.value) {
-		throw new Error('Expected a move object with contents');
-	}
-
-	// Parse with generated BCS type
-	const parsed = CounterStruct.parse(response.object.contents.value);
+	// Parse the Move struct fields from BCS content
+	const parsed = CounterStruct.parse(object.content);
 	console.log('Counter value:', parsed.value);
 	console.log('Counter owner:', parsed.owner);
 
 	return parsed;
 }
 ```
+
+<Callout type="warn">
+	Always use `content`, not `objectBcs`, when parsing with generated types. The `objectBcs` field
+	contains a full object envelope with additional metadata that will cause parsing to fail. See the
+	[Core API docs](/sui/clients/core#objectbcs) for details.
+</Callout>
 
 ## Client Configuration
 

--- a/packages/docs/content/sui/bcs.mdx
+++ b/packages/docs/content/sui/bcs.mdx
@@ -63,37 +63,57 @@ bcs.TypeTag.serialize({
 
 ## Working with Objects
 
-The `bcs.Object` schema can be used to serialize and deserialize complete Sui objects:
+To parse on-chain objects, fetch them with `include: { content: true }` and pass `object.content` to
+a generated BCS type or a manual struct definition. The `content` field contains only the inner Move
+struct bytes:
+
+```typescript
+import { MyStruct } from './generated/my-module';
+
+const { object } = await client.core.getObject({
+	objectId: '0x123...',
+	include: { content: true },
+});
+
+const parsed = MyStruct.parse(object.content);
+```
+
+### `bcs.Object` — Full object envelope
+
+The `bcs.Object` schema represents the complete on-chain object, including metadata (type, owner,
+version, previous transaction, storage rebate) wrapping the inner struct bytes. This is what the
+`objectBcs` include option returns. Most of this metadata is already available as fields on the
+object response, so you typically only need `content`.
 
 ```typescript
 import { bcs } from '@mysten/sui/bcs';
 
-// Parse a BCS-encoded object
-const objectBytes = await client.getObjects({
-  ids: [objectId],
-  include: { objectBcs: true },
-});
+// Parse a full object envelope (from objectBcs include option)
+const envelope = bcs.Object.parse(object.objectBcs);
+console.log('Owner:', envelope.owner);
+console.log('Inner struct bytes:', envelope.data.Move.contents);
 
-const parsed = bcs.Object.parse(objectBytes.objects[0].objectBcs);
-console.log('Owner:', parsed.owner);
-console.log('Previous Transaction:', parsed.previousTransaction);
-console.log('Storage Rebate:', parsed.storageRebate);
-
-// Serialize an object
+// Serialize a full object envelope
 const serialized = bcs.Object.serialize({
-  data: {
-    Move: {
-      type: { GasCoin: null },
-      hasPublicTransfer: true,
-      version: '1',
-      contents: new Uint8Array([...]),
-    },
-  },
-  owner: { AddressOwner: '0x...' },
-  previousTransaction: '...',
-  storageRebate: '1000',
+	data: {
+		Move: {
+			type: { GasCoin: null },
+			hasPublicTransfer: true,
+			version: '1',
+			contents: new Uint8Array([...]),
+		},
+	},
+	owner: { AddressOwner: '0x...' },
+	previousTransaction: '...',
+	storageRebate: '1000',
 });
 ```
+
+<Callout type="warn">
+	Do not pass `objectBcs` bytes to a Move struct parser — it contains wrapping metadata that will
+	cause parsing to fail. Use `content` for parsing Move struct fields. See the [Core API
+	docs](/sui/clients/core#objectbcs) for details.
+</Callout>
 
 ## Working with Transaction Effects
 

--- a/packages/docs/content/sui/clients/core.mdx
+++ b/packages/docs/content/sui/clients/core.mdx
@@ -27,6 +27,17 @@ class MySDK {
 
 ## Object Methods
 
+Object methods accept an optional `include` parameter to control what data is returned. By default,
+every object comes with `objectId`, `version`, `digest`, `owner`, and `type`. The following fields
+are only populated when requested:
+
+| Option                | Type      | Description                                                               |
+| --------------------- | --------- | ------------------------------------------------------------------------- |
+| `content`             | `boolean` | BCS-encoded Move struct content — pass this to generated BCS type parsers |
+| `previousTransaction` | `boolean` | Digest of the transaction that last mutated this object                   |
+| `json`                | `boolean` | JSON representation of the object's Move struct content                   |
+| `objectBcs`           | `boolean` | Full BCS-encoded object envelope (rarely needed, see [below](#objectbcs)) |
+
 ### getObject
 
 Fetch a single object by ID.
@@ -45,25 +56,6 @@ console.log(object.version);
 console.log(object.digest);
 console.log(object.type); // e.g., "0x2::coin::Coin<0x2::sui::SUI>"
 ```
-
-You can also fetch the JSON representation of the object's Move struct content:
-
-```typescript
-const { object } = await client.core.getObject({
-	objectId: '0x123...',
-	include: { json: true },
-});
-
-// Access the JSON representation
-console.log(object.json);
-```
-
-<Callout type="warn">
-The `json` field structure may vary between API implementations. For example, JSON-RPC returns UID
-fields as nested objects (`{ "id": { "id": "0x..." } }`), while gRPC and GraphQL flatten them
-(`{ "id": "0x..." }`). For consistent data across all clients, use `include: { content: true }` and
-parse the BCS data directly.
-</Callout>
 
 ### getObjects
 
@@ -109,6 +101,51 @@ if (result.cursor) {
 	});
 }
 ```
+
+### Parsing object content
+
+Use `include: { content: true }` to get the BCS-encoded Move struct bytes, then parse them with
+generated types (from `@mysten/codegen`) or manual BCS definitions:
+
+```typescript
+import { MyStruct } from './generated/my-module';
+
+const { object } = await client.core.getObject({
+	objectId: '0x123...',
+	include: { content: true },
+});
+
+const parsed = MyStruct.parse(object.content);
+```
+
+### `json` include option
+
+You can also fetch a JSON representation of the object's content with `include: { json: true }`.
+
+<Callout type="warn">
+	The `json` field structure may vary between API implementations. For example, JSON-RPC returns
+	UID fields as nested objects (`{ "id": { "id": "0x..." } }`), while gRPC and GraphQL flatten
+	them (`{ "id": "0x..." }`). For consistent data across all clients, use `content` and parse BCS
+	directly.
+</Callout>
+
+### `objectBcs`
+
+The `objectBcs` option returns the full BCS-encoded object envelope — the struct content wrapped in
+metadata (type, `hasPublicTransfer`, version, owner, previous transaction, storage rebate). Most of
+this metadata is already available as fields on the object response, so you typically only need
+`content`. If you do need `objectBcs`, parse it with `bcs.Object` from `@mysten/sui/bcs`:
+
+```typescript
+import { bcs } from '@mysten/sui/bcs';
+
+const envelope = bcs.Object.parse(object.objectBcs);
+```
+
+<Callout type="error">
+	Do not pass `objectBcs` to a Move struct parser — it contains wrapping metadata that will cause
+	parsing to fail or produce incorrect results. Use `content` for parsing Move struct fields.
+</Callout>
 
 ## Coin and Balance Methods
 
@@ -210,7 +247,8 @@ console.log(dynamicField.value.bcs); // BCS-encoded value
 
 ### getDynamicObjectField
 
-Get a dynamic object field, returning the referenced object.
+Get a dynamic object field, returning the referenced object. Supports the same
+[object include options](#object-methods) as `getObject`.
 
 ```typescript
 const { object } = await client.core.getDynamicObjectField({
@@ -224,6 +262,25 @@ const { object } = await client.core.getDynamicObjectField({
 ```
 
 ## Transaction Methods
+
+Transaction methods accept an optional `include` parameter to control what data is returned. By
+default, every transaction result includes `digest`, `signatures`, `epoch`, and `status`. The
+following fields are only populated when requested:
+
+| Option           | Type      | Description                                                          |
+| ---------------- | --------- | -------------------------------------------------------------------- |
+| `effects`        | `boolean` | Parsed transaction effects (gas used, changed objects, status, etc.) |
+| `events`         | `boolean` | Events emitted during execution                                      |
+| `transaction`    | `boolean` | Parsed transaction data (sender, gas config, inputs, commands)       |
+| `balanceChanges` | `boolean` | Balance changes caused by the transaction                            |
+| `objectTypes`    | `boolean` | Map of object IDs to their types for all changed objects             |
+| `bcs`            | `boolean` | Raw BCS-encoded transaction bytes                                    |
+
+`simulateTransaction` also supports:
+
+| Option           | Type      | Description                                            |
+| ---------------- | --------- | ------------------------------------------------------ |
+| `commandResults` | `boolean` | Return values and mutated references from each command |
 
 ### executeTransaction
 
@@ -257,6 +314,7 @@ const result = await client.core.simulateTransaction({
 	include: {
 		effects: true,
 		balanceChanges: true,
+		commandResults: true, // simulation-only option
 	},
 });
 
@@ -419,40 +477,6 @@ const { type } = await client.core.mvr.resolveType({
 });
 
 console.log(type); // "0x2::coin::Coin<0x2::sui::SUI>"
-```
-
-## Include Options
-
-Most methods accept an `include` parameter to control what data is returned:
-
-### Object Include Options
-
-```typescript
-{
-  content: boolean,             // BCS-encoded object content
-  previousTransaction: boolean, // Digest of creating transaction
-  json: boolean,                // JSON representation of Move struct content
-}
-```
-
-<Callout type="warn">
-	The `json` field returns the JSON representation of an object's Move struct content. **Warning:**
-	The exact shape and field names of this data may vary between different API implementations
-	(JSON-RPC vs gRPC or GraphQL). For consistent data across APIs, use the `content` field and parse
-	the BCS data directly.
-</Callout>
-
-### Transaction Include Options
-
-```typescript
-{
-  effects: boolean,        // Transaction effects (BCS-encoded)
-  events: boolean,         // Emitted events
-  transaction: boolean,    // Parsed transaction data (sender, gas, inputs, commands)
-  balanceChanges: boolean, // Balance changes
-  objectTypes: boolean,    // Map of object IDs to their types for changed objects
-  bcs: boolean,            // Raw BCS-encoded transaction bytes
-}
 ```
 
 ## Error Handling

--- a/packages/sui/src/client/types.ts
+++ b/packages/sui/src/client/types.ts
@@ -58,9 +58,32 @@ export namespace SuiClientTypes {
 	}
 
 	export interface ObjectInclude {
+		/**
+		 * Include the BCS-encoded Move struct content of the object.
+		 *
+		 * Returns the raw bytes of the object's Move struct fields — pass directly to
+		 * generated BCS types (e.g., `MyStruct.parse(object.content)`).
+		 */
 		content?: boolean;
+		/**
+		 * Include the digest of the transaction that last mutated this object.
+		 */
 		previousTransaction?: boolean;
+		/**
+		 * Include the full BCS-encoded object envelope. Rarely needed — most metadata
+		 * (owner, version, type) is already available as fields on the object response.
+		 *
+		 * Parse with `bcs.Object.parse(object.objectBcs)` from `@mysten/sui/bcs`.
+		 * Do not pass to a Move struct parser — use `content` for that instead.
+		 */
 		objectBcs?: boolean;
+		/**
+		 * Include the JSON representation of the object's Move struct content.
+		 *
+		 * **Warning:** The exact shape and field names of this data may vary between different
+		 * API implementations (JSON-RPC vs gRPC or GraphQL). For consistent data across APIs,
+		 * use the `content` field and parse the BCS data directly.
+		 */
 		json?: boolean;
 	}
 
@@ -133,8 +156,10 @@ export namespace SuiClientTypes {
 		digest: string;
 		owner: ObjectOwner;
 		type: string;
+		/** BCS-encoded Move struct content — pass to generated BCS type parsers. */
 		content: Include extends { content: true } ? Uint8Array<ArrayBuffer> : undefined;
 		previousTransaction: Include extends { previousTransaction: true } ? string | null : undefined;
+		/** Full BCS-encoded object envelope — parse with `bcs.Object` not a struct parser. */
 		objectBcs: Include extends { objectBcs: true } ? Uint8Array<ArrayBuffer> : undefined;
 		/**
 		 * The JSON representation of the object's Move struct content.
@@ -313,15 +338,22 @@ export namespace SuiClientTypes {
 		  };
 
 	export interface TransactionInclude {
+		/** Include balance changes caused by the transaction. */
 		balanceChanges?: boolean;
+		/** Include parsed transaction effects (gas used, changed objects, status, etc.). */
 		effects?: boolean;
+		/** Include events emitted by the transaction. */
 		events?: boolean;
+		/** Include a map of object IDs to their types for all changed objects. */
 		objectTypes?: boolean;
+		/** Include the parsed transaction data (sender, gas config, inputs, commands). */
 		transaction?: boolean;
+		/** Include the raw BCS-encoded transaction bytes. */
 		bcs?: boolean;
 	}
 
 	export interface SimulateTransactionInclude extends TransactionInclude {
+		/** Include return values and mutated references from each command (simulation only). */
 		commandResults?: boolean;
 	}
 


### PR DESCRIPTION
## Description

Clarifies the difference between `content` and `objectBcs` include options across the SDK types and documentation. This was prompted by a user who was incorrectly passing `objectBcs` to their Move struct parsers and getting inconsistent results.

Changes:
- Added JSDoc comments to `ObjectInclude`, `TransactionInclude`, and `SimulateTransactionInclude` fields in `types.ts`
- Added JSDoc to the `content` and `objectBcs` fields on the `Object` interface
- Updated Core API docs with full include options tables and a dedicated "content vs objectBcs" section with code examples
- Updated codegen docs to use Core API examples (replacing legacy gRPC-specific code) and warn against passing `objectBcs` to struct parsers
- Restructured BCS docs "Working with Objects" section to clearly explain both approaches

## Test plan

- Verified `pnpm turbo build --filter=@mysten/sui` passes
- Verified `tsc --noEmit` passes
- Verified `pnpm lint` passes (oxlint + prettier)
- Documentation-only changes to `.mdx` files; JSDoc-only changes to `types.ts` (no runtime behavior change)

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.