### PR TITLE
[Seal] Update default for verifyKeyServers to false

### DIFF
--- a/.changeset/shaky-aliens-kiss.md
+++ b/.changeset/shaky-aliens-kiss.md
@@ -1,0 +1,5 @@
+---
+'@mysten/seal': minor
+---
+
+[seal] Update default for verifyKeyServers to false

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -82,7 +82,7 @@ export class SealClient {
 			.map((server) => server.weight)
 			.reduce((sum, term) => sum + term, 0);
 
-		this.#verifyKeyServers = options.verifyKeyServers ?? true;
+		this.#verifyKeyServers = options.verifyKeyServers ?? false;
 		this.#timeout = options.timeout ?? 10_000;
 	}
 

--- a/packages/seal/src/types.ts
+++ b/packages/seal/src/types.ts
@@ -13,7 +13,11 @@ export type SealCompatibleClient = ClientWithExtensions<{
 export interface SealOptions<Name = 'seal'> {
 	/** Array of key server configs consisting of objectId, weight, optional API key name and API key */
 	serverConfigs: KeyServerConfig[];
-	/** Whether to verify the key servers' authenticity. */
+	/**
+	 * Whether to verify the key servers' authenticity.
+	 * Note: /service verification is skipped for committee key servers (serverType === 'Committee')
+	 * since their requests go through an aggregator.
+	 */
 	verifyKeyServers?: boolean;
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;
@@ -36,7 +40,11 @@ export interface SealClientOptions {
 	suiClient: SealCompatibleClient;
 	/** Array of key server configs consisting of objectId, weight, optional API key name and API key */
 	serverConfigs: KeyServerConfig[];
-	/** Whether to verify the key servers' authenticity. */
+	/**
+	 * Whether to verify the key servers' authenticity.
+	 * Note: /service verification is skipped for committee key servers (serverType === 'Committee')
+	 * since their requests go through an aggregator.
+	 */
 	verifyKeyServers?: boolean;
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;


### PR DESCRIPTION
## Description

`verifyKeyServers = true` fetches a proof of possession from the key server to confirm that the onchain registered url is indeed associated with the key server. This is needed when key servers are dynamically chosen by users.

However in most applications of Seal, the key servers are fixed and chosen by the app developer. Therefore this PR changes the default value of `verifyKeyServers` to `false`.

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
