### PR TITLE
Add USDSUI pools to DeepBook mainnet constants

### DIFF
--- a/.changeset/chilly-pumas-teach.md
+++ b/.changeset/chilly-pumas-teach.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Add USDSUI pools

--- a/packages/deepbook-v3/src/utils/constants.ts
+++ b/packages/deepbook-v3/src/utils/constants.ts
@@ -353,6 +353,16 @@ export const mainnetPools: PoolMap = {
 		baseCoin: 'SUI',
 		quoteCoin: 'SUIUSDE',
 	},
+	SUI_USDSUI: {
+		address: '0x826eeacb2799726334aa580396338891205a41cf9344655e526aae6ddd5dc03f',
+		baseCoin: 'SUI',
+		quoteCoin: 'USDSUI',
+	},
+	USDSUI_USDC: {
+		address: '0xa374264d43e6baa5aa8b35ff18ff24fdba7443b4bcb884cb4c2f568d32cdac36',
+		baseCoin: 'USDSUI',
+		quoteCoin: 'USDC',
+	},
 };
 
 export const testnetMarginPools = {


### PR DESCRIPTION
## Summary
- Add SUI/USDSUI pool
- Add USDSUI/USDC pool

## Test plan
- [x] USDSUI coin already exists in mainnet constants
- [x] Verify pool addresses on-chain

### AI Assistance Notice
- [x] This PR was primarily written by AI