### PR TITLE
Fix auto-reconnect after explicit wallet disconnect

### DIFF
--- a/.changeset/fix-autoconnect-disconnect.md
+++ b/.changeset/fix-autoconnect-disconnect.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit-core': patch
+---
+
+Clear persisted wallet session on explicit disconnect to prevent auto-reconnect after page refresh. Wallet removal (HMR, React strict mode) is unaffected.

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/actions/disconnect-wallet.ts
@@ -7,10 +7,14 @@ import type { DAppKitStores } from '../store.js';
 import { task } from 'nanostores';
 import { getWalletFeature } from '@wallet-standard/ui';
 import { WalletNotConnectedError } from '../../utils/errors.js';
+import type { StateStorage } from '../../utils/storage.js';
 
 export type DisconnectWalletArgs = Parameters<StandardDisconnectMethod>;
 
-export function disconnectWalletCreator({ $baseConnection, $connection }: DAppKitStores) {
+export function disconnectWalletCreator(
+	{ $baseConnection, $connection }: DAppKitStores,
+	{ storage, storageKey }: { storage: StateStorage; storageKey: string },
+) {
 	/**
 	 * Disconnects the current wallet from the application and prompts the current wallet
 	 * to deauthorize accounts from the current domain depending on the wallet's implemetation
@@ -33,6 +37,7 @@ export function disconnectWalletCreator({ $baseConnection, $connection }: DAppKi
 			} catch (error) {
 				console.warn('Failed to disconnect the current wallet from the application.', error);
 			} finally {
+				storage.removeItem(storageKey);
 				$baseConnection.set({
 					status: 'disconnected',
 					currentAccount: null,

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/index.ts
@@ -106,7 +106,7 @@ export function createDAppKit<
 		signAndExecuteTransaction: signAndExecuteTransactionCreator(stores),
 		signPersonalMessage: signPersonalMessageCreator(stores),
 		connectWallet: connectWalletCreator(stores, networks),
-		disconnectWallet: disconnectWalletCreator(stores),
+		disconnectWallet: disconnectWalletCreator(stores, { storage, storageKey }),
 		switchAccount: switchAccountCreator(stores),
 		switchNetwork: switchNetworkCreator(stores),
 		stores: {

--- a/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/sync-state-to-storage.ts
+++ b/packages/dapp-kit-next/packages/dapp-kit-core/src/core/initializers/sync-state-to-storage.ts
@@ -29,13 +29,13 @@ export function syncStateToStorage({
 					getSavedAccountStorageKey(connection.account, connection.supportedIntents),
 				);
 			}
-			// Storage is intentionally NOT cleared on disconnect. When a wallet
-			// unregisters and re-registers (HMR, React strict mode, effect re-runs),
-			// the autoconnect initializer uses the persisted session to seamlessly
-			// reconnect once the wallet reappears. Clearing storage here would
-			// permanently lose the session. Stale entries are harmless — autoconnect
-			// ignores them when the wallet is not found, and connecting to a new
-			// wallet overwrites the entry.
+			// Storage is cleared by the disconnectWallet action on explicit user
+			// disconnect so autoconnect won't reconnect after a page refresh.
+			// Wallet *removal* (HMR, React strict mode, effect re-runs) does NOT
+			// clear storage — those cases are handled by the $baseConnection /
+			// $connection computed split: $baseConnection stays 'connected' while
+			// the wallet is temporarily unregistered, and $connection recomputes
+			// to 'connected' once the wallet re-appears.
 		});
 	});
 }


### PR DESCRIPTION
## Description

When a user explicitly disconnects their wallet and refreshes the page, dapp-kit-next would auto-reconnect because the persisted wallet session in storage was never cleared on disconnect.

This was intentional to handle HMR/React strict mode (where wallets briefly unregister and re-register), but those cases are already handled by the `$baseConnection`/`$connection` computed split — `$baseConnection` stays `'connected'` when a wallet merely unregisters, and `$connection` recomputes to `'connected'` when it re-appears.

**Changes:**
- `disconnectWallet` action now clears persisted storage (`storage.removeItem(storageKey)`) on explicit disconnect
- Updated comment in `sync-state-to-storage.ts` to reflect the new behavior

## Test plan

- Verified build passes for `@mysten/dapp-kit-core` and `@mysten/dapp-kit-react`
- Verified lint/prettier passes on changed files
- Tested HMR re-registration in the Enoki demo (wallet unregisters/re-registers without disruption)

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.