### PR TITLE
feat(sui): add kind constraint to UnresolvedObject

### DIFF
--- a/.changeset/add-kind-constraint-to-unresolved-object.md
+++ b/.changeset/add-kind-constraint-to-unresolved-object.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add optional `kind` field to `UnresolvedObject` for validating object kind during transaction resolution

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -290,9 +290,10 @@ async function resolveObjectReferences(
 			continue;
 		}
 
-		let updated: CallArg | undefined;
 		const id = normalizeSuiAddress(input.UnresolvedObject.objectId);
 		const object = objectsById.get(id);
+
+		let updated: CallArg;
 
 		if (input.UnresolvedObject.initialSharedVersion ?? object?.initialSharedVersion) {
 			updated = Inputs.SharedObjectRef({
@@ -309,15 +310,22 @@ async function resolveObjectReferences(
 					version: input.UnresolvedObject.version ?? object?.version!,
 				}!,
 			);
-		}
-
-		transactionData.inputs[transactionData.inputs.indexOf(input)] =
-			updated ??
-			Inputs.ObjectRef({
+		} else {
+			updated = Inputs.ObjectRef({
 				objectId: id,
 				digest: input.UnresolvedObject.digest ?? object?.digest!,
 				version: input.UnresolvedObject.version ?? object?.version!,
 			});
+		}
+
+		const kind = input.UnresolvedObject.kind;
+		if (kind && kind !== updated.Object!.$kind) {
+			throw new Error(
+				`Object ${id} was expected to be ${kind} but was resolved as ${updated.Object!.$kind}`,
+			);
+		}
+
+		transactionData.inputs[transactionData.inputs.indexOf(input)] = updated;
 	}
 }
 

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -60,9 +60,15 @@ function callArgToGrpcInput(arg: CallArg): Input {
 			}
 			throw new Error(`Unknown Object kind: ${JSON.stringify(arg.Object)}`);
 
-		case 'UnresolvedObject':
+		case 'UnresolvedObject': {
 			const unresolved = arg.UnresolvedObject;
+			const kindToInputKind: Record<string, Input_InputKind> = {
+				ImmOrOwnedObject: Input_InputKind.IMMUTABLE_OR_OWNED,
+				SharedObject: Input_InputKind.SHARED,
+				Receiving: Input_InputKind.RECEIVING,
+			};
 			return {
+				kind: unresolved.kind ? kindToInputKind[unresolved.kind] : undefined,
 				objectId: unresolved.objectId,
 				version: unresolved.version
 					? BigInt(unresolved.version)
@@ -72,6 +78,7 @@ function callArgToGrpcInput(arg: CallArg): Input {
 				digest: unresolved.digest ?? undefined,
 				mutable: unresolved.mutable ?? undefined,
 			};
+		}
 
 		case 'UnresolvedPure':
 			throw new Error('UnresolvedPure arguments must be resolved before converting to gRPC format');

--- a/packages/sui/src/transactions/TransactionData.ts
+++ b/packages/sui/src/transactions/TransactionData.ts
@@ -541,6 +541,15 @@ export class TransactionDataBuilder implements TransactionData {
 						);
 					}
 
+					if (
+						input.UnresolvedObject.kind &&
+						resolvedInput.Object.$kind !== input.UnresolvedObject.kind
+					) {
+						throw new Error(
+							`Object ${input.UnresolvedObject.objectId} was expected to be ${input.UnresolvedObject.kind} but was resolved as ${resolvedInput.Object.$kind}`,
+						);
+					}
+
 					this.inputs[i] = resolvedInput;
 					break;
 			}

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -15,6 +15,7 @@ import {
 	number,
 	object,
 	optional,
+	picklist,
 	pipe,
 	record,
 	string,
@@ -320,6 +321,7 @@ const CallArgSchema = safeEnum({
 		digest: optional(nullable(string())),
 		initialSharedVersion: optional(nullable(JsonU64)),
 		mutable: optional(nullable(boolean())),
+		kind: optional(nullable(picklist(['ImmOrOwnedObject', 'SharedObject', 'Receiving']))),
 	}),
 	FundsWithdrawal: FundsWithdrawalArgSchema,
 });

--- a/packages/sui/test/e2e/clients/core/expected-owner.test.ts
+++ b/packages/sui/test/e2e/clients/core/expected-owner.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, describe, expect } from 'vitest';
+import { setup, TestToolbox, createTestWithAllClients } from '../../utils/setup.js';
+import { Transaction } from '../../../../src/transactions/index.js';
+import { SUI_TYPE_ARG } from '../../../../src/utils/index.js';
+import type { TransactionPlugin } from '../../../../src/transactions/resolve.js';
+
+/**
+ * Creates a transaction plugin that sets kind on a specific input index.
+ */
+function setExpectedKindPlugin(
+	inputIndex: number,
+	kind: 'ImmOrOwnedObject' | 'SharedObject' | 'Receiving',
+): TransactionPlugin {
+	return async (transactionData, _options, next) => {
+		const input = transactionData.inputs[inputIndex];
+		if (input?.UnresolvedObject) {
+			input.UnresolvedObject.kind = kind;
+		}
+		await next();
+	};
+}
+
+describe('Core API - Expected Kind Validation', () => {
+	let toolbox: TestToolbox;
+	let testAddress: string;
+
+	const testWithAllClients = createTestWithAllClients(() => toolbox);
+
+	beforeAll(async () => {
+		toolbox = await setup();
+		testAddress = toolbox.address();
+	});
+
+	describe('correct kind passes validation', () => {
+		testWithAllClients(
+			'owned object with kind=ImmOrOwnedObject resolves successfully',
+			async (client) => {
+				const coins = await client.core.listCoins({
+					owner: testAddress,
+					coinType: SUI_TYPE_ARG,
+				});
+				expect(coins.objects.length).toBeGreaterThan(0);
+
+				const tx = new Transaction();
+				tx.transferObjects([tx.object(coins.objects[0].objectId)], testAddress);
+				tx.setSender(testAddress);
+				tx.addBuildPlugin(setExpectedKindPlugin(0, 'ImmOrOwnedObject'));
+
+				// Should not throw
+				const bytes = await tx.build({ client });
+				expect(bytes).toBeDefined();
+			},
+		);
+
+		testWithAllClients(
+			'shared object with kind=SharedObject resolves successfully',
+			async (client) => {
+				const packageId = toolbox.getPackage('test_data');
+
+				// Create a shared object
+				const setupTx = new Transaction();
+				setupTx.moveCall({
+					target: `${packageId}::test_objects::create_shared_object`,
+					arguments: [],
+				});
+				const setupResult = await toolbox.jsonRpcClient.signAndExecuteTransaction({
+					transaction: setupTx,
+					signer: toolbox.keypair,
+					options: { showEffects: true },
+				});
+				expect(setupResult.effects?.status.status).toBe('success');
+				await toolbox.jsonRpcClient.waitForTransaction({ digest: setupResult.digest });
+
+				const created = setupResult.effects?.created || [];
+				const sharedObject = created.find((obj) => {
+					const owner = obj.owner;
+					return typeof owner === 'object' && 'Shared' in owner;
+				});
+				expect(sharedObject).toBeDefined();
+
+				const tx = new Transaction();
+				tx.moveCall({
+					target: `${packageId}::test_objects::increment_shared`,
+					arguments: [tx.object(sharedObject!.reference.objectId)],
+				});
+				tx.setSender(testAddress);
+				tx.addBuildPlugin(setExpectedKindPlugin(0, 'SharedObject'));
+
+				// Should not throw
+				const bytes = await tx.build({ client });
+				expect(bytes).toBeDefined();
+			},
+		);
+	});
+
+	describe('incorrect kind throws error', () => {
+		testWithAllClients('owned object with kind=SharedObject throws', async (client) => {
+			const coins = await client.core.listCoins({
+				owner: testAddress,
+				coinType: SUI_TYPE_ARG,
+			});
+			expect(coins.objects.length).toBeGreaterThan(0);
+
+			const tx = new Transaction();
+			tx.transferObjects([tx.object(coins.objects[0].objectId)], testAddress);
+			tx.setSender(testAddress);
+			tx.addBuildPlugin(setExpectedKindPlugin(0, 'SharedObject'));
+
+			// JSON-RPC: client-side validation catches the mismatch
+			// gRPC/GraphQL: server rejects the incorrect kind hint during simulation
+			await expect(tx.build({ client })).rejects.toThrow();
+		});
+
+		testWithAllClients('shared object with kind=ImmOrOwnedObject throws', async (client) => {
+			const packageId = toolbox.getPackage('test_data');
+
+			// Create a shared object
+			const setupTx = new Transaction();
+			setupTx.moveCall({
+				target: `${packageId}::test_objects::create_shared_object`,
+				arguments: [],
+			});
+			const setupResult = await toolbox.jsonRpcClient.signAndExecuteTransaction({
+				transaction: setupTx,
+				signer: toolbox.keypair,
+				options: { showEffects: true },
+			});
+			expect(setupResult.effects?.status.status).toBe('success');
+			await toolbox.jsonRpcClient.waitForTransaction({ digest: setupResult.digest });
+
+			const created = setupResult.effects?.created || [];
+			const sharedObject = created.find((obj) => {
+				const owner = obj.owner;
+				return typeof owner === 'object' && 'Shared' in owner;
+			});
+			expect(sharedObject).toBeDefined();
+
+			const tx = new Transaction();
+			tx.moveCall({
+				target: `${packageId}::test_objects::increment_shared`,
+				arguments: [tx.object(sharedObject!.reference.objectId)],
+			});
+			tx.setSender(testAddress);
+			tx.addBuildPlugin(setExpectedKindPlugin(0, 'ImmOrOwnedObject'));
+
+			// JSON-RPC: client-side validation catches the mismatch
+			// gRPC/GraphQL: server rejects "object ... is not Immutable or AddressOwned"
+			await expect(tx.build({ client })).rejects.toThrow();
+		});
+
+		testWithAllClients(
+			'owned object with kind=Receiving throws when not used as receiving',
+			async (client) => {
+				const coins = await client.core.listCoins({
+					owner: testAddress,
+					coinType: SUI_TYPE_ARG,
+				});
+				expect(coins.objects.length).toBeGreaterThan(0);
+
+				const tx = new Transaction();
+				tx.transferObjects([tx.object(coins.objects[0].objectId)], testAddress);
+				tx.setSender(testAddress);
+				tx.addBuildPlugin(setExpectedKindPlugin(0, 'Receiving'));
+
+				// JSON-RPC: client-side validation catches the mismatch
+				// gRPC/GraphQL: server rejects the incorrect kind during simulation
+				await expect(tx.build({ client })).rejects.toThrow();
+			},
+		);
+	});
+});

--- a/packages/sui/test/unit/client/transaction-resolver.test.ts
+++ b/packages/sui/test/unit/client/transaction-resolver.test.ts
@@ -177,6 +177,38 @@ describe('Transaction Resolver - TypeScript to gRPC Conversion', () => {
 			// Version should be set even if it's 0 (will be resolved by server)
 			expect(input?.version).toBe(BigInt(0));
 		});
+
+		it('should pass kind as kind hint for UnresolvedObject', () => {
+			const tx = new Transaction();
+			tx.moveCall({
+				target: '0x2::foo::bar',
+				arguments: [tx.object('0x123')],
+			});
+
+			// Set kind on the unresolved input
+			const data = tx.getData();
+			data.inputs[0].UnresolvedObject!.kind = 'SharedObject';
+
+			const grpcTx = transactionDataToGrpcTransaction(data);
+			const ptx = getProgrammableTx(grpcTx);
+			const input = ptx.inputs?.[0];
+
+			expect(input?.kind).toBe(Input_InputKind.SHARED);
+		});
+
+		it('should not set kind when kind is not set', () => {
+			const tx = new Transaction();
+			tx.moveCall({
+				target: '0x2::foo::bar',
+				arguments: [tx.object('0x123')],
+			});
+
+			const grpcTx = transactionDataToGrpcTransaction(tx.getData());
+			const ptx = getProgrammableTx(grpcTx);
+			const input = ptx.inputs?.[0];
+
+			expect(input?.kind).toBeUndefined();
+		});
 	});
 
 	describe('Argument Conversion', () => {


### PR DESCRIPTION
## Description

Adds a `kind` field to `UnresolvedObject` so that when resolving objects during transaction building, it throws if the object resolves to an unexpected kind (e.g., expecting `SharedObject` but getting `ImmOrOwnedObject`).

Changes:
- Added optional `kind` field (`'ImmOrOwnedObject' | 'SharedObject' | 'Receiving'`) to `UnresolvedObject` schema in `internal.ts`
- Added kind validation in `applyResolvedData` on `TransactionDataBuilder` — after resolution, if `kind` is set and the resolved kind doesn't match, it throws
- Added kind validation in the JSON-RPC core resolver (`core-resolver.ts`) for the non-simulation path
- When `kind` is set on `UnresolvedObject`, it's passed as a kind hint to the gRPC/GraphQL server during simulation via `callArgToGrpcInput`
- Added e2e tests using a build plugin (`setExpectedKindPlugin`) that validates correct kind passes and incorrect kind throws, across all three transports

## Test plan

- Unit tests: `pnpm --filter @mysten/sui vitest run test/unit/client/transaction-resolver.test.ts` — 28 tests pass
- E2e tests: `pnpm --filter @mysten/sui vitest run --config test/e2e/vitest.config.mts test/e2e/clients/core/expected-owner.test.ts` — 15 tests pass (5 per transport × 3 transports)

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.