### PR TITLE
Add changesets for embedded LLM docs

### DIFF
--- a/.changeset/embed-llm-docs.md
+++ b/.changeset/embed-llm-docs.md
@@ -1,0 +1,17 @@
+---
+'@mysten/bcs': patch
+'@mysten/codegen': patch
+'@mysten/dapp-kit': patch
+'@mysten/dapp-kit-core': patch
+'@mysten/dapp-kit-react': patch
+'@mysten/docs': patch
+'@mysten/kiosk': patch
+'@mysten/payment-kit': patch
+'@mysten/seal': patch
+'@mysten/slush-wallet': patch
+'@mysten/sui': patch
+'@mysten/walrus': patch
+'@mysten/zksend': patch
+---
+
+Add embedded LLM-friendly docs to published packages


### PR DESCRIPTION
## Description

Add patch changesets for all 13 packages that received embedded LLM-friendly docs in #929. This triggers a version bump so the new `docs/` directory is included in the next npm publish.

Packages: `@mysten/bcs`, `@mysten/codegen`, `@mysten/dapp-kit`, `@mysten/dapp-kit-core`, `@mysten/dapp-kit-react`, `@mysten/docs`, `@mysten/kiosk`, `@mysten/payment-kit`, `@mysten/seal`, `@mysten/slush-wallet`, `@mysten/sui`, `@mysten/walrus`, `@mysten/zksend`

## Test plan

- No code changes, only a changeset file added

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.