### PR TITLE
fix: remove @mysten/docs from changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
 	"baseBranch": "main",
 	"updateInternalDependencies": "minor",
 	"privatePackages": false,
-	"ignore": ["@mysten/docs"],
+	"ignore": [],
 	"___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
 		"onlyUpdatePeerDependentsWhenOutOfRange": true
 	}


### PR DESCRIPTION
## Description

Remove `@mysten/docs` from the changeset `ignore` list in `.changeset/config.json` so it gets published alongside other packages. This fixes the CI error where the `embed-llm-docs` changeset was rejected for mixing ignored and non-ignored packages.

## Test plan

- CI should no longer fail with "Mixed changesets that contain both ignored and not ignored packages are not allowed"

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.