### PR TITLE
Fix MVR type resolution to handle vector and primitive type parameters

### DIFF
--- a/.changeset/fix-mvr-vector-type-params.md
+++ b/.changeset/fix-mvr-vector-type-params.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Fix `extractMvrTypes` and `replaceMvrNames` to handle vector and primitive type parameters. Previously, these functions passed all string type parameters directly to `parseStructTag`, which produced corrupted results for vector types (e.g., `vector<@mvr/demo::baz::Qux>`) and threw on primitives (e.g., `u8`). Vector types are now unwrapped and recursed into, and primitive types are passed through unchanged.

--- a/packages/sui/src/client/mvr.ts
+++ b/packages/sui/src/client/mvr.ts
@@ -332,6 +332,10 @@ function validateOverrides(overrides?: {
 export function extractMvrTypes(type: string | StructTag, types = new Set<string>()) {
 	if (typeof type === 'string' && !hasMvrName(type)) return types;
 
+	if (typeof type === 'string' && type.startsWith('vector<') && type.endsWith('>')) {
+		return extractMvrTypes(type.slice(7, -1), types);
+	}
+
 	const tag = isStructTag(type) ? type : parseStructTag(type);
 
 	if (hasMvrName(tag.address)) types.add(`${tag.address}::${tag.module}::${tag.name}`);
@@ -348,6 +352,14 @@ export function extractMvrTypes(type: string | StructTag, types = new Set<string
  * based on the supplied type cache.
  */
 function replaceMvrNames(tag: string | StructTag, typeCache: Record<string, string>): string {
+	if (typeof tag === 'string' && !tag.includes('::')) {
+		return tag;
+	}
+
+	if (typeof tag === 'string' && tag.startsWith('vector<') && tag.endsWith('>')) {
+		return `vector<${replaceMvrNames(tag.slice(7, -1), typeCache)}>`;
+	}
+
 	const type = isStructTag(tag) ? tag : parseStructTag(tag);
 
 	const typeTag = `${type.address}::${type.module}::${type.name}`;

--- a/packages/sui/test/unit/client/mvr.test.ts
+++ b/packages/sui/test/unit/client/mvr.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { extractMvrTypes } from '../../../src/client/mvr.js';
+
+describe('extractMvrTypes', () => {
+	it('extracts MVR types from struct tags', () => {
+		expect([...extractMvrTypes('@mvr/demo::foo::Bar')]).toEqual(['@mvr/demo::foo::Bar']);
+	});
+
+	it('extracts MVR types from struct tag type parameters', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<@mvr/demo::baz::Qux>')]).toEqual([
+			'@mvr/demo::baz::Qux',
+		]);
+	});
+
+	it('extracts MVR types from vector type parameters', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<vector<@mvr/demo::baz::Qux>>')]).toEqual([
+			'@mvr/demo::baz::Qux',
+		]);
+	});
+
+	it('extracts MVR types from nested vector type parameters', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<vector<vector<@mvr/demo::baz::Qux>>>')]).toEqual([
+			'@mvr/demo::baz::Qux',
+		]);
+	});
+
+	it('extracts MVR types from vectors with parameterized inner types', () => {
+		expect([
+			...extractMvrTypes('0x2::foo::Bar<vector<@mvr/demo::coin::Token<0x2::sui::SUI>>>'),
+		]).toEqual(['@mvr/demo::coin::Token']);
+	});
+
+	it('extracts MVR types from top-level vector', () => {
+		expect([...extractMvrTypes('vector<@mvr/demo::baz::Qux>')]).toEqual([
+			'@mvr/demo::baz::Qux',
+		]);
+	});
+
+	it('extracts MVR types from types with mixed MVR and primitive params', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<@mvr/demo::baz::Qux,u8>')]).toEqual([
+			'@mvr/demo::baz::Qux',
+		]);
+	});
+
+	it('returns empty set for types without MVR names', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<vector<0x2::sui::SUI>>')]).toEqual([]);
+	});
+
+	it('returns empty set for primitive type parameters', () => {
+		expect([...extractMvrTypes('0x2::foo::Bar<u8>')]).toEqual([]);
+	});
+});

--- a/packages/sui/test/unit/client/mvr.test.ts
+++ b/packages/sui/test/unit/client/mvr.test.ts
@@ -35,9 +35,7 @@ describe('extractMvrTypes', () => {
 	});
 
 	it('extracts MVR types from top-level vector', () => {
-		expect([...extractMvrTypes('vector<@mvr/demo::baz::Qux>')]).toEqual([
-			'@mvr/demo::baz::Qux',
-		]);
+		expect([...extractMvrTypes('vector<@mvr/demo::baz::Qux>')]).toEqual(['@mvr/demo::baz::Qux']);
 	});
 
 	it('extracts MVR types from types with mixed MVR and primitive params', () => {


### PR DESCRIPTION
## Description

`extractMvrTypes` and `replaceMvrNames` call `parseStructTag` on all string type parameters, but type parameters from `parseTypeTag` can be vectors (e.g., `"vector<@mvr/demo::baz::Qux>"`) or primitives (e.g., `"u8"`), neither of which are valid struct tags.

This is the same root cause as #983 — functions calling `parseStructTag` on strings that aren't struct tags.

**Bug 1 — vectors produce corrupted MVR type names:**
```ts
extractMvrTypes('0x2::foo::Bar<vector<@mvr/demo::baz::Qux>>')
// Expected: Set(['@mvr/demo::baz::Qux'])
// Actual:   Set(['0x00000000000000000000000000000000000000000000000vector<@mvr/demo::baz::Qux>'])
```

**Bug 2 — primitives crash `replaceMvrNames`:**
When a struct tag has a primitive type parameter (e.g., `u8`), the recursive call `replaceMvrNames("u8", cache)` calls `parseStructTag("u8")` which throws `"Invalid struct tag: u8"`.

**Fix:** Vector types are now unwrapped and recursed into. Primitives are passed through unchanged in `replaceMvrNames`. Both guards use the same pattern: check before calling `parseStructTag`.

## Test plan

- Created new test file `test/unit/client/mvr.test.ts` with 9 test cases for `extractMvrTypes`:
  - MVR type in struct tag (baseline)
  - MVR type in struct tag type parameter
  - MVR type inside vector type parameter (Bug 1 fix)
  - MVR type inside nested vectors
  - MVR type inside vector with parameterized inner type
  - MVR type in top-level vector
  - Mixed MVR + primitive type parameters
  - Non-MVR vector types (no false positives)
  - Primitive type parameters (no false positives)
- All 9 tests pass
- `pnpm turbo build --filter=@mysten/sui` clean
- `pnpm lint` clean

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

Written with [Claude Code](https://claude.ai/code) (claude-opus-4-6). Bug originally identified during PR #827 validation work; fix implementation and tests were AI-assisted with human review and validation.