### PR TITLE
Add parseToUnits / parseToMist balance parsers

### DIFF
--- a/.changeset/add-balance-parsers.md
+++ b/.changeset/add-balance-parsers.md
@@ -2,4 +2,4 @@
 '@mysten/sui': minor
 ---
 
-Add `parseToUnits` and `parseToMist` utilities for converting human-readable decimal strings into smallest-unit bigints. `parseToUnits(amount, decimals)` works for any coin; `parseToMist(amount)` is a SUI-specific convenience wrapper using 9 decimals. Uses pure bigint arithmetic — no floating point — so it preserves precision for values above `Number.MAX_SAFE_INTEGER`, where the common `BigInt(Math.round(parseFloat(s) * 1e9))` workaround silently corrupts amounts above ~9M SUI.
+Add `parseToUnits` and `parseToMist` balance parsing utilities using pure bigint arithmetic.

--- a/.changeset/add-balance-parsers.md
+++ b/.changeset/add-balance-parsers.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add `parseToUnits` and `parseToMist` utilities for converting human-readable decimal strings into smallest-unit bigints. `parseToUnits(amount, decimals)` works for any coin; `parseToMist(amount)` is a SUI-specific convenience wrapper using 9 decimals. Uses pure bigint arithmetic — no floating point — so it preserves precision for values above `Number.MAX_SAFE_INTEGER`, where the common `BigInt(Math.round(parseFloat(s) * 1e9))` workaround silently corrupts amounts above ~9M SUI.

--- a/.changeset/add-format-balance-utils.md
+++ b/.changeset/add-format-balance-utils.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add `formatAmount`, `parseAmount`, `formatSui`, and `parseSui` utility functions for converting between human-readable decimal strings and smallest-unit bigint representations. `formatAmount`/`parseAmount` accept a `decimals` parameter for any coin type, while `formatSui`/`parseSui` are convenience wrappers using SUI's 9 decimal places. Uses pure bigint arithmetic — no floating point.

--- a/.changeset/add-format-balance-utils.md
+++ b/.changeset/add-format-balance-utils.md
@@ -1,5 +1,0 @@
----
-'@mysten/sui': minor
----
-
-Add `formatAmount`, `parseAmount`, `formatSui`, and `parseSui` utility functions for converting between human-readable decimal strings and smallest-unit bigint representations. `formatAmount`/`parseAmount` accept a `decimals` parameter for any coin type, while `formatSui`/`parseSui` are convenience wrappers using SUI's 9 decimal places. Uses pure bigint arithmetic — no floating point.

--- a/packages/docs/content/sui/utils/index.mdx
+++ b/packages/docs/content/sui/utils/index.mdx
@@ -34,13 +34,10 @@ You can use the following helpers to format various values:
 
 ## Parsers
 
-You can use the following helpers to parse human-readable decimal strings into their on-chain
-smallest-unit representation. These use pure bigint arithmetic — no floating point — so precision is
-preserved for values well above `Number.MAX_SAFE_INTEGER`, where the common
-`BigInt(Math.round(parseFloat(s) * 1e9))` workaround silently corrupts amounts above ~9M SUI.
+You can use the following helpers to parse decimal strings into on-chain smallest-unit bigints:
 
 - `parseToUnits`: Parse a decimal string into a `bigint`, given a coin's `decimals`
-- `parseToMist`: Parse a SUI decimal string into MIST (SUI's smallest unit, 9 decimals)
+- `parseToMist`: Parse a SUI decimal string into MIST (9 decimals)
 
 ## Validators
 

--- a/packages/docs/content/sui/utils/index.mdx
+++ b/packages/docs/content/sui/utils/index.mdx
@@ -34,7 +34,7 @@ You can use the following helpers to format various values:
 
 ## Parsers
 
-You can use the following helpers to parse decimal strings into on-chain smallest-unit bigints:
+You can use the following helpers to parse decimal strings into smallest-unit bigints:
 
 - `parseToUnits`: Parse a decimal string into a `bigint`, given a coin's `decimals`
 - `parseToMist`: Parse a SUI decimal string into MIST (9 decimals)

--- a/packages/docs/content/sui/utils/index.mdx
+++ b/packages/docs/content/sui/utils/index.mdx
@@ -32,6 +32,16 @@ You can use the following helpers to format various values:
 - `normalizeSuiNSName`
 - `normalizeSuiNSName`
 
+## Parsers
+
+You can use the following helpers to parse human-readable decimal strings into their on-chain
+smallest-unit representation. These use pure bigint arithmetic — no floating point — so precision is
+preserved for values well above `Number.MAX_SAFE_INTEGER`, where the common
+`BigInt(Math.round(parseFloat(s) * 1e9))` workaround silently corrupts amounts above ~9M SUI.
+
+- `parseToUnits`: Parse a decimal string into a `bigint`, given a coin's `decimals`
+- `parseToMist`: Parse a SUI decimal string into MIST (SUI's smallest unit, 9 decimals)
+
 ## Validators
 
 You can use the following helpers to validate the format of various values (this only validates that

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -20,7 +20,7 @@ export function formatDigest(digest: string) {
 	return `${digest.slice(0, 10)}${ELLIPSIS}`;
 }
 
-const AMOUNT_REGEX = /^-?[0-9]*\.?[0-9]+$/;
+const AMOUNT_REGEX = /^-?(?:[0-9]+(?:\.[0-9]+)?|\.[0-9]+)$/;
 
 /** Parse a decimal string into its smallest-unit bigint representation. No floating point. */
 export function parseToUnits(amount: string, decimals: number): bigint {
@@ -49,7 +49,7 @@ export function parseToUnits(amount: string, decimals: number): bigint {
 	return negative ? -result : result;
 }
 
-/** Parse a SUI decimal string into MIST (10^-9 SUI). */
+/** Parse a SUI decimal string into MIST. */
 export function parseToMist(amount: string): bigint {
 	return parseToUnits(amount, SUI_DECIMALS);
 }

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -90,6 +90,7 @@ export function parseAmount(value: string, decimals: number): bigint {
 		);
 	}
 
+	// When decimals=0, padEnd produces '' which BigInt() can't parse
 	const paddedFraction = fraction.padEnd(decimals, '0') || '0';
 	const result = BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFraction);
 

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -34,6 +34,10 @@ const AMOUNT_REGEX = /^-?[0-9]+(\.[0-9]+)?$/;
  * Throws on excess decimal places rather than rounding: callers must handle precision
  * explicitly.
  *
+ * @throws error if `decimals` is negative, non-integer, or greater than 77.
+ * @throws error if `amount` is not a valid decimal string (rejects whitespace, scientific notation, bare dots).
+ * @throws error if `amount` has more fractional digits than `decimals` allows.
+ *
  * @example
  * ```ts
  * parseToUnits('1', 9)      // => 1000000000n

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { SUI_DECIMALS } from './constants.js';
+
 const ELLIPSIS = '\u{2026}';
 
 export function formatAddress(address: string) {
@@ -16,4 +18,106 @@ export function formatAddress(address: string) {
 export function formatDigest(digest: string) {
 	// Use 10 first characters
 	return `${digest.slice(0, 10)}${ELLIPSIS}`;
+}
+
+/**
+ * Convert an amount from its smallest unit representation to a human-readable decimal string.
+ * Handles negative values correctly. Uses bigint arithmetic exclusively — no floating point.
+ *
+ * @example
+ * ```ts
+ * formatAmount(1000000000n, 9) // => '1'
+ * formatAmount(1500000000n, 9) // => '1.5'
+ * formatAmount(100n, 6)        // => '0.0001'
+ * formatAmount(-1500000000n, 9) // => '-1.5'
+ * ```
+ */
+export function formatAmount(amount: bigint, decimals: number): string {
+	if (decimals < 0 || !Number.isInteger(decimals) || decimals > 77) {
+		throw new Error(`Invalid decimals: ${decimals}`);
+	}
+
+	const negative = amount < 0n;
+	const absolute = negative ? -amount : amount;
+
+	const divisor = 10n ** BigInt(decimals);
+	const whole = absolute / divisor;
+	const remainder = absolute % divisor;
+
+	let result: string;
+	if (remainder === 0n) {
+		result = whole.toString();
+	} else {
+		const fractional = remainder.toString().padStart(decimals, '0').replace(/0+$/, '');
+		result = `${whole}.${fractional}`;
+	}
+
+	return negative ? `-${result}` : result;
+}
+
+const AMOUNT_REGEX = /^-?[0-9]+\.?[0-9]*$/;
+
+/**
+ * Convert a human-readable decimal string to the smallest unit representation.
+ * Throws on excess decimal places rather than rounding — callers must handle precision explicitly.
+ * Uses bigint arithmetic exclusively — no floating point.
+ *
+ * @example
+ * ```ts
+ * parseAmount('1', 9)      // => 1000000000n
+ * parseAmount('1.5', 9)    // => 1500000000n
+ * parseAmount('0.0001', 6) // => 100n
+ * parseAmount('-1.5', 9)   // => -1500000000n
+ * ```
+ */
+export function parseAmount(value: string, decimals: number): bigint {
+	if (decimals < 0 || !Number.isInteger(decimals) || decimals > 77) {
+		throw new Error(`Invalid decimals: ${decimals}`);
+	}
+
+	if (!AMOUNT_REGEX.test(value)) {
+		throw new Error(`Invalid amount: "${value}"`);
+	}
+
+	const negative = value.startsWith('-');
+	const stripped = negative ? value.slice(1) : value;
+
+	const [whole = '0', fraction = ''] = stripped.split('.');
+
+	if (fraction.length > decimals) {
+		throw new Error(
+			`Too many decimal places: "${value}" has ${fraction.length} but max is ${decimals}`,
+		);
+	}
+
+	const paddedFraction = fraction.padEnd(decimals, '0') || '0';
+	const result = BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFraction);
+
+	return negative ? -result : result;
+}
+
+/**
+ * Format a MIST balance as a SUI decimal string.
+ *
+ * @example
+ * ```ts
+ * formatSui(1000000000n) // => '1'
+ * formatSui(1500000000n) // => '1.5'
+ * ```
+ */
+export function formatSui(balance: bigint): string {
+	return formatAmount(balance, SUI_DECIMALS);
+}
+
+/**
+ * Parse a SUI decimal string into MIST.
+ *
+ * @example
+ * ```ts
+ * parseSui('1')   // => 1000000000n
+ * parseSui('1.5') // => 1500000000n
+ * ```
+ */
+export function parseSui(value: string): bigint {
+	return parseAmount(value, SUI_DECIMALS);
 }

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -20,73 +20,45 @@ export function formatDigest(digest: string) {
 	return `${digest.slice(0, 10)}${ELLIPSIS}`;
 }
 
+// Requires at least one digit before an optional fractional part, and if a
+// fractional part is present it must have at least one digit. This rejects
+// ambiguous forms like "1." or "." while still accepting leading zeros
+// ("01.5") which are an ecosystem norm (e.g. viem's parseUnits).
+const AMOUNT_REGEX = /^-?[0-9]+(\.[0-9]+)?$/;
+
 /**
- * Convert an amount from its smallest unit representation to a human-readable decimal string.
- * Handles negative values correctly. Uses bigint arithmetic exclusively — no floating point.
+ * Parse a human-readable decimal string into a bigint in the smallest unit for a coin
+ * with the given number of decimals. Uses pure bigint arithmetic — no floating point —
+ * so it preserves precision for values well above `Number.MAX_SAFE_INTEGER`.
+ *
+ * Throws on excess decimal places rather than rounding: callers must handle precision
+ * explicitly.
  *
  * @example
  * ```ts
- * formatAmount(1000000000n, 9) // => '1'
- * formatAmount(1500000000n, 9) // => '1.5'
- * formatAmount(100n, 6)        // => '0.0001'
- * formatAmount(-1500000000n, 9) // => '-1.5'
+ * parseToUnits('1', 9)      // => 1000000000n
+ * parseToUnits('1.5', 9)    // => 1500000000n
+ * parseToUnits('0.0001', 6) // => 100n
+ * parseToUnits('-1.5', 9)   // => -1500000000n
  * ```
  */
-export function formatAmount(amount: bigint, decimals: number): string {
+export function parseToUnits(amount: string, decimals: number): bigint {
 	if (decimals < 0 || !Number.isInteger(decimals) || decimals > 77) {
 		throw new Error(`Invalid decimals: ${decimals}`);
 	}
 
-	const negative = amount < 0n;
-	const absolute = negative ? -amount : amount;
-
-	const divisor = 10n ** BigInt(decimals);
-	const whole = absolute / divisor;
-	const remainder = absolute % divisor;
-
-	let result: string;
-	if (remainder === 0n) {
-		result = whole.toString();
-	} else {
-		const fractional = remainder.toString().padStart(decimals, '0').replace(/0+$/, '');
-		result = `${whole}.${fractional}`;
+	if (!AMOUNT_REGEX.test(amount)) {
+		throw new Error(`Invalid amount: "${amount}"`);
 	}
 
-	return negative ? `-${result}` : result;
-}
-
-const AMOUNT_REGEX = /^-?[0-9]+\.?[0-9]*$/;
-
-/**
- * Convert a human-readable decimal string to the smallest unit representation.
- * Throws on excess decimal places rather than rounding — callers must handle precision explicitly.
- * Uses bigint arithmetic exclusively — no floating point.
- *
- * @example
- * ```ts
- * parseAmount('1', 9)      // => 1000000000n
- * parseAmount('1.5', 9)    // => 1500000000n
- * parseAmount('0.0001', 6) // => 100n
- * parseAmount('-1.5', 9)   // => -1500000000n
- * ```
- */
-export function parseAmount(value: string, decimals: number): bigint {
-	if (decimals < 0 || !Number.isInteger(decimals) || decimals > 77) {
-		throw new Error(`Invalid decimals: ${decimals}`);
-	}
-
-	if (!AMOUNT_REGEX.test(value)) {
-		throw new Error(`Invalid amount: "${value}"`);
-	}
-
-	const negative = value.startsWith('-');
-	const stripped = negative ? value.slice(1) : value;
+	const negative = amount.startsWith('-');
+	const stripped = negative ? amount.slice(1) : amount;
 
 	const [whole = '0', fraction = ''] = stripped.split('.');
 
 	if (fraction.length > decimals) {
 		throw new Error(
-			`Too many decimal places: "${value}" has ${fraction.length} but max is ${decimals}`,
+			`Too many decimal places: "${amount}" has ${fraction.length} but max is ${decimals}`,
 		);
 	}
 
@@ -98,27 +70,15 @@ export function parseAmount(value: string, decimals: number): bigint {
 }
 
 /**
- * Format a MIST balance as a SUI decimal string.
+ * Parse a human-readable SUI decimal string into MIST (SUI's smallest unit, 10^-9 SUI).
+ * Thin wrapper around {@link parseToUnits} that hard-codes SUI's 9-decimal precision.
  *
  * @example
  * ```ts
- * formatSui(1000000000n) // => '1'
- * formatSui(1500000000n) // => '1.5'
+ * parseToMist('1')   // => 1000000000n
+ * parseToMist('1.5') // => 1500000000n
  * ```
  */
-export function formatSui(balance: bigint): string {
-	return formatAmount(balance, SUI_DECIMALS);
-}
-
-/**
- * Parse a SUI decimal string into MIST.
- *
- * @example
- * ```ts
- * parseSui('1')   // => 1000000000n
- * parseSui('1.5') // => 1500000000n
- * ```
- */
-export function parseSui(value: string): bigint {
-	return parseAmount(value, SUI_DECIMALS);
+export function parseToMist(amount: string): bigint {
+	return parseToUnits(amount, SUI_DECIMALS);
 }

--- a/packages/sui/src/utils/format.ts
+++ b/packages/sui/src/utils/format.ts
@@ -20,34 +20,11 @@ export function formatDigest(digest: string) {
 	return `${digest.slice(0, 10)}${ELLIPSIS}`;
 }
 
-// Requires at least one digit before an optional fractional part, and if a
-// fractional part is present it must have at least one digit. This rejects
-// ambiguous forms like "1." or "." while still accepting leading zeros
-// ("01.5") which are an ecosystem norm (e.g. viem's parseUnits).
-const AMOUNT_REGEX = /^-?[0-9]+(\.[0-9]+)?$/;
+const AMOUNT_REGEX = /^-?[0-9]*\.?[0-9]+$/;
 
-/**
- * Parse a human-readable decimal string into a bigint in the smallest unit for a coin
- * with the given number of decimals. Uses pure bigint arithmetic — no floating point —
- * so it preserves precision for values well above `Number.MAX_SAFE_INTEGER`.
- *
- * Throws on excess decimal places rather than rounding: callers must handle precision
- * explicitly.
- *
- * @throws error if `decimals` is negative, non-integer, or greater than 77.
- * @throws error if `amount` is not a valid decimal string (rejects whitespace, scientific notation, bare dots).
- * @throws error if `amount` has more fractional digits than `decimals` allows.
- *
- * @example
- * ```ts
- * parseToUnits('1', 9)      // => 1000000000n
- * parseToUnits('1.5', 9)    // => 1500000000n
- * parseToUnits('0.0001', 6) // => 100n
- * parseToUnits('-1.5', 9)   // => -1500000000n
- * ```
- */
+/** Parse a decimal string into its smallest-unit bigint representation. No floating point. */
 export function parseToUnits(amount: string, decimals: number): bigint {
-	if (decimals < 0 || !Number.isInteger(decimals) || decimals > 77) {
+	if (decimals < 0 || !Number.isInteger(decimals)) {
 		throw new Error(`Invalid decimals: ${decimals}`);
 	}
 
@@ -58,7 +35,7 @@ export function parseToUnits(amount: string, decimals: number): bigint {
 	const negative = amount.startsWith('-');
 	const stripped = negative ? amount.slice(1) : amount;
 
-	const [whole = '0', fraction = ''] = stripped.split('.');
+	const [whole, fraction = ''] = stripped.split('.');
 
 	if (fraction.length > decimals) {
 		throw new Error(
@@ -66,23 +43,13 @@ export function parseToUnits(amount: string, decimals: number): bigint {
 		);
 	}
 
-	// When decimals=0, padEnd produces '' which BigInt() can't parse
 	const paddedFraction = fraction.padEnd(decimals, '0') || '0';
-	const result = BigInt(whole) * 10n ** BigInt(decimals) + BigInt(paddedFraction);
+	const result = BigInt(whole || '0') * 10n ** BigInt(decimals) + BigInt(paddedFraction);
 
 	return negative ? -result : result;
 }
 
-/**
- * Parse a human-readable SUI decimal string into MIST (SUI's smallest unit, 10^-9 SUI).
- * Thin wrapper around {@link parseToUnits} that hard-codes SUI's 9-decimal precision.
- *
- * @example
- * ```ts
- * parseToMist('1')   // => 1000000000n
- * parseToMist('1.5') // => 1500000000n
- * ```
- */
+/** Parse a SUI decimal string into MIST (10^-9 SUI). */
 export function parseToMist(amount: string): bigint {
 	return parseToUnits(amount, SUI_DECIMALS);
 }

--- a/packages/sui/src/utils/index.ts
+++ b/packages/sui/src/utils/index.ts
@@ -1,14 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export {
-	formatAddress,
-	formatDigest,
-	formatAmount,
-	parseAmount,
-	formatSui,
-	parseSui,
-} from './format.js';
+export { formatAddress, formatDigest, parseToUnits, parseToMist } from './format.js';
 export {
 	isValidStructTag,
 	isValidSuiAddress,

--- a/packages/sui/src/utils/index.ts
+++ b/packages/sui/src/utils/index.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export { formatAddress, formatDigest } from './format.js';
+export {
+	formatAddress,
+	formatDigest,
+	formatAmount,
+	parseAmount,
+	formatSui,
+	parseSui,
+} from './format.js';
 export {
 	isValidStructTag,
 	isValidSuiAddress,

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { formatAmount, formatSui, parseAmount, parseSui } from '../../../src/utils/format.js';
+
+describe('formatAmount', () => {
+	it('formats whole numbers', () => {
+		expect(formatAmount(1000000000n, 9)).toEqual('1');
+		expect(formatAmount(5000000000n, 9)).toEqual('5');
+		expect(formatAmount(0n, 9)).toEqual('0');
+	});
+
+	it('formats fractional amounts and strips trailing zeros', () => {
+		expect(formatAmount(1500000000n, 9)).toEqual('1.5');
+		expect(formatAmount(1230000000n, 9)).toEqual('1.23');
+		expect(formatAmount(100000000n, 9)).toEqual('0.1');
+		expect(formatAmount(1n, 9)).toEqual('0.000000001');
+	});
+
+	it('works with different decimal places', () => {
+		expect(formatAmount(1000000n, 6)).toEqual('1');
+		expect(formatAmount(1500000n, 6)).toEqual('1.5');
+		expect(formatAmount(42n, 0)).toEqual('42');
+	});
+
+	it('handles negative values', () => {
+		expect(formatAmount(-1n, 9)).toEqual('-0.000000001');
+		expect(formatAmount(-1500000000n, 9)).toEqual('-1.5');
+		expect(formatAmount(-1000000000n, 9)).toEqual('-1');
+	});
+
+	it('throws on invalid decimals', () => {
+		expect(() => formatAmount(1n, -1)).toThrow('Invalid decimals');
+		expect(() => formatAmount(1n, 78)).toThrow('Invalid decimals');
+	});
+});
+
+describe('parseAmount', () => {
+	it('parses whole and fractional amounts', () => {
+		expect(parseAmount('1', 9)).toEqual(1000000000n);
+		expect(parseAmount('1.5', 9)).toEqual(1500000000n);
+		expect(parseAmount('0.000000001', 9)).toEqual(1n);
+		expect(parseAmount('0', 9)).toEqual(0n);
+	});
+
+	it('handles negative values', () => {
+		expect(parseAmount('-1.5', 9)).toEqual(-1500000000n);
+		expect(parseAmount('-0.5', 9)).toEqual(-500000000n);
+	});
+
+	it('works with different decimal places', () => {
+		expect(parseAmount('1.5', 6)).toEqual(1500000n);
+		expect(parseAmount('42', 0)).toEqual(42n);
+	});
+
+	it('throws on too many decimal places', () => {
+		expect(() => parseAmount('1.0000000001', 9)).toThrow('Too many decimal places');
+	});
+
+	it('rejects invalid input', () => {
+		expect(() => parseAmount('', 9)).toThrow('Invalid amount');
+		expect(() => parseAmount('0x1', 9)).toThrow('Invalid amount');
+		expect(() => parseAmount('.5', 9)).toThrow('Invalid amount');
+		expect(() => parseAmount('1.2.3', 9)).toThrow('Invalid amount');
+		expect(() => parseAmount(' 1 ', 9)).toThrow('Invalid amount');
+		expect(() => parseAmount('1e5', 9)).toThrow('Invalid amount');
+	});
+});
+
+describe('formatAmount/parseAmount round-trip', () => {
+	it('round-trips across value ranges and decimal configurations', () => {
+		const cases: [bigint, number][] = [
+			[0n, 9],
+			[1n, 9],
+			[1500000000n, 9],
+			[999999999n, 9],
+			[-1n, 9],
+			[-1500000000n, 9],
+			[1500000n, 6],
+			[42n, 0],
+		];
+		for (const [value, decimals] of cases) {
+			expect(parseAmount(formatAmount(value, decimals), decimals)).toEqual(value);
+		}
+	});
+});
+
+describe('formatSui/parseSui', () => {
+	it('formats MIST to SUI and back', () => {
+		expect(formatSui(1000000000n)).toEqual('1');
+		expect(formatSui(1500000000n)).toEqual('1.5');
+		expect(parseSui('1')).toEqual(1000000000n);
+		expect(parseSui('1.5')).toEqual(1500000000n);
+	});
+});

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -35,6 +35,13 @@ describe('formatAmount', () => {
 		expect(() => formatAmount(1n, -1)).toThrow('Invalid decimals');
 		expect(() => formatAmount(1n, 78)).toThrow('Invalid decimals');
 	});
+
+	it('handles values beyond MAX_SAFE_INTEGER', () => {
+		const u128Max = 2n ** 128n - 1n;
+		expect(formatAmount(u128Max, 9)).toEqual(
+			'340282366920938463463374607431.768211455',
+		);
+	});
 });
 
 describe('parseAmount', () => {
@@ -67,6 +74,16 @@ describe('parseAmount', () => {
 		expect(() => parseAmount(' 1 ', 9)).toThrow('Invalid amount');
 		expect(() => parseAmount('1e5', 9)).toThrow('Invalid amount');
 	});
+
+	it('throws on invalid decimals', () => {
+		expect(() => parseAmount('1', -1)).toThrow('Invalid decimals');
+		expect(() => parseAmount('1', 78)).toThrow('Invalid decimals');
+	});
+
+	it('handles values beyond MAX_SAFE_INTEGER', () => {
+		const u128Max = 2n ** 128n - 1n;
+		expect(parseAmount('340282366920938463463374607431.768211455', 9)).toEqual(u128Max);
+	});
 });
 
 describe('formatAmount/parseAmount round-trip', () => {
@@ -80,6 +97,7 @@ describe('formatAmount/parseAmount round-trip', () => {
 			[-1500000000n, 9],
 			[1500000n, 6],
 			[42n, 0],
+			[2n ** 128n - 1n, 9],
 		];
 		for (const [value, decimals] of cases) {
 			expect(parseAmount(formatAmount(value, decimals), decimals)).toEqual(value);

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -1,113 +1,90 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
-import { formatAmount, formatSui, parseAmount, parseSui } from '../../../src/utils/format.js';
+import { parseToMist, parseToUnits } from '../../../src/utils/format.js';
 
-describe('formatAmount', () => {
-	it('formats whole numbers', () => {
-		expect(formatAmount(1000000000n, 9)).toEqual('1');
-		expect(formatAmount(5000000000n, 9)).toEqual('5');
-		expect(formatAmount(0n, 9)).toEqual('0');
+describe('parseToUnits', () => {
+	test('parses whole and fractional amounts', () => {
+		expect(parseToUnits('1', 9)).toEqual(1000000000n);
+		expect(parseToUnits('1.5', 9)).toEqual(1500000000n);
+		expect(parseToUnits('0.000000001', 9)).toEqual(1n);
+		expect(parseToUnits('0', 9)).toEqual(0n);
 	});
 
-	it('formats fractional amounts and strips trailing zeros', () => {
-		expect(formatAmount(1500000000n, 9)).toEqual('1.5');
-		expect(formatAmount(1230000000n, 9)).toEqual('1.23');
-		expect(formatAmount(100000000n, 9)).toEqual('0.1');
-		expect(formatAmount(1n, 9)).toEqual('0.000000001');
+	test('handles negative values', () => {
+		expect(parseToUnits('-1.5', 9)).toEqual(-1500000000n);
+		expect(parseToUnits('-0.5', 9)).toEqual(-500000000n);
 	});
 
-	it('works with different decimal places', () => {
-		expect(formatAmount(1000000n, 6)).toEqual('1');
-		expect(formatAmount(1500000n, 6)).toEqual('1.5');
-		expect(formatAmount(42n, 0)).toEqual('42');
+	test('normalizes negative zero to 0n', () => {
+		expect(parseToUnits('-0', 9)).toEqual(0n);
+		expect(parseToUnits('-0.0', 9)).toEqual(0n);
+		expect(parseToUnits('-0.000000000', 9)).toEqual(0n);
 	});
 
-	it('handles negative values', () => {
-		expect(formatAmount(-1n, 9)).toEqual('-0.000000001');
-		expect(formatAmount(-1500000000n, 9)).toEqual('-1.5');
-		expect(formatAmount(-1000000000n, 9)).toEqual('-1');
+	test('accepts leading zeros (ecosystem norm)', () => {
+		expect(parseToUnits('01.5', 9)).toEqual(1500000000n);
+		expect(parseToUnits('007', 9)).toEqual(7000000000n);
 	});
 
-	it('throws on invalid decimals', () => {
-		expect(() => formatAmount(1n, -1)).toThrow('Invalid decimals');
-		expect(() => formatAmount(1n, 78)).toThrow('Invalid decimals');
+	test('works with different decimal places', () => {
+		expect(parseToUnits('1.5', 6)).toEqual(1500000n);
+		expect(parseToUnits('42', 0)).toEqual(42n);
 	});
 
-	it('handles values beyond MAX_SAFE_INTEGER', () => {
+	test('throws on too many decimal places', () => {
+		expect(() => parseToUnits('1.0000000001', 9)).toThrow('Too many decimal places');
+	});
+
+	test('rejects invalid input', () => {
+		expect(() => parseToUnits('', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('0x1', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('.5', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('1.', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('1.2.3', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits(' 1 ', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('1e5', 9)).toThrow('Invalid amount');
+	});
+
+	test('throws on invalid decimals', () => {
+		expect(() => parseToUnits('1', -1)).toThrow('Invalid decimals');
+		expect(() => parseToUnits('1', 78)).toThrow('Invalid decimals');
+	});
+
+	test('preserves precision for values above Number.MAX_SAFE_INTEGER', () => {
+		// The naive workaround `BigInt(Math.round(parseFloat(s) * 1e9))` silently
+		// loses precision for amounts above ~9M SUI (MAX_SAFE_INTEGER / 1e9).
+		// These cases are the whole reason parseToUnits exists.
+		expect(parseToUnits('10000000', 9)).toEqual(10_000_000_000_000_000n);
+		expect(parseToUnits('9007199.254740993', 9)).toEqual(9_007_199_254_740_993n);
+
 		const u128Max = 2n ** 128n - 1n;
-		expect(formatAmount(u128Max, 9)).toEqual('340282366920938463463374607431.768211455');
+		expect(parseToUnits('340282366920938463463374607431.768211455', 9)).toEqual(u128Max);
 	});
 });
 
-describe('parseAmount', () => {
-	it('parses whole and fractional amounts', () => {
-		expect(parseAmount('1', 9)).toEqual(1000000000n);
-		expect(parseAmount('1.5', 9)).toEqual(1500000000n);
-		expect(parseAmount('0.000000001', 9)).toEqual(1n);
-		expect(parseAmount('0', 9)).toEqual(0n);
+describe('parseToMist', () => {
+	test('parses SUI decimal strings into MIST', () => {
+		expect(parseToMist('1')).toEqual(1000000000n);
+		expect(parseToMist('1.5')).toEqual(1500000000n);
+		expect(parseToMist('0.000000001')).toEqual(1n);
 	});
 
-	it('handles negative values', () => {
-		expect(parseAmount('-1.5', 9)).toEqual(-1500000000n);
-		expect(parseAmount('-0.5', 9)).toEqual(-500000000n);
+	test('handles negative values', () => {
+		expect(parseToMist('-1.5')).toEqual(-1500000000n);
 	});
 
-	it('works with different decimal places', () => {
-		expect(parseAmount('1.5', 6)).toEqual(1500000n);
-		expect(parseAmount('42', 0)).toEqual(42n);
+	test('rejects invalid input', () => {
+		expect(() => parseToMist('1.')).toThrow('Invalid amount');
+		expect(() => parseToMist('1.0000000001')).toThrow('Too many decimal places');
 	});
 
-	it('throws on too many decimal places', () => {
-		expect(() => parseAmount('1.0000000001', 9)).toThrow('Too many decimal places');
-	});
-
-	it('rejects invalid input', () => {
-		expect(() => parseAmount('', 9)).toThrow('Invalid amount');
-		expect(() => parseAmount('0x1', 9)).toThrow('Invalid amount');
-		expect(() => parseAmount('.5', 9)).toThrow('Invalid amount');
-		expect(() => parseAmount('1.2.3', 9)).toThrow('Invalid amount');
-		expect(() => parseAmount(' 1 ', 9)).toThrow('Invalid amount');
-		expect(() => parseAmount('1e5', 9)).toThrow('Invalid amount');
-	});
-
-	it('throws on invalid decimals', () => {
-		expect(() => parseAmount('1', -1)).toThrow('Invalid decimals');
-		expect(() => parseAmount('1', 78)).toThrow('Invalid decimals');
-	});
-
-	it('handles values beyond MAX_SAFE_INTEGER', () => {
-		const u128Max = 2n ** 128n - 1n;
-		expect(parseAmount('340282366920938463463374607431.768211455', 9)).toEqual(u128Max);
-	});
-});
-
-describe('formatAmount/parseAmount round-trip', () => {
-	it('round-trips across value ranges and decimal configurations', () => {
-		const cases: [bigint, number][] = [
-			[0n, 9],
-			[1n, 9],
-			[1500000000n, 9],
-			[999999999n, 9],
-			[-1n, 9],
-			[-1500000000n, 9],
-			[1500000n, 6],
-			[42n, 0],
-			[2n ** 128n - 1n, 9],
-		];
-		for (const [value, decimals] of cases) {
-			expect(parseAmount(formatAmount(value, decimals), decimals)).toEqual(value);
-		}
-	});
-});
-
-describe('formatSui/parseSui', () => {
-	it('formats MIST to SUI and back', () => {
-		expect(formatSui(1000000000n)).toEqual('1');
-		expect(formatSui(1500000000n)).toEqual('1.5');
-		expect(parseSui('1')).toEqual(1000000000n);
-		expect(parseSui('1.5')).toEqual(1500000000n);
+	test('preserves precision above Number.MAX_SAFE_INTEGER', () => {
+		// Same precision guarantee as parseToUnits — parseToMist is just a
+		// 9-decimal wrapper, but test it independently so the contract is
+		// documented at the SUI-specific entry point.
+		expect(parseToMist('9007199.254740993')).toEqual(9_007_199_254_740_993n);
 	});
 });

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -29,10 +29,14 @@ describe('parseToUnits', () => {
 		expect(parseToUnits('007', 9)).toEqual(7000000000n);
 	});
 
+	test('accepts shorthand decimal notation', () => {
+		expect(parseToUnits('.5', 9)).toEqual(500000000n);
+		expect(parseToUnits('.000000001', 9)).toEqual(1n);
+	});
+
 	test('works with different decimal places', () => {
 		expect(parseToUnits('1.5', 6)).toEqual(1500000n);
 		expect(parseToUnits('42', 0)).toEqual(42n);
-		expect(parseToUnits('1', 77)).toEqual(10n ** 77n);
 	});
 
 	test('throws on too many decimal places', () => {
@@ -42,7 +46,6 @@ describe('parseToUnits', () => {
 	test('rejects invalid input', () => {
 		expect(() => parseToUnits('', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits('0x1', 9)).toThrow('Invalid amount');
-		expect(() => parseToUnits('.5', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits('1.', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits('1.2.3', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits(' 1 ', 9)).toThrow('Invalid amount');
@@ -51,19 +54,13 @@ describe('parseToUnits', () => {
 
 	test('throws on invalid decimals', () => {
 		expect(() => parseToUnits('1', -1)).toThrow('Invalid decimals');
-		expect(() => parseToUnits('1', 78)).toThrow('Invalid decimals');
 		expect(() => parseToUnits('1', 1.5)).toThrow('Invalid decimals');
 	});
 
-	test('preserves precision for values above Number.MAX_SAFE_INTEGER', () => {
-		// The naive workaround `BigInt(Math.round(parseFloat(s) * 1e9))` silently
-		// loses precision for amounts above ~9M SUI (MAX_SAFE_INTEGER / 1e9).
-		// These cases are the whole reason parseToUnits exists.
+	test('preserves precision above Number.MAX_SAFE_INTEGER', () => {
 		expect(parseToUnits('10000000', 9)).toEqual(10_000_000_000_000_000n);
 		expect(parseToUnits('9007199.254740993', 9)).toEqual(9_007_199_254_740_993n);
-
-		const u128Max = 2n ** 128n - 1n;
-		expect(parseToUnits('340282366920938463463374607431.768211455', 9)).toEqual(u128Max);
+		expect(parseToUnits('340282366920938463463374607431.768211455', 9)).toEqual(2n ** 128n - 1n);
 	});
 });
 
@@ -84,9 +81,6 @@ describe('parseToMist', () => {
 	});
 
 	test('preserves precision above Number.MAX_SAFE_INTEGER', () => {
-		// Same precision guarantee as parseToUnits — parseToMist is just a
-		// 9-decimal wrapper, but test it independently so the contract is
-		// documented at the SUI-specific entry point.
 		expect(parseToMist('9007199.254740993')).toEqual(9_007_199_254_740_993n);
 	});
 });

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -32,6 +32,7 @@ describe('parseToUnits', () => {
 	test('works with different decimal places', () => {
 		expect(parseToUnits('1.5', 6)).toEqual(1500000n);
 		expect(parseToUnits('42', 0)).toEqual(42n);
+		expect(parseToUnits('1', 77)).toEqual(10n ** 77n);
 	});
 
 	test('throws on too many decimal places', () => {
@@ -51,6 +52,7 @@ describe('parseToUnits', () => {
 	test('throws on invalid decimals', () => {
 		expect(() => parseToUnits('1', -1)).toThrow('Invalid decimals');
 		expect(() => parseToUnits('1', 78)).toThrow('Invalid decimals');
+		expect(() => parseToUnits('1', 1.5)).toThrow('Invalid decimals');
 	});
 
 	test('preserves precision for values above Number.MAX_SAFE_INTEGER', () => {

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -32,6 +32,7 @@ describe('parseToUnits', () => {
 	test('accepts shorthand decimal notation', () => {
 		expect(parseToUnits('.5', 9)).toEqual(500000000n);
 		expect(parseToUnits('.000000001', 9)).toEqual(1n);
+		expect(parseToUnits('-.5', 9)).toEqual(-500000000n);
 	});
 
 	test('works with different decimal places', () => {

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -24,7 +24,7 @@ describe('parseToUnits', () => {
 		expect(parseToUnits('-0.000000000', 9)).toEqual(0n);
 	});
 
-	test('accepts leading zeros (ecosystem norm)', () => {
+	test('accepts leading zeros', () => {
 		expect(parseToUnits('01.5', 9)).toEqual(1500000000n);
 		expect(parseToUnits('007', 9)).toEqual(7000000000n);
 	});
@@ -51,6 +51,8 @@ describe('parseToUnits', () => {
 		expect(() => parseToUnits('1.2.3', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits(' 1 ', 9)).toThrow('Invalid amount');
 		expect(() => parseToUnits('1e5', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('1,000', 9)).toThrow('Invalid amount');
+		expect(() => parseToUnits('+1.5', 9)).toThrow('Invalid amount');
 	});
 
 	test('throws on invalid decimals', () => {

--- a/packages/sui/test/unit/utils/format.test.ts
+++ b/packages/sui/test/unit/utils/format.test.ts
@@ -38,9 +38,7 @@ describe('formatAmount', () => {
 
 	it('handles values beyond MAX_SAFE_INTEGER', () => {
 		const u128Max = 2n ** 128n - 1n;
-		expect(formatAmount(u128Max, 9)).toEqual(
-			'340282366920938463463374607431.768211455',
-		);
+		expect(formatAmount(u128Max, 9)).toEqual('340282366920938463463374607431.768211455');
 	});
 });
 


### PR DESCRIPTION
## Description

Adds two parser utilities to `@mysten/sui/utils` for converting human-readable decimal strings into smallest-unit `bigint`s:

- **`parseToUnits(amount: string, decimals: number): bigint`** — generic parser for any coin
- **`parseToMist(amount: string): bigint`** — SUI-specific wrapper (9 decimals)

### Why

The common ecosystem workaround for decimal → smallest-unit conversion is:

    BigInt(Math.round(parseFloat(s) * 1e9))

This silently loses precision above `Number.MAX_SAFE_INTEGER / 1e9 ≈ 9,007,199` SUI. These parsers use pure `bigint` arithmetic — no floating point — so precision is preserved at any magnitude.

### Behavior

- Accepts whole numbers, decimals, leading zeros, shorthand notation (`.5`, `-.5`)
- Normalizes `-0` → `0n`
- Rejects: trailing dots (`1.`), multiple dots, whitespace, hex, scientific notation, commas, leading `+`
- Throws on too many decimal places (no silent truncation)
- Throws on invalid `decimals` (`< 0`, non-integer)

### Scope history

Originally proposed a broader `formatAmount` / `formatSui` / `parseAmount` / `parseSui` set. After review feedback that formatting is inherently opinionated, the formatting half was dropped. Parser signatures refactored: `parseAmount` → `parseToUnits`, `parseSui` → `parseToMist`, plain `decimals: number` instead of `CoinMetadata`.

## Test plan

- 14 unit tests passing (`pnpm --filter @mysten/sui vitest run test/unit/utils/format.test.ts`)
- Covers: happy path, negatives, negative-zero normalization, leading zeros, shorthand decimals, different decimal counts (9/6/0), precision above `MAX_SAFE_INTEGER` including `u128::MAX`, rejection suite (8 cases), decimals validation
- Prettier: clean

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.