### PR TITLE
deepbook-v3: add cancelLiveOrder(s) builders and bump mainnet package id (DBU-350)

### DIFF
--- a/.changeset/deepbook-cancel-live-orders.md
+++ b/.changeset/deepbook-cancel-live-orders.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook-v3': minor
+---
+
+Add `cancelLiveOrder` and `cancelLiveOrders` transaction builders that skip order ids not currently in the balance manager's open orders (already filled, cancelled, expired-and-swept, or not owned by this BM) instead of aborting. Also updates mainnet `DEEPBOOK_PACKAGE_ID` to `0xf48222c4e057fa468baf136bff8e12504209d43850c5778f76159292a96f621e`.

--- a/.changeset/suins-axios-bump.md
+++ b/.changeset/suins-axios-bump.md
@@ -1,0 +1,5 @@
+---
+'@mysten/suins': patch
+---
+
+Bump `axios` to `^1.15.0` to patch GHSA-3p68-rc4w-qgx5 (NO_PROXY hostname normalization SSRF).

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"packageManager": "pnpm@10.33.0",
 	"pnpm": {
 		"overrides": {
-			"axios": "^1.13.5",
+			"axios": "^1.15.0",
 			"lodash": ">=4.18.0",
 			"defu": ">=6.1.5"
 		}

--- a/packages/deepbook-v3/package.json
+++ b/packages/deepbook-v3/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"@mysten/bcs": "workspace:^",
 		"@noble/hashes": "^2.0.1",
-		"axios": "^1.13.5",
+		"axios": "^1.15.0",
 		"axios-retry": "^4.5.0"
 	},
 	"devDependencies": {

--- a/packages/deepbook-v3/src/transactions/deepbook.ts
+++ b/packages/deepbook-v3/src/transactions/deepbook.ts
@@ -217,6 +217,70 @@ export class DeepBookContract {
 		};
 
 	/**
+	 * @description Cancel an existing order, no-op if the order is not currently in the
+	 * balance manager's open orders (e.g. already filled, cancelled, expired-and-swept,
+	 * or not owned by this balance manager). Unlike `cancelOrder`, this will not abort
+	 * on unknown order ids.
+	 * @param {string} poolKey The key to identify the pool
+	 * @param {string} balanceManagerKey The key to identify the BalanceManager
+	 * @param {string} orderId Order ID to cancel
+	 * @returns A function that takes a Transaction object
+	 */
+	cancelLiveOrder =
+		(poolKey: string, balanceManagerKey: string, orderId: string) => (tx: Transaction) => {
+			tx.setGasBudgetIfNotSet(GAS_BUDGET);
+			const pool = this.#config.getPool(poolKey);
+			const balanceManager = this.#config.getBalanceManager(balanceManagerKey);
+			const baseCoin = this.#config.getCoin(pool.baseCoin);
+			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
+			const tradeProof = tx.add(this.#config.balanceManager.generateProof(balanceManagerKey));
+
+			tx.moveCall({
+				target: `${this.#config.DEEPBOOK_PACKAGE_ID}::pool::cancel_live_order`,
+				arguments: [
+					tx.object(pool.address),
+					tx.object(balanceManager.address),
+					tradeProof,
+					tx.pure.u128(orderId),
+					tx.object.clock(),
+				],
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			});
+		};
+
+	/**
+	 * @description Cancel multiple orders, skipping any order_id that is not currently in
+	 * the balance manager's open orders (e.g. already filled, cancelled, expired-and-swept,
+	 * or not owned by this balance manager). Duplicate ids in the input vector are handled
+	 * gracefully. Unlike `cancelOrders`, this will not abort on unknown order ids.
+	 * @param {string} poolKey The key to identify the pool
+	 * @param {string} balanceManagerKey The key to identify the BalanceManager
+	 * @param {string[]} orderIds Array of order IDs to cancel
+	 * @returns A function that takes a Transaction object
+	 */
+	cancelLiveOrders =
+		(poolKey: string, balanceManagerKey: string, orderIds: string[]) => (tx: Transaction) => {
+			tx.setGasBudgetIfNotSet(GAS_BUDGET);
+			const pool = this.#config.getPool(poolKey);
+			const balanceManager = this.#config.getBalanceManager(balanceManagerKey);
+			const baseCoin = this.#config.getCoin(pool.baseCoin);
+			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
+			const tradeProof = tx.add(this.#config.balanceManager.generateProof(balanceManagerKey));
+
+			tx.moveCall({
+				target: `${this.#config.DEEPBOOK_PACKAGE_ID}::pool::cancel_live_orders`,
+				arguments: [
+					tx.object(pool.address),
+					tx.object(balanceManager.address),
+					tradeProof,
+					tx.pure.vector('u128', orderIds),
+					tx.object.clock(),
+				],
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			});
+		};
+
+	/**
 	 * @description Cancel all open orders for a balance manager
 	 * @param {string} poolKey The key to identify the pool
 	 * @param {string} balanceManagerKey The key to identify the BalanceManager

--- a/packages/deepbook-v3/src/utils/constants.ts
+++ b/packages/deepbook-v3/src/utils/constants.ts
@@ -25,7 +25,7 @@ export const testnetPackageIds = {
 } satisfies DeepbookPackageIds;
 
 export const mainnetPackageIds = {
-	DEEPBOOK_PACKAGE_ID: '0x337f4f4f6567fcd778d5454f27c16c70e2f274cc6377ea6249ddf491482ef497',
+	DEEPBOOK_PACKAGE_ID: '0xf48222c4e057fa468baf136bff8e12504209d43850c5778f76159292a96f621e',
 	REGISTRY_ID: '0xaf16199a2dff736e9f07a845f23c5da6df6f756eddb631aed9d24a93efc4549d',
 	DEEP_TREASURY_ID: '0x032abf8948dda67a271bcc18e776dbbcfb0d58c8d288a700ff0d5521e57a1ffe',
 	MARGIN_PACKAGE_ID: '0xfbd322126f1452fd4c89aedbaeb9fd0c44df9b5cedbe70d76bf80dc086031377',

--- a/packages/suins/package.json
+++ b/packages/suins/package.json
@@ -42,7 +42,7 @@
 		"node": ">=16"
 	},
 	"dependencies": {
-		"axios": "^1.13.5",
+		"axios": "^1.15.0",
 		"axios-retry": "^4.5.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.13.5
+  axios: ^1.15.0
   lodash: '>=4.18.0'
   defu: '>=6.1.5'
 
@@ -584,11 +584,11 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       axios:
-        specifier: ^1.13.5
-        version: 1.13.6
+        specifier: ^1.15.0
+        version: 1.15.0
       axios-retry:
         specifier: ^4.5.0
-        version: 4.5.0(axios@1.13.6)
+        version: 4.5.0(axios@1.15.0)
     devDependencies:
       '@iarna/toml':
         specifier: ^2.2.5
@@ -1251,11 +1251,11 @@ importers:
   packages/suins:
     dependencies:
       axios:
-        specifier: ^1.13.5
-        version: 1.13.6
+        specifier: ^1.15.0
+        version: 1.15.0
       axios-retry:
         specifier: ^4.5.0
-        version: 4.5.0(axios@1.13.6)
+        version: 4.5.0(axios@1.15.0)
     devDependencies:
       '@mysten/codegen':
         specifier: workspace:^
@@ -5906,10 +5906,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: ^1.13.5
+      axios: ^1.15.0
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -8448,8 +8448,9 @@ packages:
   proxy-compare@3.0.1:
     resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -10339,8 +10340,8 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.13.6
-      axios-retry: 4.5.0(axios@1.13.6)
+      axios: 1.15.0
+      axios-retry: 4.5.0(axios@1.15.0)
       jose: 6.2.2
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -11402,7 +11403,7 @@ snapshots:
       '@ledgerhq/live-env': 2.30.0
       '@ledgerhq/live-promise': 0.2.2
       '@ledgerhq/logs': 6.16.0
-      axios: 1.13.6
+      axios: 1.15.0
       lru-cache: 7.18.3
     transitivePeerDependencies:
       - debug
@@ -15042,16 +15043,16 @@ snapshots:
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
-  axios-retry@4.5.0(axios@1.13.6):
+  axios-retry@4.5.0(axios@1.15.0):
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       is-retry-allowed: 2.2.0
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -17960,7 +17961,7 @@ snapshots:
 
   proxy-compare@3.0.1: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -19390,7 +19391,7 @@ snapshots:
 
   wait-on@9.0.4:
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       joi: 18.1.1
       lodash: 4.18.0
       minimist: 1.2.8


### PR DESCRIPTION
## Description

Updates `@mysten/deepbook-v3` to track the latest mainnet deploy and surfaces the new graceful cancel APIs added in MystenLabs/deepbookv3#952.

- Bump mainnet `DEEPBOOK_PACKAGE_ID` to `0xf48222c4e057fa468baf136bff8e12504209d43850c5778f76159292a96f621e`.
- Add `DeepBookContract.cancelLiveOrder(poolKey, balanceManagerKey, orderId)` — targets `pool::cancel_live_order`. No-ops when the id is not in the balance manager's `account_open_orders` (already filled, cancelled, expired-and-swept, or not owned by this BM) instead of aborting like `cancelOrder`.
- Add `DeepBookContract.cancelLiveOrders(poolKey, balanceManagerKey, orderIds)` — targets `pool::cancel_live_orders`. Same graceful behavior; handles duplicate ids in the input vector.

The builders mirror the existing `cancelOrder` / `cancelOrders` shape. The auto-generated `contracts/deepbook/pool.ts` bindings are intentionally untouched — they're not imported by any transaction builder and will pick up the new functions on the next codegen run.

Linear: [DBU-350](https://linear.app/mysten-labs/issue/DBU-350/ts-sdk-update-deepbook-package-id-and-add-cancelliveorders-builders)

## Test plan

- [x] `pnpm --filter @mysten/deepbook-v3 exec tsc --noEmit` passes
- [x] `pnpm exec prettier --write .` clean
- [x] Manual smoke test: build a PTB with `client.deepBook.cancelLiveOrder(...)` / `cancelLiveOrders(...)` against the new mainnet package and confirm the no-op path silently skips unknown ids

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.