### PR TITLE
deepbook v3 | TS | SDK | fixes | setSender

### DIFF
--- a/packages/deepbook-v3/src/queries/balanceManagerQueries.ts
+++ b/packages/deepbook-v3/src/queries/balanceManagerQueries.ts
@@ -17,6 +17,7 @@ export class BalanceManagerQueries {
 
 	async checkManagerBalance(managerKey: string, coinKey: string): Promise<ManagerBalance> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.config.address);
 		const coin = this.#ctx.config.getCoin(coinKey);
 
 		tx.add(this.#ctx.balanceManager.checkManagerBalance(managerKey, coinKey));

--- a/packages/deepbook-v3/src/queries/poolQueries.ts
+++ b/packages/deepbook-v3/src/queries/poolQueries.ts
@@ -25,6 +25,7 @@ export class PoolQueries {
 	async whitelisted(poolKey: string): Promise<boolean> {
 		const tx = new Transaction();
 
+		tx.setSender(this.#ctx.config.address);
 		tx.add(this.#ctx.deepBook.whitelisted(poolKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
 			transaction: tx,
@@ -94,6 +95,7 @@ export class PoolQueries {
 	async poolTradeParams(poolKey: string): Promise<PoolTradeParams> {
 		const tx = new Transaction();
 
+		tx.setSender(this.#ctx.config.address);
 		tx.add(this.#ctx.deepBook.poolTradeParams(poolKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
 			transaction: tx,
@@ -117,6 +119,7 @@ export class PoolQueries {
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
 
+		tx.setSender(this.#ctx.config.address);
 		tx.add(this.#ctx.deepBook.poolBookParams(poolKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
 			transaction: tx,


### PR DESCRIPTION
Fix for the following error on calling changed methods:
`Missing transaction sender`