### PR TITLE
feat(zksend): composable claim via createClaimCommands

### DIFF
--- a/packages/zksend/src/index.test.ts
+++ b/packages/zksend/src/index.test.ts
@@ -281,6 +281,75 @@ describe('Contract links', () => {
 		}
 	}, 60_000);
 
+	test('createClaimCommands — compose with claimed assets', async () => {
+		const link = client.zksend.linkBuilder({
+			sender: keypair.toSuiAddress(),
+		});
+
+		const bears = await createBears(2);
+
+		for (const bear of bears) {
+			link.addClaimableObject(bear.objectId);
+		}
+
+		link.addClaimableMist(100n);
+
+		const linkUrl = link.getLink();
+
+		await link.create({
+			signer: keypair,
+			waitForTransaction: true,
+		});
+
+		const claimLink = await client.zksend.loadLinkFromUrl(linkUrl);
+		expect(claimLink.assets!.nfts.length).toEqual(2);
+
+		// Build a composable claim transaction
+		const tx = new Transaction();
+		tx.setSender(claimLink.keypair!.toSuiAddress());
+
+		const { assets, finalize } = claimLink.createClaimCommands(tx);
+
+		// Verify assets have type metadata
+		expect(assets.length).toEqual(3); // 2 bears + 1 SUI coin
+		const bearAssets = assets.filter((a) => a.type.includes('::demo_bear::DemoBear'));
+		const coinAssets = assets.filter((a) => !a.type.includes('::demo_bear::DemoBear'));
+		expect(bearAssets.length).toEqual(2);
+		expect(coinAssets.length).toEqual(1);
+
+		// Compose: transfer bears and coins separately (simulates using them in a Move call)
+		tx.transferObjects(
+			bearAssets.map((a) => a.argument),
+			keypair.toSuiAddress(),
+		);
+		tx.transferObjects(
+			coinAssets.map((a) => a.argument),
+			keypair.toSuiAddress(),
+		);
+
+		finalize();
+
+		// Execute with dual signing (ephemeral key is sender, test keypair pays gas)
+		tx.setGasOwner(keypair.toSuiAddress());
+		const txBytes = await tx.build({ client });
+		const ephemeralSig = await claimLink.keypair!.signTransaction(txBytes);
+		const gasSig = await keypair.signTransaction(txBytes);
+
+		const result = await client.executeTransaction({
+			transaction: txBytes,
+			signatures: [ephemeralSig.signature, gasSig.signature],
+		});
+
+		await client.core.waitForTransaction({
+			result,
+			include: { effects: true },
+		});
+
+		// Link should be claimed
+		const link2 = await client.zksend.loadLinkFromUrl(linkUrl);
+		expect(link2.claimed).toEqual(true);
+	}, 30_000);
+
 	test('create link with minted assets', async () => {
 		const link = client.zksend.linkBuilder({
 			sender: keypair.toSuiAddress(),

--- a/packages/zksend/src/index.ts
+++ b/packages/zksend/src/index.ts
@@ -20,4 +20,4 @@ export { ZkSendLink, type ZkSendLinkOptions } from './links/claim.js';
 export { type ZkBagContractOptions, ZkBag } from './links/zk-bag.js';
 export { MAINNET_CONTRACT_IDS, TESTNET_CONTRACT_IDS } from './links/zk-bag.js';
 
-export { isClaimTransaction } from './links/utils.js';
+export { isClaimTransaction, type ClaimedAsset } from './links/utils.js';

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -4,7 +4,6 @@
 import { bcs } from '@mysten/sui/bcs';
 import type { Keypair } from '@mysten/sui/cryptography';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import type { TransactionObjectArgument } from '@mysten/sui/transactions';
 import { Transaction } from '@mysten/sui/transactions';
 import {
 	fromBase64,
@@ -16,7 +15,7 @@ import {
 
 import type { ZkSendLinkBuilderOptions } from './builder.js';
 import { ZkSendLinkBuilder } from './builder.js';
-import type { LinkAssets } from './utils.js';
+import type { ClaimedAsset, LinkAssets } from './utils.js';
 import type { ZkBagContractOptions } from './zk-bag.js';
 import { getContractIds, ZkBag, ZkBagStruct } from './zk-bag.js';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
@@ -208,6 +207,10 @@ export class ZkSendLink {
 		return result;
 	}
 
+	/**
+	 * Build a complete claim transaction that transfers all assets to `address`.
+	 * For composable claims, use {@link createClaimCommands} instead.
+	 */
 	createClaimTransaction(
 		address: string,
 		{
@@ -216,13 +219,52 @@ export class ZkSendLink {
 			reclaim?: boolean;
 		} = {},
 	) {
-		if (!this.keypair && !reclaim) {
-			throw new Error('Cannot claim assets without the links keypair');
-		}
-
 		const tx = new Transaction();
 		const sender = reclaim ? address : this.keypair!.toSuiAddress();
 		tx.setSender(sender);
+
+		const { assets, finalize } = this.createClaimCommands(tx, { reclaim });
+
+		if (assets.length > 0) {
+			tx.transferObjects(
+				assets.map((a) => a.argument),
+				address,
+			);
+		}
+
+		finalize();
+
+		return tx;
+	}
+
+	/**
+	 * Add claim commands to an existing transaction and return the claimed
+	 * assets for composition. The caller is responsible for transferring or
+	 * using every asset and calling `finalize()` when done.
+	 *
+	 * @example
+	 * ```ts
+	 * const tx = new Transaction();
+	 * const { assets, finalize } = link.createClaimCommands(tx);
+	 *
+	 * const record = assets.find(a => a.type.includes('::record::Record'));
+	 * tx.moveCall({ target: 'player::add_record', arguments: [player, record.argument] });
+	 * tx.transferObjects(assets.filter(a => a !== record).map(a => a.argument), address);
+	 *
+	 * finalize();
+	 * ```
+	 */
+	createClaimCommands(
+		tx: Transaction,
+		{
+			reclaim,
+		}: {
+			reclaim?: boolean;
+		} = {},
+	): { assets: ClaimedAsset[]; finalize: () => void } {
+		if (!this.keypair && !reclaim) {
+			throw new Error('Cannot claim assets without the links keypair');
+		}
 
 		const store = tx.object(this.#contract.ids.bagStoreId);
 		const command = reclaim
@@ -231,34 +273,30 @@ export class ZkSendLink {
 
 		const [bag, proof] = tx.add(command);
 
-		const objectsToTransfer: TransactionObjectArgument[] = [];
-
 		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
 
-		for (const object of objects) {
-			objectsToTransfer.push(
-				this.#contract.claim({
-					arguments: [
-						bag,
-						proof,
-						tx.receivingRef({
-							objectId: object.objectId,
-							version: object.version,
-							digest: object.digest,
-						}),
-					],
-					typeArguments: [object.type],
-				}),
-			);
-		}
+		const assets: ClaimedAsset[] = objects.map((object) => ({
+			argument: this.#contract.claim({
+				arguments: [
+					bag,
+					proof,
+					tx.receivingRef({
+						objectId: object.objectId,
+						version: object.version,
+						digest: object.digest,
+					}),
+				],
+				typeArguments: [object.type],
+			}),
+			type: object.type,
+			objectId: object.objectId,
+		}));
 
-		if (objectsToTransfer.length > 0) {
-			tx.transferObjects(objectsToTransfer, address);
-		}
+		const finalize = () => {
+			tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
+		};
 
-		tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
-
-		return tx;
+		return { assets, finalize };
 	}
 
 	async createRegenerateTransaction(

--- a/packages/zksend/src/links/utils.ts
+++ b/packages/zksend/src/links/utils.ts
@@ -1,7 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Transaction } from '@mysten/sui/transactions';
+import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
+
+/** A claimed asset paired with its on-chain type, available for composition within a claim transaction. */
+export interface ClaimedAsset {
+	/** Transaction argument representing the claimed object — pass to moveCall or transferObjects. */
+	argument: TransactionObjectArgument;
+	/** Full Move type of the object (e.g. "0x...::record::Record"). */
+	type: string;
+	/** Object ID of the asset in the link's bag. */
+	objectId: string;
+}
 
 export interface LinkAssets {
 	balances: {


### PR DESCRIPTION
## Summary
Adds `ZkSendLink.createClaimCommands(tx)` that returns claimed assets for composition within a caller-owned transaction. The caller decides what to do with each asset and calls `finalize()` to close the bag.

## Motivation
Currently, `createClaimTransaction` auto-transfers all claimed objects to the recipient. There's no way to intercept the claimed objects to compose additional operations (e.g., adding a record to a player, staking a token, depositing into a vault) in the same transaction.

## Changes
- New `createClaimCommands(tx)` method → `{ assets: ClaimedAsset[], finalize: () => void }`
- New `ClaimedAsset` type: `{ argument: TransactionObjectArgument, type: string, objectId: string }` — pairs the tx argument with on-chain type metadata so callers can filter by Move type or object ID
- `createClaimTransaction(address)` refactored as a thin wrapper (claim → transfer all → finalize). Backwards compatible.
- No auto-transfer, no callbacks — caller explicitly handles every asset

## Usage
```ts
const tx = new Transaction();
const { assets, finalize } = link.createClaimCommands(tx);

const record = assets.find(a => a.type.includes('::record::Record'));
tx.moveCall({ target: 'player::add_record', arguments: [player, record.argument] });
tx.transferObjects(assets.filter(a => a !== record).map(a => a.argument), address);

finalize(); // closes the bag — must call
```

## Test plan
- [x] All 5 existing contract link tests pass unchanged (backwards compatible)
- [x] New test: `createClaimCommands` — claims 2 DemoBear NFTs + SUI coin, filters assets by type, composes separate `transferObjects` calls, verifies link marked as claimed on-chain