### PR TITLE
fix(deepbook-v3): set sender on read-only query transactions

### DIFF
--- a/.changeset/deepbook-jsonrpc-setsender.md
+++ b/.changeset/deepbook-jsonrpc-setsender.md
@@ -1,0 +1,5 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Set the transaction sender on all read-only query methods so they work under `SuiJsonRpcClient`. Previously these queries built a `Transaction` without calling `tx.setSender(...)`, which was tolerated by the gRPC core client (it substitutes `0x0` for a missing sender during resolution) but failed under JSON-RPC with `Missing transaction sender`. JSON-RPC is scheduled to be sunset on July 31, 2026 — migrate to `SuiGrpcClient` when possible.

--- a/packages/deepbook-v3/src/queries/accountQueries.ts
+++ b/packages/deepbook-v3/src/queries/accountQueries.ts
@@ -18,6 +18,7 @@ export class AccountQueries {
 
 	async account(poolKey: string, managerKey: string): Promise<AccountInfo> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -60,6 +61,7 @@ export class AccountQueries {
 
 	async lockedBalance(poolKey: string, balanceManagerKey: string): Promise<LockedBalances> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -83,6 +85,7 @@ export class AccountQueries {
 
 	async getPoolDeepPrice(poolKey: string): Promise<PoolDeepPrice> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		tx.add(this.#ctx.deepBook.getPoolDeepPrice(poolKey));
 

--- a/packages/deepbook-v3/src/queries/balanceManagerQueries.ts
+++ b/packages/deepbook-v3/src/queries/balanceManagerQueries.ts
@@ -17,6 +17,7 @@ export class BalanceManagerQueries {
 
 	async checkManagerBalance(managerKey: string, coinKey: string): Promise<ManagerBalance> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const coin = this.#ctx.config.getCoin(coinKey);
 
 		tx.add(this.#ctx.balanceManager.checkManagerBalance(managerKey, coinKey));
@@ -41,6 +42,7 @@ export class BalanceManagerQueries {
 		coinKey: string,
 	): Promise<ManagerBalance> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const coin = this.#ctx.config.getCoin(coinKey);
 
 		tx.moveCall({
@@ -74,6 +76,7 @@ export class BalanceManagerQueries {
 		}
 
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const coins = coinKeys.map((coinKey) => this.#ctx.config.getCoin(coinKey));
 
 		for (const managerAddress of managerAddresses) {
@@ -128,6 +131,7 @@ export class BalanceManagerQueries {
 
 	async getBalanceManagerIds(owner: string): Promise<string[]> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.getBalanceManagerIds(owner));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -143,6 +147,7 @@ export class BalanceManagerQueries {
 
 	async accountExists(poolKey: string, managerKey: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.accountExists(poolKey, managerKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/marginManagerQueries.ts
+++ b/packages/deepbook-v3/src/queries/marginManagerQueries.ts
@@ -26,6 +26,7 @@ export class MarginManagerQueries {
 	async getMarginManagerOwner(marginManagerKey: string): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.ownerByPoolKey(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -40,6 +41,7 @@ export class MarginManagerQueries {
 	async getMarginManagerDeepbookPool(marginManagerKey: string): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.deepbookPool(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -54,6 +56,7 @@ export class MarginManagerQueries {
 	async getMarginManagerMarginPoolId(marginManagerKey: string): Promise<string | null> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.marginPoolId(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -69,6 +72,7 @@ export class MarginManagerQueries {
 	async getMarginManagerBorrowedShares(marginManagerKey: string): Promise<BorrowedShares> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.borrowedShares(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -87,6 +91,7 @@ export class MarginManagerQueries {
 	async getMarginManagerBorrowedBaseShares(marginManagerKey: string): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.borrowedBaseShares(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -101,6 +106,7 @@ export class MarginManagerQueries {
 	async getMarginManagerBorrowedQuoteShares(marginManagerKey: string): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.borrowedQuoteShares(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -115,6 +121,7 @@ export class MarginManagerQueries {
 	async getMarginManagerHasBaseDebt(marginManagerKey: string): Promise<boolean> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.hasBaseDebt(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -154,6 +161,7 @@ export class MarginManagerQueries {
 	): Promise<MarginManagerAssets> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.calculateAssets(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -192,6 +200,7 @@ export class MarginManagerQueries {
 		const debtCoinKey = hasBaseDebt ? pool.baseCoin : pool.quoteCoin;
 
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.calculateDebts(manager.poolKey, debtCoinKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -229,6 +238,7 @@ export class MarginManagerQueries {
 	): Promise<MarginManagerState> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.managerState(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -322,6 +332,7 @@ export class MarginManagerQueries {
 		}
 
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		for (const [managerId, poolKey] of entries) {
 			tx.add(this.#ctx.marginManager.managerState(poolKey, managerId));
@@ -419,6 +430,7 @@ export class MarginManagerQueries {
 	): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.baseBalance(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -449,6 +461,7 @@ export class MarginManagerQueries {
 	): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.quoteBalance(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -479,6 +492,7 @@ export class MarginManagerQueries {
 	): Promise<string> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginManager.deepBalance(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -512,6 +526,7 @@ export class MarginManagerQueries {
 		}
 
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		for (const [managerId, poolKey] of entries) {
 			tx.add(this.#ctx.marginManager.baseBalance(poolKey, managerId));

--- a/packages/deepbook-v3/src/queries/marginPoolQueries.ts
+++ b/packages/deepbook-v3/src/queries/marginPoolQueries.ts
@@ -17,6 +17,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolId(coinKey: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.getId(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -30,6 +31,7 @@ export class MarginPoolQueries {
 
 	async isDeepbookPoolAllowed(coinKey: string, deepbookPoolId: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.deepbookPoolAllowed(coinKey, deepbookPoolId));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -43,6 +45,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolTotalSupply(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.totalSupply(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -58,6 +61,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolSupplyShares(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.supplyShares(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -73,6 +77,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolTotalBorrow(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.totalBorrow(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -88,6 +93,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolBorrowShares(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.borrowShares(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -103,6 +109,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolLastUpdateTimestamp(coinKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.lastUpdateTimestamp(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -116,6 +123,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolSupplyCap(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.supplyCap(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -131,6 +139,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolMaxUtilizationRate(coinKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.maxUtilizationRate(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -145,6 +154,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolProtocolSpread(coinKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.protocolSpread(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -159,6 +169,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolMinBorrow(coinKey: string, decimals: number = 6): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.minBorrow(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -174,6 +185,7 @@ export class MarginPoolQueries {
 
 	async getMarginPoolInterestRate(coinKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.interestRate(coinKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -192,6 +204,7 @@ export class MarginPoolQueries {
 		decimals: number = 6,
 	): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.userSupplyShares(coinKey, supplierCapId));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -211,6 +224,7 @@ export class MarginPoolQueries {
 		decimals: number = 6,
 	): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginPool.userSupplyAmount(coinKey, supplierCapId));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/orderQueries.ts
+++ b/packages/deepbook-v3/src/queries/orderQueries.ts
@@ -19,6 +19,7 @@ export class OrderQueries {
 
 	async accountOpenOrders(poolKey: string, managerKey: string): Promise<string[]> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.accountOpenOrders(poolKey, managerKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -33,6 +34,7 @@ export class OrderQueries {
 
 	async getOrder(poolKey: string, orderId: string): Promise<ReturnType<typeof Order.parse> | null> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.getOrder(poolKey, orderId));
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -50,6 +52,7 @@ export class OrderQueries {
 
 	async getOrderNormalized(poolKey: string, orderId: string) {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.getOrder(poolKey, orderId));
 		const res = await this.#ctx.client.core.simulateTransaction({
 			transaction: tx,
@@ -95,6 +98,7 @@ export class OrderQueries {
 		orderIds: string[],
 	): Promise<ReturnType<typeof Order.parse>[] | null> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.getOrders(poolKey, orderIds));
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -117,6 +121,7 @@ export class OrderQueries {
 		isBid: boolean,
 	): Promise<Level2Range> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseCoin = this.#ctx.config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#ctx.config.getCoin(pool.quoteCoin);
@@ -144,6 +149,7 @@ export class OrderQueries {
 
 	async getLevel2TicksFromMid(poolKey: string, ticks: number): Promise<Level2TicksFromMid> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseCoin = this.#ctx.config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#ctx.config.getCoin(pool.quoteCoin);
@@ -185,6 +191,7 @@ export class OrderQueries {
 		managerKey: string,
 	): Promise<ReturnType<typeof Order.parse>[] | []> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.getAccountOrderDetails(poolKey, managerKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/poolQueries.ts
+++ b/packages/deepbook-v3/src/queries/poolQueries.ts
@@ -24,6 +24,7 @@ export class PoolQueries {
 
 	async whitelisted(poolKey: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.whitelisted(poolKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -37,6 +38,7 @@ export class PoolQueries {
 
 	async vaultBalances(poolKey: string): Promise<VaultBalances> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -60,6 +62,7 @@ export class PoolQueries {
 
 	async getPoolIdByAssets(baseType: string, quoteType: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.getPoolIdByAssets(baseType, quoteType));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -72,6 +75,7 @@ export class PoolQueries {
 
 	async midPrice(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		tx.add(this.#ctx.deepBook.midPrice(poolKey));
 
@@ -93,6 +97,7 @@ export class PoolQueries {
 
 	async poolTradeParams(poolKey: string): Promise<PoolTradeParams> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.poolTradeParams(poolKey));
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -113,6 +118,7 @@ export class PoolQueries {
 
 	async poolBookParams(poolKey: string): Promise<PoolBookParams> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -136,6 +142,7 @@ export class PoolQueries {
 
 	async stablePool(poolKey: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.stablePool(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -149,6 +156,7 @@ export class PoolQueries {
 
 	async registeredPool(poolKey: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.registeredPool(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -162,6 +170,7 @@ export class PoolQueries {
 
 	async poolTradeParamsNext(poolKey: string): Promise<PoolTradeParams> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.poolTradeParamsNext(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -182,6 +191,7 @@ export class PoolQueries {
 
 	async quorum(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.quorum(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -196,6 +206,7 @@ export class PoolQueries {
 
 	async poolId(poolKey: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.poolId(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -209,6 +220,7 @@ export class PoolQueries {
 
 	async canPlaceLimitOrder(params: CanPlaceLimitOrderParams): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.canPlaceLimitOrder(params));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -222,6 +234,7 @@ export class PoolQueries {
 
 	async canPlaceMarketOrder(params: CanPlaceMarketOrderParams): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.canPlaceMarketOrder(params));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -235,6 +248,7 @@ export class PoolQueries {
 
 	async checkMarketOrderParams(poolKey: string, quantity: number | bigint): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.checkMarketOrderParams(poolKey, quantity));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -253,6 +267,7 @@ export class PoolQueries {
 		expireTimestamp: number,
 	): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.checkLimitOrderParams(poolKey, price, quantity, expireTimestamp));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/quantityQueries.ts
+++ b/packages/deepbook-v3/src/queries/quantityQueries.ts
@@ -27,6 +27,7 @@ export class QuantityQueries {
 		baseQuantity: number | bigint,
 	): Promise<QuoteQuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -54,6 +55,7 @@ export class QuantityQueries {
 		quoteQuantity: number | bigint,
 	): Promise<BaseQuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -82,6 +84,7 @@ export class QuantityQueries {
 		quoteQuantity: number | bigint,
 	): Promise<QuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -110,6 +113,7 @@ export class QuantityQueries {
 		baseQuantity: number | bigint,
 	): Promise<QuoteQuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -137,6 +141,7 @@ export class QuantityQueries {
 		quoteQuantity: number | bigint,
 	): Promise<BaseQuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -165,6 +170,7 @@ export class QuantityQueries {
 		quoteQuantity: number | bigint,
 	): Promise<QuantityOut> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -194,6 +200,7 @@ export class QuantityQueries {
 		payWithDeep: boolean,
 	): Promise<BaseQuantityIn> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -221,6 +228,7 @@ export class QuantityQueries {
 		payWithDeep: boolean,
 	): Promise<QuoteQuantityIn> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -248,6 +256,7 @@ export class QuantityQueries {
 		price: number | bigint,
 	): Promise<OrderDeepRequiredResult> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.deepBook.getOrderDeepRequired(poolKey, baseQuantity, price));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/referralQueries.ts
+++ b/packages/deepbook-v3/src/queries/referralQueries.ts
@@ -18,6 +18,7 @@ export class ReferralQueries {
 
 	async balanceManagerReferralOwner(referral: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.balanceManager.balanceManagerReferralOwner(referral));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -31,6 +32,7 @@ export class ReferralQueries {
 
 	async getPoolReferralBalances(poolKey: string, referral: string): Promise<ReferralBalances> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		const pool = this.#ctx.config.getPool(poolKey);
 		const baseScalar = this.#ctx.config.getCoin(pool.baseCoin).scalar;
 		const quoteScalar = this.#ctx.config.getCoin(pool.quoteCoin).scalar;
@@ -59,6 +61,7 @@ export class ReferralQueries {
 
 	async balanceManagerReferralPoolId(referral: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.balanceManager.balanceManagerReferralPoolId(referral));
 
@@ -75,6 +78,7 @@ export class ReferralQueries {
 
 	async poolReferralMultiplier(poolKey: string, referral: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 
 		tx.add(this.#ctx.deepBook.poolReferralMultiplier(poolKey, referral));
 
@@ -91,6 +95,7 @@ export class ReferralQueries {
 
 	async getBalanceManagerReferralId(managerKey: string, poolKey: string): Promise<string | null> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.balanceManager.getBalanceManagerReferralId(managerKey, poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/registryQueries.ts
+++ b/packages/deepbook-v3/src/queries/registryQueries.ts
@@ -18,6 +18,7 @@ export class RegistryQueries {
 
 	async isPoolEnabledForMargin(poolKey: string): Promise<boolean> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.poolEnabled(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -31,6 +32,7 @@ export class RegistryQueries {
 
 	async getMarginManagerIdsForOwner(owner: string): Promise<string[]> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.getMarginManagerIds(owner));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -45,6 +47,7 @@ export class RegistryQueries {
 
 	async getBaseMarginPoolId(poolKey: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.baseMarginPoolId(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -59,6 +62,7 @@ export class RegistryQueries {
 
 	async getQuoteMarginPoolId(poolKey: string): Promise<string> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.quoteMarginPoolId(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -73,6 +77,7 @@ export class RegistryQueries {
 
 	async getMinWithdrawRiskRatio(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.minWithdrawRiskRatio(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -87,6 +92,7 @@ export class RegistryQueries {
 
 	async getMinBorrowRiskRatio(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.minBorrowRiskRatio(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -101,6 +107,7 @@ export class RegistryQueries {
 
 	async getLiquidationRiskRatio(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.liquidationRiskRatio(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -115,6 +122,7 @@ export class RegistryQueries {
 
 	async getTargetLiquidationRiskRatio(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.targetLiquidationRiskRatio(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -129,6 +137,7 @@ export class RegistryQueries {
 
 	async getUserLiquidationReward(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.userLiquidationReward(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -143,6 +152,7 @@ export class RegistryQueries {
 
 	async getPoolLiquidationReward(poolKey: string): Promise<number> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.poolLiquidationReward(poolKey));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -157,6 +167,7 @@ export class RegistryQueries {
 
 	async getAllowedMaintainers(): Promise<string[]> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.allowedMaintainers());
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -171,6 +182,7 @@ export class RegistryQueries {
 
 	async getAllowedPauseCaps(): Promise<string[]> {
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginRegistry.allowedPauseCaps());
 
 		const res = await this.#ctx.client.core.simulateTransaction({

--- a/packages/deepbook-v3/src/queries/tpslQueries.ts
+++ b/packages/deepbook-v3/src/queries/tpslQueries.ts
@@ -16,6 +16,7 @@ export class TPSLQueries {
 	async getConditionalOrderIds(marginManagerKey: string): Promise<string[]> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginTPSL.conditionalOrderIds(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -41,6 +42,7 @@ export class TPSLQueries {
 	async getLowestTriggerAbovePrice(marginManagerKey: string): Promise<bigint> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginTPSL.lowestTriggerAbovePrice(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({
@@ -65,6 +67,7 @@ export class TPSLQueries {
 	async getHighestTriggerBelowPrice(marginManagerKey: string): Promise<bigint> {
 		const manager = this.#ctx.config.getMarginManager(marginManagerKey);
 		const tx = new Transaction();
+		tx.setSender(this.#ctx.address);
 		tx.add(this.#ctx.marginTPSL.highestTriggerBelowPrice(manager.poolKey, manager.address));
 
 		const res = await this.#ctx.client.core.simulateTransaction({


### PR DESCRIPTION
## Description

Every read-only query method in `packages/deepbook-v3/src/queries/` builds its own `Transaction`, adds a Move call, and simulates it — but none of them ever call `tx.setSender(...)`. This is tolerated under `SuiGrpcClient` because its core resolution plugin silently substitutes `0x0` for a missing sender. `SuiJsonRpcClient` has no such substitution, so every single query (e.g. `client.deepbook.whitelisted('SUI_USDC')`) throws:

```
Error: Missing transaction sender
  at TransactionDataBuilder.build
  at JSONRpcCoreClient.simulateTransaction
  at PoolQueries.whitelisted
```

This affects real users today (e.g. market-maker setups still on JSON-RPC) and will continue to until the JSON-RPC sunset on **July 31, 2026**.

The fix is a one-liner per internal `Transaction` construction:

```ts
const tx = new Transaction();
tx.setSender(this.#ctx.address);
```

applied to every query method across the ten affected modules (88 total insertions). `QueryContext.address` is already populated via `normalizeSuiAddress(address)` in `DeepBookConfig`, so no new plumbing is needed. The gRPC path is unchanged (an explicit sender takes precedence over the resolution plugin's default).

Follows the pattern of #1018, but applied consistently across all query modules rather than a subset.

## Test plan

- [x] `pnpm --filter @mysten/deepbook-v3 tsc --noEmit` passes.
- [x] `pnpm exec prettier -c` clean.
- [ ] Manually re-run a JSON-RPC reproduction of `client.deepbook.whitelisted('SUI_USDC')` on mainnet — should return `true` instead of throwing `Missing transaction sender`.
- [ ] Spot-check gRPC parity (one read-only query from each module) to confirm no behavioral regression.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.