### PR TITLE
feat(zksend): composable claim via ZkSendLink.claimFlow()

### DIFF
--- a/.changeset/zksend-composable-claim.md
+++ b/.changeset/zksend-composable-claim.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zksend': minor
+---
+
+Add `ZkSendLink.claimFlow()` — returns `{ init, assets, finalize }` for composing a caller-driven claim into an existing transaction. `init` is the `init_claim` (or `reclaim`) thunk, each `asset.argument` is a lazy `TransactionObjectArgument` that emits the backing `claim<T>` move call the first time it's used, and `finalize` closes out the claim proof. Enables flows like claiming an NFT and passing it directly into another on-chain object in the same transaction. Apps using this API must provide their own sponsorship for non-standard claim transactions.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
 	"pnpm": {
 		"overrides": {
 			"axios": "^1.15.0",
-			"lodash": ">=4.18.0"
+			"lodash": ">=4.18.0",
+			"hono": ">=4.12.14",
+			"protobufjs": ">=7.5.5"
 		}
 	},
 	"engines": {

--- a/packages/docs/content/zksend/composable-claim.mdx
+++ b/packages/docs/content/zksend/composable-claim.mdx
@@ -1,0 +1,72 @@
+---
+title: Composable Claims
+description: Claim a zkSend link and use the assets in the same transaction
+---
+
+By default, `link.claimAssets(address)` builds a claim transaction that transfers every asset to the
+recipient and submits it via a Mysten-hosted sponsor. If you want to _use_ a claimed object in the
+same transaction — for example, inserting a claimed NFT into another on-chain object, staking a
+claimed coin, or depositing into a vault — use `link.claimFlow()` to compose the claim into your own
+transaction.
+
+## How it works
+
+`link.claimFlow()` returns three transaction thunks:
+
+- **`init`** — adds the `init_claim` (or `reclaim`) move call that creates the claim proof.
+- **`assets`** — an array of claimable assets. Each `asset.argument` is a lazy
+  `TransactionObjectArgument` that emits the backing `claim<T>` move call the first time it's used.
+- **`finalize`** — consumes the claim proof. Must be added after every asset is claimed.
+
+```ts
+import { Transaction } from '@mysten/sui/transactions';
+
+const tx = new Transaction();
+tx.setSender(claimLink.keypair!.toSuiAddress());
+
+const { init, assets, finalize } = claimLink.claimFlow();
+
+tx.add(init);
+
+for (const asset of assets) {
+	if (asset.type === `${PACKAGE_ID}::record::Record`) {
+		// Insert the claimed record directly into the recipient's player object
+		tx.moveCall({
+			target: `${PACKAGE_ID}::player::add_record`,
+			arguments: [tx.object(playerId), asset.argument],
+		});
+	} else {
+		tx.transferObjects([asset.argument], recipient);
+	}
+}
+
+tx.add(finalize);
+```
+
+Every asset in the returned list must be claimed somewhere in the transaction — assets that are
+never used won't create a `claim<T>` command and the transaction will fail. If you only want the
+default claim-and-transfer behavior, use `link.createClaimTransaction(address)` instead.
+
+## Sponsorship
+
+`link.claimAssets(address)` uses a sponsorship flow so the claimer does not need gas to claim the
+assets, but it only accepts the standard `init_claim` → `claim<T>` → transfer → `finalize` shape.
+Transactions built with `claimFlow()` may include extra move calls, so the default sponsor may
+reject them.
+
+Apps using `claimFlow()` are responsible for their own gas and sponsorship. The ephemeral link
+keypair is still the transaction sender (it authorizes the claim), so the typical pattern is dual
+signing: the link keypair signs as sender and your app's sponsor signs for gas.
+
+```ts
+tx.setGasOwner(sponsorAddress);
+const txBytes = await tx.build({ client });
+
+const linkSig = await claimLink.keypair!.signTransaction(txBytes);
+const sponsorSig = await sponsor.signTransaction(txBytes);
+
+const result = await client.core.executeTransaction({
+	transaction: txBytes,
+	signatures: [linkSig.signature, sponsorSig.signature],
+});
+```

--- a/packages/docs/content/zksend/meta.json
+++ b/packages/docs/content/zksend/meta.json
@@ -2,5 +2,5 @@
 	"root": true,
 	"title": "ZkSend",
 	"description": "Send Sui with a link",
-	"pages": ["index", "link-builder"]
+	"pages": ["index", "link-builder", "composable-claim"]
 }

--- a/packages/zksend/src/index.test.ts
+++ b/packages/zksend/src/index.test.ts
@@ -281,6 +281,75 @@ describe('Contract links', () => {
 		}
 	}, 60_000);
 
+	test('createClaimCommands — compose with claimed assets', async () => {
+		const link = client.zksend.linkBuilder({
+			sender: keypair.toSuiAddress(),
+		});
+
+		const bears = await createBears(2);
+
+		for (const bear of bears) {
+			link.addClaimableObject(bear.objectId);
+		}
+
+		link.addClaimableMist(100n);
+
+		const linkUrl = link.getLink();
+
+		await link.create({
+			signer: keypair,
+			waitForTransaction: true,
+		});
+
+		const claimLink = await client.zksend.loadLinkFromUrl(linkUrl);
+		expect(claimLink.assets!.nfts.length).toEqual(2);
+
+		// Build a composable claim transaction
+		const tx = new Transaction();
+		tx.setSender(claimLink.keypair!.toSuiAddress());
+
+		const { assets, finalize } = claimLink.createClaimCommands(tx);
+
+		// Verify assets have type metadata
+		expect(assets.length).toEqual(3); // 2 bears + 1 SUI coin
+		const bearAssets = assets.filter((a) => a.type.includes('::demo_bear::DemoBear'));
+		const coinAssets = assets.filter((a) => !a.type.includes('::demo_bear::DemoBear'));
+		expect(bearAssets.length).toEqual(2);
+		expect(coinAssets.length).toEqual(1);
+
+		// Compose: transfer bears and coins separately (simulates using them in a Move call)
+		tx.transferObjects(
+			bearAssets.map((a) => a.argument),
+			keypair.toSuiAddress(),
+		);
+		tx.transferObjects(
+			coinAssets.map((a) => a.argument),
+			keypair.toSuiAddress(),
+		);
+
+		finalize();
+
+		// Execute with dual signing (ephemeral key is sender, test keypair pays gas)
+		tx.setGasOwner(keypair.toSuiAddress());
+		const txBytes = await tx.build({ client });
+		const ephemeralSig = await claimLink.keypair!.signTransaction(txBytes);
+		const gasSig = await keypair.signTransaction(txBytes);
+
+		const result = await client.executeTransaction({
+			transaction: txBytes,
+			signatures: [ephemeralSig.signature, gasSig.signature],
+		});
+
+		await client.core.waitForTransaction({
+			result,
+			include: { effects: true },
+		});
+
+		// Link should be claimed
+		const link2 = await client.zksend.loadLinkFromUrl(linkUrl);
+		expect(link2.claimed).toEqual(true);
+	}, 30_000);
+
 	test('create link with minted assets', async () => {
 		const link = client.zksend.linkBuilder({
 			sender: keypair.toSuiAddress(),

--- a/packages/zksend/src/index.test.ts
+++ b/packages/zksend/src/index.test.ts
@@ -29,7 +29,7 @@ const keypair = Ed25519Keypair.fromSecretKey(
 // Automatically get gas from testnet is not working reliably, manually request gas via discord,
 // or uncomment the beforeAll and gas function below
 beforeAll(async () => {
-	const balance = await client.core.getBalance({
+	const balance = await client.getBalance({
 		owner: keypair.toSuiAddress(),
 	});
 
@@ -84,7 +84,7 @@ describe('Contract links', () => {
 
 		const claim = await claimLink.claimAssets(keypair.toSuiAddress());
 
-		const res = await client.core.waitForTransaction({
+		const res = await client.waitForTransaction({
 			result: claim,
 			include: {
 				effects: true,
@@ -124,7 +124,7 @@ describe('Contract links', () => {
 			waitForTransaction: true,
 		});
 
-		await client.core.waitForTransaction({ result: createResult });
+		await client.waitForTransaction({ result: createResult });
 
 		const lostLink = await client.zksend.loadLink({
 			address: linkKp.toSuiAddress(),
@@ -140,7 +140,7 @@ describe('Contract links', () => {
 			client,
 		});
 
-		await client.core.waitForTransaction({ digest: result.Transaction!.digest });
+		await client.waitForTransaction({ digest: result.Transaction!.digest });
 
 		const claimLink = await client.zksend.loadLinkFromUrl(url);
 
@@ -156,7 +156,7 @@ describe('Contract links', () => {
 
 		const claim = await claimLink.claimAssets(keypair.toSuiAddress());
 
-		const res = await client.core.waitForTransaction({
+		const res = await client.waitForTransaction({
 			result: claim,
 			include: {
 				effects: true,
@@ -195,7 +195,7 @@ describe('Contract links', () => {
 			waitForTransaction: true,
 		});
 
-		await client.core.waitForTransaction({ result: createResult });
+		await client.waitForTransaction({ result: createResult });
 
 		const lostLink = await client.zksend.loadLink({
 			address: linkKp.toSuiAddress(),
@@ -206,7 +206,7 @@ describe('Contract links', () => {
 			sign: async (tx) => (await keypair.signTransaction(tx)).signature,
 		});
 
-		const result = await client.core.waitForTransaction({
+		const result = await client.waitForTransaction({
 			digest: claimTx!.digest,
 			include: {
 				effects: true,
@@ -243,7 +243,7 @@ describe('Contract links', () => {
 			client,
 		});
 
-		await client.core.waitForTransaction({ digest: result.Transaction!.digest });
+		await client.waitForTransaction({ digest: result.Transaction!.digest });
 
 		for (const link of links) {
 			const linkUrl = link.getLink();
@@ -265,7 +265,7 @@ describe('Contract links', () => {
 
 			const claim = await claimLink.claimAssets(keypair.toSuiAddress());
 
-			const res = await client.core.waitForTransaction({
+			const res = await client.waitForTransaction({
 				digest: claim.Transaction!.digest,
 				include: {
 					effects: true,
@@ -281,7 +281,7 @@ describe('Contract links', () => {
 		}
 	}, 60_000);
 
-	test('createClaimCommands — compose with claimed assets', async () => {
+	test('claimFlow — compose with claimed assets', async () => {
 		const link = client.zksend.linkBuilder({
 			sender: keypair.toSuiAddress(),
 		});
@@ -304,20 +304,19 @@ describe('Contract links', () => {
 		const claimLink = await client.zksend.loadLinkFromUrl(linkUrl);
 		expect(claimLink.assets!.nfts.length).toEqual(2);
 
-		// Build a composable claim transaction
 		const tx = new Transaction();
 		tx.setSender(claimLink.keypair!.toSuiAddress());
 
-		const { assets, finalize } = claimLink.createClaimCommands(tx);
+		const { init, assets, finalize } = claimLink.claimFlow();
+		expect(assets.length).toEqual(3);
 
-		// Verify assets have type metadata
-		expect(assets.length).toEqual(3); // 2 bears + 1 SUI coin
 		const bearAssets = assets.filter((a) => a.type.includes('::demo_bear::DemoBear'));
 		const coinAssets = assets.filter((a) => !a.type.includes('::demo_bear::DemoBear'));
 		expect(bearAssets.length).toEqual(2);
 		expect(coinAssets.length).toEqual(1);
 
-		// Compose: transfer bears and coins separately (simulates using them in a Move call)
+		tx.add(init);
+
 		tx.transferObjects(
 			bearAssets.map((a) => a.argument),
 			keypair.toSuiAddress(),
@@ -327,9 +326,8 @@ describe('Contract links', () => {
 			keypair.toSuiAddress(),
 		);
 
-		finalize();
+		tx.add(finalize);
 
-		// Execute with dual signing (ephemeral key is sender, test keypair pays gas)
 		tx.setGasOwner(keypair.toSuiAddress());
 		const txBytes = await tx.build({ client });
 		const ephemeralSig = await claimLink.keypair!.signTransaction(txBytes);
@@ -340,12 +338,11 @@ describe('Contract links', () => {
 			signatures: [ephemeralSig.signature, gasSig.signature],
 		});
 
-		await client.core.waitForTransaction({
-			result,
+		await client.waitForTransaction({
+			digest: result.Transaction!.digest,
 			include: { effects: true },
 		});
 
-		// Link should be claimed
 		const link2 = await client.zksend.loadLinkFromUrl(linkUrl);
 		expect(link2.claimed).toEqual(true);
 	}, 30_000);
@@ -393,7 +390,7 @@ describe('Contract links', () => {
 
 		const claim = await claimLink.claimAssets(keypair.toSuiAddress());
 
-		const res = await client.core.waitForTransaction({
+		const res = await client.waitForTransaction({
 			result: claim,
 			include: {
 				effects: true,
@@ -433,11 +430,11 @@ async function createBears(totalBears: number) {
 		client,
 	});
 
-	await client.core.waitForTransaction({
+	await client.waitForTransaction({
 		digest: res.Transaction!.digest,
 	});
 
-	const objects = await client.core.getObjects({
+	const objects = await client.getObjects({
 		objectIds: res
 			.Transaction!.effects!.changedObjects.filter((obj) => obj.idOperation === 'Created')
 			.map((obj) => obj.objectId),

--- a/packages/zksend/src/index.ts
+++ b/packages/zksend/src/index.ts
@@ -20,4 +20,4 @@ export { ZkSendLink, type ZkSendLinkOptions } from './links/claim.js';
 export { type ZkBagContractOptions, ZkBag } from './links/zk-bag.js';
 export { MAINNET_CONTRACT_IDS, TESTNET_CONTRACT_IDS } from './links/zk-bag.js';
 
-export { isClaimTransaction } from './links/utils.js';
+export { isClaimTransaction, type ClaimedAsset } from './links/utils.js';

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -242,6 +242,16 @@ export class ZkSendLink {
 			throw new Error('Cannot claim assets without the links keypair');
 		}
 
+		if (this.claimed) {
+			throw new Error('Assets have already been claimed');
+		}
+
+		if (!this.assets) {
+			throw new Error(
+				'Link assets have not been loaded. Call `loadAssets()` or use `ZkSendLink.fromUrl()` / `ZkSendLink.fromAddress()` before calling `claimFlow()`.',
+			);
+		}
+
 		const storeId = this.#contract.ids.bagStoreId;
 		const initCommand = reclaim
 			? this.#contract.reclaim({ arguments: [storeId, this.address] })
@@ -256,7 +266,7 @@ export class ZkSendLink {
 			return result;
 		};
 
-		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
+		const objects = [...this.assets.coins, ...this.assets.nfts];
 
 		const assets: ClaimedAsset[] = objects.map((object) => ({
 			type: object.type,

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -4,7 +4,6 @@
 import { bcs } from '@mysten/sui/bcs';
 import type { Keypair } from '@mysten/sui/cryptography';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import type { TransactionObjectArgument } from '@mysten/sui/transactions';
 import { Transaction } from '@mysten/sui/transactions';
 import {
 	fromBase64,
@@ -16,7 +15,7 @@ import {
 
 import type { ZkSendLinkBuilderOptions } from './builder.js';
 import { ZkSendLinkBuilder } from './builder.js';
-import type { LinkAssets } from './utils.js';
+import type { ClaimedAsset, LinkAssets } from './utils.js';
 import type { ZkBagContractOptions } from './zk-bag.js';
 import { getContractIds, ZkBag, ZkBagStruct } from './zk-bag.js';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
@@ -208,6 +207,10 @@ export class ZkSendLink {
 		return result;
 	}
 
+	/**
+	 * Build a complete claim transaction that transfers all assets to `address`.
+	 * For composable claims, use {@link createClaimCommands} instead.
+	 */
 	createClaimTransaction(
 		address: string,
 		{
@@ -216,13 +219,52 @@ export class ZkSendLink {
 			reclaim?: boolean;
 		} = {},
 	) {
-		if (!this.keypair && !reclaim) {
-			throw new Error('Cannot claim assets without the links keypair');
-		}
-
 		const tx = new Transaction();
 		const sender = reclaim ? address : this.keypair!.toSuiAddress();
 		tx.setSender(sender);
+
+		const { assets, finalize } = this.createClaimCommands(tx, { reclaim });
+
+		if (assets.length > 0) {
+			tx.transferObjects(
+				assets.map((a) => a.argument),
+				address,
+			);
+		}
+
+		finalize();
+
+		return tx;
+	}
+
+	/**
+	 * Add claim commands to an existing transaction and return the claimed
+	 * assets for composition. The caller is responsible for transferring or
+	 * using every asset and calling `finalize()` when done.
+	 *
+	 * @example
+	 * ```ts
+	 * const tx = new Transaction();
+	 * const { assets, finalize } = link.createClaimCommands(tx);
+	 *
+	 * const record = assets.find(a => a.type.includes('::record::Record'));
+	 * tx.moveCall({ target: 'player::add_record', arguments: [player, record.argument] });
+	 * tx.transferObjects(assets.filter(a => a !== record).map(a => a.argument), address);
+	 *
+	 * finalize();
+	 * ```
+	 */
+	createClaimCommands(
+		tx: Transaction,
+		{
+			reclaim,
+		}: {
+			reclaim?: boolean;
+		} = {},
+	): { assets: ClaimedAsset[]; finalize: () => void } {
+		if (!this.keypair && !reclaim) {
+			throw new Error('Cannot claim assets without the links keypair');
+		}
 
 		const store = tx.object(this.#contract.ids.bagStoreId);
 		const command = reclaim
@@ -231,34 +273,30 @@ export class ZkSendLink {
 
 		const [bag, proof] = tx.add(command);
 
-		const objectsToTransfer: TransactionObjectArgument[] = [];
-
 		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
 
-		for (const object of objects) {
-			objectsToTransfer.push(
-				this.#contract.claim({
-					arguments: [
-						bag,
-						proof,
-						tx.receivingRef({
-							objectId: object.objectId,
-							version: object.version,
-							digest: object.digest,
-						}),
-					],
-					typeArguments: [object.type],
-				}),
-			);
-		}
+		const assets: ClaimedAsset[] = objects.map((object) => ({
+			argument: this.#contract.claim({
+				arguments: [
+					bag,
+					proof,
+					tx.receivingRef({
+						objectId: object.objectId,
+						version: object.version,
+						digest: object.digest,
+					}),
+				],
+				typeArguments: [object.type],
+			}),
+			type: object.type,
+			objectId: object.objectId,
+		}));
 
-		if (objectsToTransfer.length > 0) {
-			tx.transferObjects(objectsToTransfer, address);
-		}
+		const finalize = () => {
+			tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
+		};
 
-		tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
-
-		return tx;
+		return { assets, finalize };
 	}
 
 	async createRegenerateTransaction(

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -207,10 +207,6 @@ export class ZkSendLink {
 		return result;
 	}
 
-	/**
-	 * Build a complete claim transaction that transfers all assets to `address`.
-	 * For composable claims, use {@link createClaimCommands} instead.
-	 */
 	createClaimTransaction(
 		address: string,
 		{
@@ -220,10 +216,10 @@ export class ZkSendLink {
 		} = {},
 	) {
 		const tx = new Transaction();
-		const sender = reclaim ? address : this.keypair!.toSuiAddress();
-		tx.setSender(sender);
+		tx.setSender(reclaim ? address : this.keypair!.toSuiAddress());
 
-		const { assets, finalize } = this.createClaimCommands(tx, { reclaim });
+		const { init, assets, finalize } = this.claimFlow({ reclaim });
+		tx.add(init);
 
 		if (assets.length > 0) {
 			tx.transferObjects(
@@ -232,71 +228,55 @@ export class ZkSendLink {
 			);
 		}
 
-		finalize();
+		tx.add(finalize);
 
 		return tx;
 	}
 
-	/**
-	 * Add claim commands to an existing transaction and return the claimed
-	 * assets for composition. The caller is responsible for transferring or
-	 * using every asset and calling `finalize()` when done.
-	 *
-	 * @example
-	 * ```ts
-	 * const tx = new Transaction();
-	 * const { assets, finalize } = link.createClaimCommands(tx);
-	 *
-	 * const record = assets.find(a => a.type.includes('::record::Record'));
-	 * tx.moveCall({ target: 'player::add_record', arguments: [player, record.argument] });
-	 * tx.transferObjects(assets.filter(a => a !== record).map(a => a.argument), address);
-	 *
-	 * finalize();
-	 * ```
-	 */
-	createClaimCommands(
-		tx: Transaction,
-		{
-			reclaim,
-		}: {
-			reclaim?: boolean;
-		} = {},
-	): { assets: ClaimedAsset[]; finalize: () => void } {
+	claimFlow({
+		reclaim,
+	}: {
+		reclaim?: boolean;
+	} = {}) {
 		if (!this.keypair && !reclaim) {
 			throw new Error('Cannot claim assets without the links keypair');
 		}
 
-		const store = tx.object(this.#contract.ids.bagStoreId);
-		const command = reclaim
-			? this.#contract.reclaim({ arguments: [store, this.address] })
-			: this.#contract.init_claim({ arguments: [store] });
-
-		const [bag, proof] = tx.add(command);
+		const storeId = this.#contract.ids.bagStoreId;
+		const init = reclaim
+			? this.#contract.reclaim({ arguments: [storeId, this.address] })
+			: this.#contract.init_claim({ arguments: [storeId] });
 
 		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
 
 		const assets: ClaimedAsset[] = objects.map((object) => ({
-			argument: this.#contract.claim({
-				arguments: [
-					bag,
-					proof,
-					tx.receivingRef({
-						objectId: object.objectId,
-						version: object.version,
-						digest: object.digest,
-					}),
-				],
-				typeArguments: [object.type],
-			}),
 			type: object.type,
 			objectId: object.objectId,
+			argument: (tx: Transaction) => {
+				const [bag, proof] = tx.add(init);
+				return tx.add(
+					this.#contract.claim({
+						arguments: [
+							bag,
+							proof,
+							tx.receivingRef({
+								objectId: object.objectId,
+								version: object.version,
+								digest: object.digest,
+							}),
+						],
+						typeArguments: [object.type],
+					}),
+				);
+			},
 		}));
 
-		const finalize = () => {
+		const finalize = (tx: Transaction) => {
+			const [bag, proof] = tx.add(init);
 			tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
 		};
 
-		return { assets, finalize };
+		return { init, assets, finalize };
 	}
 
 	async createRegenerateTransaction(

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -247,11 +247,13 @@ export class ZkSendLink {
 			? this.#contract.reclaim({ arguments: [storeId, this.address] })
 			: this.#contract.init_claim({ arguments: [storeId] });
 
-		let bagProof: ReturnType<typeof initCommand> | undefined;
+		let bag: ReturnType<typeof initCommand>[0] | undefined;
+		let proof: ReturnType<typeof initCommand>[1] | undefined;
 
 		const init = (tx: Transaction) => {
-			bagProof = tx.add(initCommand);
-			return bagProof;
+			const result = tx.add(initCommand);
+			[bag, proof] = result;
+			return result;
 		};
 
 		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
@@ -263,8 +265,8 @@ export class ZkSendLink {
 				tx.add(
 					this.#contract.claim({
 						arguments: [
-							bagProof![0],
-							bagProof![1],
+							bag!,
+							proof!,
 							tx.receivingRef({
 								objectId: object.objectId,
 								version: object.version,
@@ -277,7 +279,7 @@ export class ZkSendLink {
 		}));
 
 		const finalize = (tx: Transaction) => {
-			tx.add(this.#contract.finalize({ arguments: [bagProof![0], bagProof![1]] }));
+			tx.add(this.#contract.finalize({ arguments: [bag!, proof!] }));
 		};
 
 		return { init, assets, finalize };

--- a/packages/zksend/src/links/claim.ts
+++ b/packages/zksend/src/links/claim.ts
@@ -243,22 +243,28 @@ export class ZkSendLink {
 		}
 
 		const storeId = this.#contract.ids.bagStoreId;
-		const init = reclaim
+		const initCommand = reclaim
 			? this.#contract.reclaim({ arguments: [storeId, this.address] })
 			: this.#contract.init_claim({ arguments: [storeId] });
+
+		let bagProof: ReturnType<typeof initCommand> | undefined;
+
+		const init = (tx: Transaction) => {
+			bagProof = tx.add(initCommand);
+			return bagProof;
+		};
 
 		const objects = [...(this.assets?.coins ?? []), ...(this.assets?.nfts ?? [])];
 
 		const assets: ClaimedAsset[] = objects.map((object) => ({
 			type: object.type,
 			objectId: object.objectId,
-			argument: (tx: Transaction) => {
-				const [bag, proof] = tx.add(init);
-				return tx.add(
+			argument: (tx: Transaction) =>
+				tx.add(
 					this.#contract.claim({
 						arguments: [
-							bag,
-							proof,
+							bagProof![0],
+							bagProof![1],
 							tx.receivingRef({
 								objectId: object.objectId,
 								version: object.version,
@@ -267,13 +273,11 @@ export class ZkSendLink {
 						],
 						typeArguments: [object.type],
 					}),
-				);
-			},
+				),
 		}));
 
 		const finalize = (tx: Transaction) => {
-			const [bag, proof] = tx.add(init);
-			tx.add(this.#contract.finalize({ arguments: [bag, proof] }));
+			tx.add(this.#contract.finalize({ arguments: [bagProof![0], bagProof![1]] }));
 		};
 
 		return { init, assets, finalize };

--- a/packages/zksend/src/links/utils.ts
+++ b/packages/zksend/src/links/utils.ts
@@ -1,7 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Transaction } from '@mysten/sui/transactions';
+import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
+
+/** A claimed asset paired with its on-chain type, available for composition within a claim transaction. */
+export interface ClaimedAsset {
+	/** Transaction argument representing the claimed object — pass to moveCall or transferObjects. */
+	argument: TransactionObjectArgument;
+	/** Full Move type of the object (e.g. "0x...::record::Record"). */
+	type: string;
+	/** Object ID of the asset in the link's bag. */
+	objectId: string;
+}
 
 export interface LinkAssets {
 	balances: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   axios: ^1.15.0
   lodash: '>=4.18.0'
+  hono: '>=4.12.14'
+  protobufjs: '>=7.5.5'
 
 importers:
 
@@ -1435,7 +1437,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: ^1.19.13
-        version: 1.19.13(hono@4.12.12)
+        version: 1.19.13(hono@4.12.14)
       '@mysten/codegen':
         specifier: workspace:^
         version: link:../codegen
@@ -1464,8 +1466,8 @@ importers:
         specifier: ^5.1.2
         version: 5.2.0(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       hono:
-        specifier: ^4.12.12
-        version: 4.12.12
+        specifier: '>=4.12.14'
+        version: 4.12.14
       react:
         specifier: ^19.2.3
         version: 19.2.4
@@ -2450,7 +2452,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.14'
 
   '@ianvs/prettier-plugin-sort-imports@4.7.1':
     resolution: {integrity: sha512-jmTNYGlg95tlsoG3JLCcuC4BrFELJtLirLAkQW/71lXSyOhVt/Xj7xWbbGcuVbNq1gwWgSyMrPjJc9Z30hynVw==}
@@ -6791,8 +6793,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -7153,8 +7155,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.0:
@@ -8440,8 +8442,8 @@ packages:
     resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
     engines: {node: '>=18'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   proxy-compare@3.0.1:
@@ -11015,14 +11017,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       yargs: 17.7.2
 
   '@hapi/address@5.1.1':
@@ -11074,9 +11076,9 @@ snapshots:
 
   '@hey-api/types@0.1.2': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@ianvs/prettier-plugin-sort-imports@4.7.1(@vue/compiler-sfc@3.5.31)(prettier@3.8.1)':
     dependencies:
@@ -15049,7 +15051,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -15641,7 +15643,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       tar-fs: 2.1.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -15914,7 +15916,7 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -16203,7 +16205,7 @@ snapshots:
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       retry-request: 8.0.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -16380,7 +16382,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   hookable@6.1.0: {}
 
@@ -17941,9 +17943,9 @@ snapshots:
 
   proto3-json-serializer@3.0.4:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
 
-  protobufjs@7.5.4:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Description

Builds on @tamashi095's #1021 to add composable claim support — letting apps claim a zkSend link and *use* the claimed objects (Move calls, staking, dynamic-field insertions, etc.) in the same transaction, rather than the default claim-and-transfer flow.

Credit to @tamashi095 for the original PR (#1021). This PR cherry-picks their initial commit and reshapes the API around `tx.add`-compatible thunks to match the SDK-building patterns in `packages/docs/content/sui/sdk-building.mdx`.

### API

```ts
const { init, assets, finalize } = link.claimFlow();

tx.add(init);

for (const asset of assets) {
  if (asset.type === MY_TYPE) {
    tx.moveCall({ target: '…', arguments: [asset.argument] });
  } else {
    tx.transferObjects([asset.argument], address);
  }
}

tx.add(finalize);
```

- `init` — `init_claim` (or `reclaim`) thunk. `tx.add(init)` returns `[bag, proof]` if callers want them, and caches them in the `claimFlow` closure for the downstream thunks.
- `asset.argument` — lazy `TransactionObjectArgument`; emits its backing `claim<T>` move call on first use, reading the cached `[bag, proof]` from the closure. Callers must `tx.add(init)` before using any `asset.argument` or `finalize`; using them before `init` throws.
- `finalize` — `(tx) => void` thunk that consumes the claim proof.

`createClaimTransaction(address)` is unchanged externally; internally it's refactored to use `claimFlow` + `transferObjects` + `finalize`.

### Sponsorship caveat

The built-in sponsor used by `link.claimAssets(address)` only accepts the standard `init_claim` → `claim<T>` → transfer → `finalize` shape. Apps using `claimFlow()` with extra commands must provide their own gas and sponsorship (typically dual signing: link keypair as sender, app sponsor for gas). Documented in the new `composable-claim.mdx` page.

### Scope

- No changes to `@mysten/sui`.
- `ClaimedAsset` type re-exported from `@mysten/zksend`.
- New docs page at `packages/docs/content/zksend/composable-claim.mdx`.

## Test plan

- [x] New e2e test \`claimFlow — compose with claimed assets\` — creates a link with 2 DemoBears + 100 mist SUI, loads via URL, calls \`claimFlow()\`, filters assets by Move type, composes two separate \`transferObjects\` commands, signs with dual signers (ephemeral link keypair as sender, test keypair as gas owner), executes, and asserts the link is claimed.
- [x] All 5 pre-existing tests still pass (including \`reclaim links\`, which exercises the refactored \`createClaimTransaction\` reclaim path through the default sponsor).
- [x] \`pnpm --filter @mysten/zksend run oxlint:check && pnpm --filter @mysten/zksend run prettier:check\`
- [x] \`pnpm turbo build --filter=@mysten/zksend\`
- [x] \`pnpm --filter @mysten/docs build:docs && pnpm --filter @mysten/docs validate-docs\`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.