### PR TITLE
docs: correct movePackageService method names in JSON-RPC migration guide

### DIFF
--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -95,22 +95,22 @@ These JSON-RPC methods have direct replacements in the core API:
 
 These JSON-RPC methods can be replaced by calling gRPC service clients directly:
 
-| JSON-RPC Method                     | gRPC Service Replacement          |
-| ----------------------------------- | --------------------------------- |
-| `getCheckpoint`                     | `ledgerService.getCheckpoint`     |
-| `getCheckpoints`                    | `ledgerService.listCheckpoints`   |
-| `getLatestCheckpointSequenceNumber` | `ledgerService.getCheckpoint`     |
-| `getEpochs`                         | `ledgerService.listEpochs`        |
-| `getCurrentEpoch`                   | `ledgerService.getEpoch`          |
-| `getLatestSuiSystemState`           | `ledgerService.getSystemState`    |
-| `getCommitteeInfo`                  | `ledgerService.getCommittee`      |
-| `getValidatorsApy`                  | `ledgerService.getValidators`     |
-| `getProtocolConfig`                 | `ledgerService.getProtocolConfig` |
-| `getNormalizedMoveModule`           | `movePackageService.getModule`    |
-| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`   |
-| `getNormalizedMoveStruct`           | `movePackageService.getStruct`    |
-| `resolveNameServiceAddress`         | `nameService.lookupName`          |
-| `resolveNameServiceNames`           | `nameService.reverseLookupName`   |
+| JSON-RPC Method                     | gRPC Service Replacement                                            |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| `getCheckpoint`                     | `ledgerService.getCheckpoint`                                       |
+| `getCheckpoints`                    | `ledgerService.listCheckpoints`                                     |
+| `getLatestCheckpointSequenceNumber` | `ledgerService.getCheckpoint`                                       |
+| `getEpochs`                         | `ledgerService.listEpochs`                                          |
+| `getCurrentEpoch`                   | `ledgerService.getEpoch`                                            |
+| `getLatestSuiSystemState`           | `ledgerService.getSystemState`                                      |
+| `getCommitteeInfo`                  | `ledgerService.getCommittee`                                        |
+| `getValidatorsApy`                  | `ledgerService.getValidators`                                       |
+| `getProtocolConfig`                 | `ledgerService.getProtocolConfig`                                   |
+| `getNormalizedMoveModule`           | `movePackageService.getPackage` (pick the module from the response) |
+| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                     |
+| `getNormalizedMoveStruct`           | `movePackageService.getDatatype`                                    |
+| `resolveNameServiceAddress`         | `nameService.lookupName`                                            |
+| `resolveNameServiceNames`           | `nameService.reverseLookupName`                                     |
 
 ### Example: Using gRPC Service Clients
 
@@ -130,10 +130,16 @@ const { response } = await client.ledgerService.getCheckpoint({
 // Get current epoch
 const { response: epoch } = await client.ledgerService.getEpoch({});
 
-// Get Move module information
-const { response: module } = await client.movePackageService.getModule({
+// Get Move package information (includes all modules)
+const { response: pkg } = await client.movePackageService.getPackage({
+	packageId: '0x2',
+});
+
+// Get a specific Move datatype (struct or enum)
+const { response: datatype } = await client.movePackageService.getDatatype({
 	packageId: '0x2',
 	moduleName: 'coin',
+	name: 'Coin',
 });
 
 // Resolve SuiNS name

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -95,22 +95,22 @@ These JSON-RPC methods have direct replacements in the core API:
 
 These JSON-RPC methods can be replaced by calling gRPC service clients directly:
 
-| JSON-RPC Method                     | gRPC Service Replacement                                            |
-| ----------------------------------- | ------------------------------------------------------------------- |
-| `getCheckpoint`                     | `ledgerService.getCheckpoint`                                       |
-| `getCheckpoints`                    | `ledgerService.listCheckpoints`                                     |
-| `getLatestCheckpointSequenceNumber` | `ledgerService.getCheckpoint`                                       |
-| `getEpochs`                         | `ledgerService.listEpochs`                                          |
-| `getCurrentEpoch`                   | `ledgerService.getEpoch`                                            |
-| `getLatestSuiSystemState`           | `ledgerService.getSystemState`                                      |
-| `getCommitteeInfo`                  | `ledgerService.getCommittee`                                        |
-| `getValidatorsApy`                  | `ledgerService.getValidators`                                       |
-| `getProtocolConfig`                 | `ledgerService.getProtocolConfig`                                   |
-| `getNormalizedMoveModule`           | `movePackageService.getPackage` (pick the module from the response) |
-| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                     |
-| `getNormalizedMoveStruct`           | `movePackageService.getDatatype`                                    |
-| `resolveNameServiceAddress`         | `nameService.lookupName`                                            |
-| `resolveNameServiceNames`           | `nameService.reverseLookupName`                                     |
+| JSON-RPC Method                     | gRPC Service Replacement                                        |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `getCheckpoint`                     | `ledgerService.getCheckpoint`                                   |
+| `getCheckpoints`                    | `ledgerService.listCheckpoints`                                 |
+| `getLatestCheckpointSequenceNumber` | `ledgerService.getCheckpoint`                                   |
+| `getEpochs`                         | `ledgerService.listEpochs`                                      |
+| `getCurrentEpoch`                   | `ledgerService.getEpoch`                                        |
+| `getLatestSuiSystemState`           | `ledgerService.getSystemState`                                  |
+| `getCommitteeInfo`                  | `ledgerService.getCommittee`                                    |
+| `getValidatorsApy`                  | `ledgerService.getValidators`                                   |
+| `getProtocolConfig`                 | `ledgerService.getProtocolConfig`                               |
+| `getNormalizedMoveModule`           | `movePackageService.getPackage` (response includes all modules) |
+| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                 |
+| `getNormalizedMoveStruct`           | `movePackageService.getDatatype`                                |
+| `resolveNameServiceAddress`         | `nameService.lookupName`                                        |
+| `resolveNameServiceNames`           | `nameService.reverseLookupName`                                 |
 
 ### Example: Using gRPC Service Clients
 


### PR DESCRIPTION
## Description

The JSON-RPC migration guide references two `movePackageService` methods that don't exist on the generated gRPC client:

- `movePackageService.getModule` (table row + code example) — no such method exists
- `movePackageService.getStruct` (table row) — the actual method is `getDatatype` (structs and enums were unified)

The generated `MovePackageServiceClient` only exposes `getPackage`, `getDatatype`, `getFunction`, and `listPackageVersions` (see `packages/sui/src/grpc/proto/sui/rpc/v2/move_package_service.client.ts`).

This PR:
- Updates the `getNormalizedMoveModule` row to point at `getPackage` (the response contains all modules — there's no single-module RPC).
- Updates the `getNormalizedMoveStruct` row to point at `getDatatype`.
- Replaces the broken `getModule` call in the example with working `getPackage` + `getDatatype` calls.

## Test plan

Verified all three methods against testnet with a scratch script:

```
--- getPackage(0x2) ---
modules: 64
first 5 module names: [ 'accumulator', 'accumulator_metadata', 'accumulator_settlement', 'address', 'address_alias' ]

--- getDatatype(0x2::coin::Coin) ---
datatype keys: [ 'abilities', 'typeParameters', 'fields', 'variants', 'typeName', 'definingId', 'module', 'name', 'kind' ]

--- getFunction(0x2::coin::mint) ---
parameter count: 3

--- getModule (should not exist) ---
typeof getModule: undefined
typeof getStruct: undefined
```

None of these RPCs require a read mask — their request messages only contain the identifier fields.

- [x] `pnpm --filter=@mysten/docs lint` passes

---

### AI Assistance Notice

- [ ] This PR was primarily written by AI.
- [x] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)