### PR TITLE
Add excludeGasBudget option to balanceFlows

### DIFF
--- a/.changeset/balance-flows-exclude-gas-budget.md
+++ b/.changeset/balance-flows-exclude-gas-budget.md
@@ -1,0 +1,11 @@
+---
+'@mysten/wallet-sdk': minor
+---
+
+Add an `excludeGasBudget` option to the `balanceFlows` analyzer. When true, the gas budget is not charged against the gas payer's per-address deltas — useful for UIs that display gas fees separately from value flows. The gas coin itself is still tracked, so splits / merges on `tx.gas` account correctly; only the budget deduction is suppressed.
+
+```ts
+await analyze({ balanceFlows }, { transaction, client, excludeGasBudget: true });
+```
+
+Also exports `BalanceFlowsResult` and `BalanceFlowsAnalyzerOptions` from `@mysten/wallet-sdk`.

--- a/.changeset/balance-flows-exclude-gas-budget.md
+++ b/.changeset/balance-flows-exclude-gas-budget.md
@@ -5,7 +5,10 @@
 Add an `excludeGasBudget` option to the `balanceFlows` analyzer. When true, the gas budget is not charged against the gas payer's per-address deltas — useful for UIs that display gas fees separately from value flows. The gas coin itself is still tracked, so splits / merges on `tx.gas` account correctly; only the budget deduction is suppressed.
 
 ```ts
-await analyze({ balanceFlows }, { transaction, client, excludeGasBudget: true });
+await analyze(
+  { balanceFlows },
+  { transaction, client, balanceFlows: { excludeGasBudget: true } },
+);
 ```
 
 Also exports `BalanceFlowsResult` and `BalanceFlowsAnalyzerOptions` from `@mysten/wallet-sdk`.

--- a/packages/wallet-sdk/src/transaction-analyzer/index.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/index.ts
@@ -10,5 +10,6 @@ export type { AnalyzedObject } from './rules/objects.js';
 export type { CoinFlow } from './rules/coin-flows.js';
 export type { CoinValueAnalyzerOptions, CoinValueAnalysis } from './rules/coin-value.js';
 export type { AnalyzedCommandInput } from './rules/inputs.js';
+export type { BalanceFlowsResult, BalanceFlowsAnalyzerOptions } from './rules/balance-flows.js';
 
 export { analyzers } from './rules/index.js';

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/balance-flows.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/balance-flows.ts
@@ -31,12 +31,23 @@ export interface BalanceFlowsResult {
 	sponsor: CoinFlow[] | null;
 }
 
+export interface BalanceFlowsAnalyzerOptions {
+	/**
+	 * When true, the gas budget is not charged against the gas payer's
+	 * deltas. Useful for UI surfaces that display value flows and gas
+	 * fees separately. The gas coin itself is still tracked, so splits
+	 * / merges on `tx.gas` continue to account correctly; only the
+	 * budget deduction is suppressed. Defaults to false.
+	 */
+	excludeGasBudget?: boolean;
+}
+
 const SUI_FRAMEWORK = normalizeSuiAddress('0x2');
 
 export const balanceFlows = createAnalyzer({
 	dependencies: { data, commands, inputs, coins, gasCoins },
 	analyze:
-		() =>
+		({ excludeGasBudget = false }: BalanceFlowsAnalyzerOptions = {}) =>
 		async ({ data, commands, inputs, coins, gasCoins }) => {
 			const issues: TransactionAnalysisIssue[] = [];
 			const trackedBalances = new Map<string, TrackedBalance>();
@@ -295,18 +306,20 @@ export const balanceFlows = createAnalyzer({
 			adjustDelta(normalizedGasOwner, suiType, -gasBalance);
 
 			if (data.gasData.budget) {
-				const budget = BigInt(data.gasData.budget);
-				if (paymentIsEmpty) {
-					adjustDelta(normalizedGasOwner, suiType, -budget);
-				} else {
-					if (budget > gasBalance) {
-						issues.push({
-							message: `Gas budget ${budget} exceeds the gas payment balance ${gasBalance}`,
-						});
+				if (!excludeGasBudget) {
+					const budget = BigInt(data.gasData.budget);
+					if (paymentIsEmpty) {
+						adjustDelta(normalizedGasOwner, suiType, -budget);
+					} else {
+						if (budget > gasBalance) {
+							issues.push({
+								message: `Gas budget ${budget} exceeds the gas payment balance ${gasBalance}`,
+							});
+						}
+						gasCoin.balance -= budget;
 					}
-					gasCoin.balance -= budget;
 				}
-			} else {
+			} else if (!excludeGasBudget) {
 				issues.push({ message: 'Gas budget not set in Transaction' });
 			}
 

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/balance-flows.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/balance-flows.ts
@@ -47,8 +47,9 @@ const SUI_FRAMEWORK = normalizeSuiAddress('0x2');
 export const balanceFlows = createAnalyzer({
 	dependencies: { data, commands, inputs, coins, gasCoins },
 	analyze:
-		({ excludeGasBudget = false }: BalanceFlowsAnalyzerOptions = {}) =>
+		({ balanceFlows: opts = {} }: { balanceFlows?: BalanceFlowsAnalyzerOptions } = {}) =>
 		async ({ data, commands, inputs, coins, gasCoins }) => {
+			const { excludeGasBudget = false } = opts;
 			const issues: TransactionAnalysisIssue[] = [];
 			const trackedBalances = new Map<string, TrackedBalance>();
 			const deltas = new Map<string, Map<string, bigint>>();

--- a/packages/wallet-sdk/test/transaction-analyzer/coin-flows-framework.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/coin-flows-framework.test.ts
@@ -1278,7 +1278,7 @@ describe('balanceFlows - excludeGasBudget', () => {
 
 		const results = await analyze(
 			{ balanceFlows },
-			{ client, transaction: await tx.toJSON(), excludeGasBudget: true },
+			{ client, transaction: await tx.toJSON(), balanceFlows: { excludeGasBudget: true } },
 		);
 
 		expect(results.balanceFlows.issues).toBeUndefined();
@@ -1300,7 +1300,7 @@ describe('balanceFlows - excludeGasBudget', () => {
 
 		const results = await analyze(
 			{ balanceFlows },
-			{ client, transaction: JSON.stringify(json), excludeGasBudget: true },
+			{ client, transaction: JSON.stringify(json), balanceFlows: { excludeGasBudget: true } },
 		);
 
 		expect(results.balanceFlows.issues).toBeUndefined();
@@ -1320,7 +1320,7 @@ describe('balanceFlows - excludeGasBudget', () => {
 
 		const results = await analyze(
 			{ balanceFlows },
-			{ client, transaction: await tx.toJSON(), excludeGasBudget: true },
+			{ client, transaction: await tx.toJSON(), balanceFlows: { excludeGasBudget: true } },
 		);
 
 		const sui = results.balanceFlows.result?.sender.find((f) => f.coinType === SUI);

--- a/packages/wallet-sdk/test/transaction-analyzer/coin-flows-framework.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/coin-flows-framework.test.ts
@@ -1269,3 +1269,73 @@ describe('balanceFlows - issues', () => {
 		).toBe(true);
 	});
 });
+
+describe('balanceFlows - excludeGasBudget', () => {
+	it('omits the gas budget from sender deltas when payment uses a coin', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+
+		const results = await analyze(
+			{ balanceFlows },
+			{ client, transaction: await tx.toJSON(), excludeGasBudget: true },
+		);
+
+		expect(results.balanceFlows.issues).toBeUndefined();
+		// No commands touch the gas coin, so with the budget excluded the
+		// net sender SUI delta is zero.
+		const sui = results.balanceFlows.result?.sender.find((f) => f.coinType === SUI);
+		expect(sui?.amount ?? 0n).toBe(0n);
+	});
+
+	it('omits the gas budget from sender deltas when gas is paid from AB', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.setGasPayment([]);
+		tx.setGasBudget(10_000_000n);
+
+		const json = JSON.parse(await tx.toJSON());
+		json.gasData.payment = [];
+
+		const results = await analyze(
+			{ balanceFlows },
+			{ client, transaction: JSON.stringify(json), excludeGasBudget: true },
+		);
+
+		expect(results.balanceFlows.issues).toBeUndefined();
+		const sui = results.balanceFlows.result?.sender.find((f) => f.coinType === SUI);
+		expect(sui?.amount ?? 0n).toBe(0n);
+	});
+
+	it('still tracks non-gas outflows when excludeGasBudget is true', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		// Transfer 200M SUI from a real coin (not from gas): this outflow
+		// is orthogonal to the gas budget and should still appear.
+		const coin = tx.object(TEST_COIN_1_ID);
+		const [split] = tx.splitCoins(coin, [200_000_000n]);
+		tx.transferObjects([split], tx.pure.address('0x456'));
+
+		const results = await analyze(
+			{ balanceFlows },
+			{ client, transaction: await tx.toJSON(), excludeGasBudget: true },
+		);
+
+		const sui = results.balanceFlows.result?.sender.find((f) => f.coinType === SUI);
+		expect(sui?.amount).toBe(-200_000_000n);
+	});
+
+	it('defaults to including the gas budget', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.setGasBudget(10_000_000n);
+
+		const results = await analyze({ balanceFlows }, { client, transaction: await tx.toJSON() });
+
+		const sui = results.balanceFlows.result?.sender.find((f) => f.coinType === SUI);
+		expect(sui?.amount).toBe(-10_000_000n);
+	});
+});


### PR DESCRIPTION
## Description

Adds an `excludeGasBudget` option to the `balanceFlows` analyzer, passed under a `balanceFlows` key in the `analyze()` options so per-analyzer options stay grouped:

```ts
await analyze(
  { balanceFlows },
  { transaction, client, balanceFlows: { excludeGasBudget: true } },
);
```

When true, the gas budget is not charged against the gas payer's per-address deltas — useful for UIs that display value flows and gas fees separately. The gas coin itself is still tracked so splits / merges on `tx.gas` account correctly; only the budget deduction is suppressed. When paired with `gasData.payment: []` (gas paid from address balance), the `-budget` adjustment to the gas payer is also skipped.

Pattern follows the existing `CoinValueAnalyzerOptions` shape — options are destructured from the analyzer's options arg — but scoped under the analyzer's name to leave room for future options without sibling-name collisions.

Also exports `BalanceFlowsResult` and `BalanceFlowsAnalyzerOptions` from `@mysten/wallet-sdk`.

## Test plan

- `pnpm --filter @mysten/wallet-sdk test` — 96 tests (4 new for `excludeGasBudget`)
- `pnpm --filter @mysten/wallet-sdk run oxlint:check && pnpm --filter @mysten/wallet-sdk run prettier:check` — clean
- `pnpm turbo build --filter=@mysten/wallet-sdk` — clean

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.