### PR TITLE
Expose ownIssues per analyzer and aggregate top-level issues

### DIFF
--- a/.changeset/analyze-issue-aggregation.md
+++ b/.changeset/analyze-issue-aggregation.md
@@ -1,0 +1,18 @@
+---
+'@mysten/wallet-sdk': minor
+---
+
+Improve issue handling on `analyze()`:
+
+- Each analyzer result now carries an additional `ownIssues` field — the issues this analyzer's own `analyze()` emitted, excluding anything inherited from failing dependencies. The existing `issues` field is unchanged (own + inherited).
+- The `analyze()` return object now exposes a top-level `issues` array — the concatenation of every analyzer's `ownIssues` across the whole run (including transitive deps). Each analyzer runs once (memoized by cacheKey), so each issue appears exactly once without needing to dedup.
+- New `AnalyzerOutput<T>` type exported from `@mysten/wallet-sdk`, returned by individual analyzer `analyze()` callbacks (the old union shape). `AnalyzerResult<T>` is what `analyze()` produces per analyzer, with the new `ownIssues` field added to the failure branch.
+
+```ts
+const r = await analyze({ balanceFlows, coinFlows }, { ... });
+
+r.balanceFlows.result      // unchanged
+r.balanceFlows.issues      // unchanged (own + inherited)
+r.balanceFlows.ownIssues   // NEW — only what balanceFlows emitted
+r.issues                   // NEW — every issue, each appearing exactly once
+```

--- a/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
@@ -20,7 +20,7 @@ export function createAnalyzer<
 		transaction: Transaction,
 	) => (analysis: {
 		[k in keyof Deps]: Deps[k] extends Analyzer<infer R, any, any> ? R : never;
-	}) => Promise<AnalyzerResult<T>> | AnalyzerResult<T>;
+	}) => Promise<AnalyzerOutput<T>> | AnalyzerOutput<T>;
 }) {
 	return {
 		cacheKey,
@@ -57,7 +57,7 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 	const tx = Transaction.from(transaction);
 	const analyzerMap = new Map<
 		unknown,
-		(analysis: object) => AnalyzerResult | Promise<AnalyzerResult>
+		(analysis: object) => AnalyzerOutput | Promise<AnalyzerOutput>
 	>();
 
 	function initializeAnalyzer(analyzer: Analyzer<Defined>) {
@@ -86,30 +86,32 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 			),
 		);
 
-		const issues = new Set<TransactionAnalysisIssue>();
+		const inherited = new Set<TransactionAnalysisIssue>();
 
 		for (const dep of Object.values(deps)) {
 			if (dep.issues) {
-				dep.issues.forEach((issue) => issues.add(issue));
+				dep.issues.forEach((issue) => inherited.add(issue));
 			}
 		}
 
-		if (issues.size) {
-			return { issues: [...issues] };
+		if (inherited.size) {
+			return { issues: [...inherited], ownIssues: [] };
 		}
 
 		try {
-			const result = await analyzerMap.get(analyzer.cacheKey ?? analyzer)!(
+			const output = await analyzerMap.get(analyzer.cacheKey ?? analyzer)!(
 				Object.fromEntries(Object.entries(deps).map(([key, dep]) => [key, dep.result])),
 			);
 
-			return result;
+			if (output.issues) {
+				return { issues: output.issues, ownIssues: output.issues };
+			}
+			return { result: output.result };
 		} catch (error) {
-			return {
-				issues: [
-					{ message: `Unexpected error while analyzing transaction: ${(error as Error).message}` },
-				],
+			const issue = {
+				message: `Unexpected error while analyzing transaction: ${(error as Error).message}`,
 			};
+			return { issues: [issue], ownIssues: [issue] };
 		}
 	}
 
@@ -123,13 +125,21 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 		return analysisMap.get(cacheKey)!;
 	}
 
-	return Object.fromEntries(
+	const perAnalyzer = Object.fromEntries(
 		await Promise.all(
 			Object.entries(analyzers).map(async ([key, analyzer]) => [key, await getAnalysis(analyzer)]),
 		),
 	) as {
 		[k in keyof T]: T[k] extends Analyzer<infer R, any, any> ? AnalyzerResult<R> : never;
 	};
+
+	const issues: TransactionAnalysisIssue[] = [];
+	for (const pending of analysisMap.values()) {
+		const result = await pending;
+		if (result.ownIssues) issues.push(...result.ownIssues);
+	}
+
+	return { ...perAnalyzer, issues };
 }
 
 export type Analyzer<
@@ -144,10 +154,10 @@ export type Analyzer<
 	analyze: (
 		options: Options,
 		transaction: Transaction,
-	) => (analysis: Analysis) => AnalyzerResult<T> | Promise<AnalyzerResult<T>>;
+	) => (analysis: Analysis) => AnalyzerOutput<T> | Promise<AnalyzerOutput<T>>;
 };
 
-export type AnalyzerResult<T extends Defined = Defined> =
+export type AnalyzerOutput<T extends Defined = Defined> =
 	| {
 			result: T;
 			issues?: never;
@@ -155,6 +165,18 @@ export type AnalyzerResult<T extends Defined = Defined> =
 	| {
 			issues: TransactionAnalysisIssue[];
 			result?: never;
+	  };
+
+export type AnalyzerResult<T extends Defined = Defined> =
+	| {
+			result: T;
+			issues?: never;
+			ownIssues?: never;
+	  }
+	| {
+			result?: never;
+			issues: TransactionAnalysisIssue[];
+			ownIssues: TransactionAnalysisIssue[];
 	  };
 
 export interface TransactionAnalysisIssue {

--- a/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
@@ -104,7 +104,7 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 			);
 
 			if (output.issues) {
-				return { issues: output.issues, ownIssues: output.issues };
+				return { issues: [...output.issues], ownIssues: [...output.issues] };
 			}
 			return { result: output.result };
 		} catch (error) {

--- a/packages/wallet-sdk/src/transaction-analyzer/index.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { analyze, createAnalyzer } from './analyzer.js';
-export type { AnalyzerResult, TransactionAnalysisIssue } from './analyzer.js';
+export type { AnalyzerResult, AnalyzerOutput, TransactionAnalysisIssue } from './analyzer.js';
 
 export type { AnalyzedCoin } from './rules/coins.js';
 export type { AnalyzedCommandArgument, AnalyzedCommand } from './rules/commands.js';

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
@@ -4,14 +4,14 @@
 import type { Transaction } from '@mysten/sui/transactions';
 import { TransactionDataBuilder } from '@mysten/sui/transactions';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
-import type { AnalyzerResult } from '../analyzer.js';
+import type { AnalyzerOutput } from '../analyzer.js';
 import { createAnalyzer } from '../analyzer.js';
 
 export const bytes = createAnalyzer({
 	cacheKey: 'bytes@1.0.0',
 	analyze:
 		(options: { client: ClientWithCoreApi }, transaction: Transaction) =>
-		async (): Promise<AnalyzerResult<Uint8Array>> => {
+		async (): Promise<AnalyzerOutput<Uint8Array>> => {
 			try {
 				return {
 					result: await transaction.build({ client: options.client }),
@@ -43,7 +43,7 @@ export const transactionResponse = createAnalyzer({
 	dependencies: { bytes },
 	analyze:
 		(options: { client: ClientWithCoreApi; transactionResponse?: SuiClientTypes.Transaction }) =>
-		async ({ bytes }): Promise<AnalyzerResult<SuiClientTypes.Transaction>> => {
+		async ({ bytes }): Promise<AnalyzerOutput<SuiClientTypes.Transaction>> => {
 			try {
 				const result = await options.client.core.simulateTransaction({ transaction: bytes });
 				return {

--- a/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { Transaction } from '@mysten/sui/transactions';
+
+import { analyze, createAnalyzer } from '../../src/transaction-analyzer/analyzer.js';
+import { DEFAULT_SENDER } from '../mocks/mockData.js';
+
+const failingDep = createAnalyzer({
+	cacheKey: 'test-failing-dep',
+	analyze: () => () => ({ issues: [{ message: 'shared-dep failed' }] }),
+});
+
+const analyzerA = createAnalyzer({
+	cacheKey: 'test-analyzer-a',
+	dependencies: { failingDep },
+	analyze: () => () => ({ result: 'a' }),
+});
+
+const analyzerB = createAnalyzer({
+	cacheKey: 'test-analyzer-b',
+	dependencies: { failingDep },
+	analyze: () => () => ({ result: 'b' }),
+});
+
+const leafOk = createAnalyzer({
+	cacheKey: 'test-leaf-ok',
+	analyze: () => () => ({ result: 42 }),
+});
+
+const ownIssuesAnalyzer = createAnalyzer({
+	cacheKey: 'test-own-issues',
+	dependencies: { leafOk },
+	analyze: () => () => ({ issues: [{ message: 'own-issue emitted by this analyzer' }] }),
+});
+
+async function txJson() {
+	const tx = new Transaction();
+	tx.setSender(DEFAULT_SENDER);
+	return tx.toJSON();
+}
+
+describe('analyze — issue handling', () => {
+	it('inherited dep issues populate `issues` but leave `ownIssues` empty', async () => {
+		const r = await analyze({ analyzerA }, { transaction: await txJson() });
+		expect(r.analyzerA.result).toBeUndefined();
+		expect(r.analyzerA.issues).toEqual([{ message: 'shared-dep failed' }]);
+		expect(r.analyzerA.ownIssues).toEqual([]);
+	});
+
+	it('own issues appear in both `issues` and `ownIssues`', async () => {
+		const r = await analyze({ ownIssuesAnalyzer }, { transaction: await txJson() });
+		expect(r.ownIssuesAnalyzer.result).toBeUndefined();
+		expect(r.ownIssuesAnalyzer.issues).toEqual([{ message: 'own-issue emitted by this analyzer' }]);
+		expect(r.ownIssuesAnalyzer.ownIssues).toEqual([
+			{ message: 'own-issue emitted by this analyzer' },
+		]);
+	});
+
+	it('successful analyzers have no issues or ownIssues', async () => {
+		const r = await analyze({ leafOk }, { transaction: await txJson() });
+		expect(r.leafOk.result).toBe(42);
+		expect(r.leafOk.issues).toBeUndefined();
+		expect(r.leafOk.ownIssues).toBeUndefined();
+	});
+
+	it('top-level `issues` reports each failing analyzer exactly once', async () => {
+		const r = await analyze({ analyzerA, analyzerB }, { transaction: await txJson() });
+		expect(r.analyzerA.issues).toEqual([{ message: 'shared-dep failed' }]);
+		expect(r.analyzerB.issues).toEqual([{ message: 'shared-dep failed' }]);
+		expect(r.issues).toEqual([{ message: 'shared-dep failed' }]);
+	});
+
+	it('top-level `issues` includes own-issues from every analyzer, not just top-level ones', async () => {
+		const r = await analyze({ analyzerA, ownIssuesAnalyzer }, { transaction: await txJson() });
+		const messages = r.issues.map((i) => i.message).sort();
+		expect(messages).toEqual(['own-issue emitted by this analyzer', 'shared-dep failed']);
+	});
+
+	it('top-level `issues` is empty when nothing fails', async () => {
+		const r = await analyze({ leafOk }, { transaction: await txJson() });
+		expect(r.issues).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Description

Two additive changes to `analyze()` so callers can see issues in both the per-analyzer and deduped-across-the-run views:

- Each analyzer result now carries an `ownIssues` field alongside the existing `issues`. `ownIssues` is only what that analyzer's own `analyze()` callback emitted, with nothing inherited from failed dependencies. `issues` keeps its old shape (own + inherited) so existing consumers are unaffected.
- The `analyze()` return itself now exposes a top-level `issues` array — the concatenation of every analyzer's `ownIssues` across the whole run, including transitive deps. Each analyzer is memoized by cacheKey and runs once, so each issue appears exactly once — no dedup needed.

```ts
const r = await analyze({ balanceFlows, coinFlows }, { ... });

r.balanceFlows.result      // unchanged
r.balanceFlows.issues      // unchanged (own + inherited)
r.balanceFlows.ownIssues   // NEW — only what balanceFlows itself emitted
r.issues                   // NEW — every issue, each appearing once
```

Type changes:

- Split `AnalyzerOutput<T>` (what an individual analyzer's `analyze` callback returns — the existing `{result}` / `{issues}` union) from `AnalyzerResult<T>` (what `analyze()` produces per analyzer — now adds `ownIssues` on the failure branch). Both exported.
- Existing analyzers that annotated their return as `Promise<AnalyzerResult<...>>` (two in `core.ts`) are updated to use `AnalyzerOutput<...>`.

## Test plan

- `pnpm --filter @mysten/wallet-sdk test` — 102 tests (6 new covering the new fields and dedup-across-graph behavior)
- `pnpm --filter @mysten/wallet-sdk run oxlint:check && pnpm --filter @mysten/wallet-sdk run prettier:check` — clean
- `pnpm turbo build --filter=@mysten/wallet-sdk` — clean

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.