### PR TITLE
Update hw-app-sui minimum version to '1.5.4'

### DIFF
--- a/.changeset/full-mice-pick.md
+++ b/.changeset/full-mice-pick.md
@@ -1,0 +1,5 @@
+---
+'@mysten/ledgerjs-hw-app-sui': patch
+---
+
+Bump device app min version

--- a/packages/ledgerjs-hw-app-sui/src/Sui.ts
+++ b/packages/ledgerjs-hw-app-sui/src/Sui.ts
@@ -54,7 +54,7 @@ enum HostToLedger {
 	RESULT_ACCUMULATING_RESPONSE = 4,
 }
 
-const MIN_VERSION = '1.2.2';
+const MIN_VERSION = '1.5.4';
 const MANAGER_APP_NAME = 'Sui';
 
 function isPKIUnsupportedError(err: unknown): err is TransportStatusError {


### PR DESCRIPTION
## Description

**Why bump the minimum even though the TS surface doesn't change:**
The JS package is a thin pass-through. The only lever it has to protect users from sending SIP-58 or dynamic-token-descriptor traffic to firmware that can't parse it is the version gate. Without this bump, users on stale firmware hit a confusing device error instead of a clean `UpdateYourApp`. The choice of 1.5.4 (vs. 1.3.0 or 1.5.2) pins to the current audited production build.

**Release timeline (LedgerHQ/app-sui):**
- 1.2.2 — 2025-08-27 (current MIN_VERSION floor)
- 1.3.0 — 2025-12-19, PR #41 "Token dynamic descriptor" (NAPPS-1192)
- 1.4.0 — 2026-01-28, PR #47 "Fallback to internal token list"
- 1.5.2 — 2026-03-25, PR #54 "Support SIP-58"
- 1.5.3 — 2026-04-02, PR #56 "Fix tx rejection state reset"
- **1.5.4 — 2026-04-10, PR #58 "Kudelski Audit fixes"** ← current production build

**What 1.5.4 actually supports that 1.2.2 does not:**
1. 1.3.0:`provideTrustedDynamicDescriptor` support 
2. 1.4.0: Fallback to internal token list
3. 1.5.2: **SIP-58 transactions** support

## Test plan

How did you test the new or updated feature?

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [x] I did not use AI for this PR.
