### PR TITLE
Fix codegen for upgraded on-chain packages

### DIFF
--- a/.changeset/fix-codegen-upgraded-package.md
+++ b/.changeset/fix-codegen-upgraded-package.md
@@ -1,0 +1,10 @@
+---
+'@mysten/codegen': minor
+---
+
+Fix codegen for upgraded on-chain package IDs (only `utils/` was emitted) and use each type's
+introducing package version for BCS type names. Type origins are read per-(package, module)
+from the summary metadata, so structs added in upgrades — for both the root package and any
+upgraded deps — render with their correct on-chain address.
+
+Adds an `errorClass` config option to swap the built-in `Error` thrown by `normalizeMoveArguments`.

--- a/.changeset/regenerate-move-types.md
+++ b/.changeset/regenerate-move-types.md
@@ -1,0 +1,13 @@
+---
+'@mysten/pas': minor
+'@mysten/suins': minor
+'@mysten/walrus': patch
+'@mysten/kiosk': patch
+'@mysten/payment-kit': patch
+'@mysten/deepbook-v3': patch
+---
+
+Regenerate generated Move types against the latest contract sources. The generated
+`utils/index.ts` `GetOptions` / `GetManyOptions` are now exported as type aliases (intersection)
+instead of interfaces. SuiNS gains `SubnamePrunedEvent`, `pruneExpiredSubname`, and
+`pruneExpiredSubnames`.

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -149,6 +149,7 @@ export default async function generate(
 			globalGenerate,
 			importExtension,
 			includePhantomTypeParameters: config.includePhantomTypeParameters,
+			errorClass: config.errorClass,
 		});
 	}
 }

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -68,12 +68,13 @@ export type PackageGenerate = z.infer<typeof packageGenerateSchema>;
 export type FunctionsOption = z.infer<typeof functionsOptionSchema>;
 export type TypesOption = z.infer<typeof typesOptionSchema>;
 
-const TS_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
 
 export const errorClassSchema = z.object({
-	name: z.string().regex(TS_IDENTIFIER, {
-		message: 'errorClass.name must be a valid TypeScript identifier',
+	name: z.string().regex(IDENTIFIER, {
+		message: 'errorClass.name must start with a letter, $ or _ and contain only [A-Za-z0-9_$]',
 	}),
+	/** Import specifier resolved relative to the generated `<output>/utils/index.ts`. */
 	source: z.string(),
 });
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -68,6 +68,15 @@ export type PackageGenerate = z.infer<typeof packageGenerateSchema>;
 export type FunctionsOption = z.infer<typeof functionsOptionSchema>;
 export type TypesOption = z.infer<typeof typesOptionSchema>;
 
+const TS_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+export const errorClassSchema = z.object({
+	name: z.string().regex(TS_IDENTIFIER, {
+		message: 'errorClass.name must be a valid TypeScript identifier',
+	}),
+	source: z.string(),
+});
+
 export const configSchema = z.object({
 	output: z.string(),
 	prune: z.boolean().optional().default(true),
@@ -78,7 +87,14 @@ export const configSchema = z.object({
 	privateMethods: z.union([z.literal('none'), z.literal('entry'), z.literal('all')]).optional(),
 	importExtension: importExtensionSchema.optional().default('.js'),
 	includePhantomTypeParameters: z.boolean().optional().default(false),
+	/**
+	 * Custom error class for `normalizeMoveArguments` in the generated `utils/index.ts`.
+	 * Defaults to the built-in `Error`.
+	 */
+	errorClass: errorClassSchema.optional(),
 });
+
+export type ErrorClassConfig = z.infer<typeof errorClassSchema>;
 
 export type PackageConfig = z.infer<typeof packageConfigSchema>;
 export type SuiCodegenConfig = z.input<typeof configSchema>;

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -1,7 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export const utilsContent = /* ts */ `
+import type { ErrorClassConfig } from './config.js';
+
+const ERROR_CLASS_SENTINEL = '__ERROR_CLASS__';
+const ERROR_IMPORT_SENTINEL = '__ERROR_IMPORT__';
+
+export function getUtilsContent(errorClass?: ErrorClassConfig): string {
+	const useDefault = !errorClass || errorClass.name === 'Error';
+	const errorImport = useDefault
+		? ''
+		: `import { ${errorClass.name} } from ${JSON.stringify(errorClass.source)};\n`;
+	const errorName = useDefault ? 'Error' : errorClass.name;
+	return content
+		.replaceAll(ERROR_CLASS_SENTINEL, errorName)
+		.replace(ERROR_IMPORT_SENTINEL, errorImport);
+}
+
+const content = /* ts */ `__ERROR_IMPORT__
 import {
 	bcs,
 	type BcsType,
@@ -20,17 +36,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;
@@ -91,7 +101,7 @@ export function normalizeMoveArguments(
 ) {
 	const argLen = Array.isArray(args) ? args.length : Object.keys(args).length;
 	if (parameterNames && argLen !== parameterNames.length) {
-		throw new Error(
+		throw new __ERROR_CLASS__(
 			\`Invalid number of arguments, expected \${parameterNames.length}, got \${argLen}\`,
 		);
 	}
@@ -123,20 +133,20 @@ export function normalizeMoveArguments(
 		let arg;
 		if (Array.isArray(args)) {
 			if (index >= args.length) {
-				throw new Error(
+				throw new __ERROR_CLASS__(
 					\`Invalid number of arguments, expected at least \${index + 1}, got \${args.length}\`,
 				);
 			}
 			arg = args[index];
 		} else {
 			if (!parameterNames) {
-				throw new Error(\`Expected arguments to be passed as an array\`);
+				throw new __ERROR_CLASS__(\`Expected arguments to be passed as an array\`);
 			}
 			const name = parameterNames[index];
 			arg = args[name as keyof typeof args];
 
 			if (arg === undefined) {
-				throw new Error(\`Parameter \${name} is required\`);
+				throw new __ERROR_CLASS__(\`Parameter \${name} is required\`);
 			}
 		}
 
@@ -161,7 +171,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(\`Invalid argument \${stringify(arg)} for type \${type}\`);
+		throw new __ERROR_CLASS__(\`Invalid argument \${stringify(arg)} for type \${type}\`);
 	}
 
 	return normalizedArgs;

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -55,7 +55,6 @@ export async function generateFromPackageSummary({
 	const mvrNameOrAddress = pkg.package;
 
 	const typeOriginsByPkgAndModule = new Map<string, Map<string, Record<string, string>>>();
-	let dependencyIds = new Set<string>();
 
 	if (isOnChainPackage) {
 		const metadata: RootPackageMetadata = JSON.parse(
@@ -68,7 +67,6 @@ export async function generateFromPackageSummary({
 		if (!packageName) {
 			packageName = rootPackageId;
 		}
-		dependencyIds = new Set(Object.keys(metadata.dependencies ?? {}));
 
 		if (metadata.type_origins) {
 			for (const [originKey, origins] of Object.entries(metadata.type_origins)) {
@@ -109,9 +107,10 @@ export async function generateFromPackageSummary({
 		statSync(join(summaryDir, file)).isDirectory(),
 	);
 
-	const mainPackageDir = isOnChainPackage
-		? packages.find((dir) => !dependencyIds.has(dir))
-		: undefined;
+	const mainPackageDir = isOnChainPackage ? rootPackageId : undefined;
+	if (isOnChainPackage && !packages.includes(mainPackageDir!)) {
+		throw new Error(`Root package dir ${mainPackageDir} not found in summary at ${pkg.path}`);
+	}
 	const isMainPackage = (pkgDir: string) => {
 		if (isOnChainPackage) {
 			return pkgDir === mainPackageDir;
@@ -177,8 +176,7 @@ export async function generateFromPackageSummary({
 		mod.builder.includeFunctions(functions);
 	}
 
-	// Clean the package output directory to remove stale files from previous runs.
-	// Done before writing utils so a pathological `packageName === 'utils'` doesn't wipe them.
+	// Wipe stale files before writing fresh ones.
 	const packageOutputDir = join(outputDir, packageName);
 	await rm(packageOutputDir, { recursive: true, force: true });
 

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -6,9 +6,11 @@ import { basename, join } from 'node:path';
 import { ModuleRegistry } from './module-registry.js';
 import { MoveModuleBuilder } from './move-module-builder.js';
 import { existsSync, statSync } from 'node:fs';
-import { utilsContent } from './generate-utils.js';
+import { getUtilsContent } from './generate-utils.js';
 import { parse } from 'toml';
+import type { RootPackageMetadata } from './types/summary.js';
 import type {
+	ErrorClassConfig,
 	FunctionsOption,
 	GenerateBase,
 	ImportExtension,
@@ -25,6 +27,7 @@ export async function generateFromPackageSummary({
 	globalGenerate,
 	importExtension = '.js',
 	includePhantomTypeParameters = false,
+	errorClass,
 }: {
 	package: PackageConfig;
 	prune: boolean;
@@ -32,6 +35,7 @@ export async function generateFromPackageSummary({
 	globalGenerate?: GenerateBase;
 	importExtension?: ImportExtension;
 	includePhantomTypeParameters?: boolean;
+	errorClass?: ErrorClassConfig;
 }) {
 	if (!pkg.path) {
 		throw new Error(`Package path is required (got ${pkg.package})`);
@@ -47,18 +51,41 @@ export async function generateFromPackageSummary({
 	}
 
 	let packageName = pkg.packageName!;
-	let mainPackageAddress: string | undefined;
+	let rootPackageId: string | undefined;
 	const mvrNameOrAddress = pkg.package;
 
+	const typeOriginsByPkgAndModule = new Map<string, Map<string, Record<string, string>>>();
+	let dependencyIds = new Set<string>();
+
 	if (isOnChainPackage) {
-		// For on-chain packages, get the main package address from root_package_metadata.json
-		const metadata = JSON.parse(
+		const metadata: RootPackageMetadata = JSON.parse(
 			await readFile(join(pkg.path, 'root_package_metadata.json'), 'utf-8'),
 		);
-		mainPackageAddress = metadata.root_package_id;
-		// Use the package name provided or fall back to the full address
+		rootPackageId = metadata.root_package_original_id ?? metadata.root_package_id;
+		if (!rootPackageId) {
+			throw new Error(`root_package_metadata.json at ${pkg.path} is missing 'root_package_id'`);
+		}
 		if (!packageName) {
-			packageName = mainPackageAddress!;
+			packageName = rootPackageId;
+		}
+		dependencyIds = new Set(Object.keys(metadata.dependencies ?? {}));
+
+		if (metadata.type_origins) {
+			for (const [originKey, origins] of Object.entries(metadata.type_origins)) {
+				let modules = typeOriginsByPkgAndModule.get(originKey);
+				if (!modules) {
+					modules = new Map();
+					typeOriginsByPkgAndModule.set(originKey, modules);
+				}
+				for (const { module_name, datatype_name, package: introducingId } of origins) {
+					let modOrigins = modules.get(module_name);
+					if (!modOrigins) {
+						modOrigins = {};
+						modules.set(module_name, modOrigins);
+					}
+					modOrigins[datatype_name] = introducingId;
+				}
+			}
 		}
 	} else if (!pkg.packageName) {
 		try {
@@ -82,11 +109,12 @@ export async function generateFromPackageSummary({
 		statSync(join(summaryDir, file)).isDirectory(),
 	);
 
-	// For on-chain packages, the main package is identified by the root_package_id
-	// For local packages, it's identified by the packageName
+	const mainPackageDir = isOnChainPackage
+		? packages.find((dir) => !dependencyIds.has(dir))
+		: undefined;
 	const isMainPackage = (pkgDir: string) => {
 		if (isOnChainPackage) {
-			return pkgDir === mainPackageAddress;
+			return pkgDir === mainPackageDir;
 		}
 		return pkgDir === packageName;
 	};
@@ -99,18 +127,23 @@ export async function generateFromPackageSummary({
 				return Promise.all(
 					moduleFiles
 						.filter((f) => f.endsWith('.json'))
-						.map(async (mod) => ({
-							package: pkgDir,
-							isMainPackage: isMainPackage(pkgDir),
-							module: basename(mod, '.json'),
-							builder: await MoveModuleBuilder.fromSummaryFile(
-								join(summaryDir, pkgDir, mod),
-								registry,
-								isMainPackage(pkgDir) ? mvrNameOrAddress : undefined,
-								importExtension,
-								includePhantomTypeParameters,
-							),
-						})),
+						.map(async (mod) => {
+							const moduleName = basename(mod, '.json');
+							return {
+								package: pkgDir,
+								isMainPackage: isMainPackage(pkgDir),
+								module: moduleName,
+								builder: await MoveModuleBuilder.fromSummaryFile(
+									join(summaryDir, pkgDir, mod),
+									registry,
+									isMainPackage(pkgDir) ? mvrNameOrAddress : undefined,
+									importExtension,
+									includePhantomTypeParameters,
+									typeOriginsByPkgAndModule.get(pkgDir)?.get(moduleName),
+									isMainPackage(pkgDir) ? rootPackageId : undefined,
+								),
+							};
+						}),
 				);
 			}),
 		)
@@ -144,11 +177,12 @@ export async function generateFromPackageSummary({
 		mod.builder.includeFunctions(functions);
 	}
 
-	await generateUtils({ outputDir });
-
-	// Clean the package output directory to remove stale files from previous runs
+	// Clean the package output directory to remove stale files from previous runs.
+	// Done before writing utils so a pathological `packageName === 'utils'` doesn't wipe them.
 	const packageOutputDir = join(outputDir, packageName);
 	await rm(packageOutputDir, { recursive: true, force: true });
+
+	await generateUtils({ outputDir, errorClass });
 
 	await Promise.all(
 		modules.map(async (mod) => {
@@ -183,7 +217,13 @@ export async function generateFromPackageSummary({
 	);
 }
 
-async function generateUtils({ outputDir }: { outputDir: string }) {
+async function generateUtils({
+	outputDir,
+	errorClass,
+}: {
+	outputDir: string;
+	errorClass?: ErrorClassConfig;
+}) {
 	await mkdir(join(outputDir, 'utils'), { recursive: true });
-	await writeFile(join(outputDir, 'utils', 'index.ts'), utilsContent);
+	await writeFile(join(outputDir, 'utils', 'index.ts'), getUtilsContent(errorClass));
 }

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -23,6 +23,7 @@ import {
 import type { Fields, ModuleSummary, Type, TypeParameter } from './types/summary.js';
 import type { FunctionsOption, ImportExtension, TypesOption } from './config.js';
 import { join } from 'node:path';
+import { isValidSuiObjectId } from '@mysten/sui/utils';
 
 const IMPORT_MAP = {
 	Transaction: { module: '@mysten/sui/transactions', isType: true },
@@ -46,12 +47,16 @@ export class MoveModuleBuilder extends FileBuilder {
 	#includedFunctions: Set<string> = new Set();
 	#orderedTypes: string[] = [];
 	#mvrNameOrAddress?: string;
+	#typeOrigins?: Record<string, string>;
+	#rootPackageId?: string;
 	#importNames: Partial<Record<ImportName, string>> = {};
 	#importExtension: ImportExtension;
 	#includePhantomTypeParameters: boolean;
 
 	constructor({
 		mvrNameOrAddress,
+		typeOrigins,
+		rootPackageId,
 		summary,
 		registry,
 		importExtension = '.js',
@@ -60,6 +65,8 @@ export class MoveModuleBuilder extends FileBuilder {
 		summary: ModuleSummary;
 		registry: ModuleRegistry;
 		mvrNameOrAddress?: string;
+		typeOrigins?: Record<string, string>;
+		rootPackageId?: string;
 		importExtension?: ImportExtension;
 		includePhantomTypeParameters?: boolean;
 	}) {
@@ -68,6 +75,8 @@ export class MoveModuleBuilder extends FileBuilder {
 		this.registry = registry;
 		this.registry.register(this);
 		this.#mvrNameOrAddress = mvrNameOrAddress;
+		this.#typeOrigins = typeOrigins;
+		this.#rootPackageId = rootPackageId;
 		this.#importExtension = importExtension;
 		this.#includePhantomTypeParameters = includePhantomTypeParameters;
 	}
@@ -78,12 +87,16 @@ export class MoveModuleBuilder extends FileBuilder {
 		mvrNameOrAddress?: string,
 		importExtension?: ImportExtension,
 		includePhantomTypeParameters?: boolean,
+		typeOrigins?: Record<string, string>,
+		rootPackageId?: string,
 	) {
 		const summary = JSON.parse(await readFile(file, 'utf-8'));
 		return new MoveModuleBuilder({
 			summary,
 			registry,
 			mvrNameOrAddress,
+			typeOrigins,
+			rootPackageId,
 			importExtension,
 			includePhantomTypeParameters,
 		});
@@ -99,9 +112,22 @@ export class MoveModuleBuilder extends FileBuilder {
 			return '0x2';
 		} else if (resolvedAddress === SUI_SYSTEM_ADDRESS) {
 			return '0x3';
+		} else if (this.#rootPackageId) {
+			return this.#rootPackageId;
+		} else if (this.#mvrNameOrAddress && !isValidSuiObjectId(this.#mvrNameOrAddress)) {
+			return this.#mvrNameOrAddress;
 		} else {
-			return this.#mvrNameOrAddress ?? this.summary.id.address;
+			return this.summary.id.address;
 		}
+	}
+
+	#getTypePrefix(datatypeName: string): string | null {
+		const originPackageId = this.#typeOrigins?.[datatypeName];
+		if (originPackageId === undefined) return null;
+		if (this.#resolveAddress(originPackageId) === this.#resolveAddress(this.summary.id.address)) {
+			return null;
+		}
+		return `${originPackageId}::${this.summary.id.name}`;
 	}
 
 	#getImportName(name: ImportName): string {
@@ -223,7 +249,10 @@ export class MoveModuleBuilder extends FileBuilder {
 	}
 
 	async renderBCSTypes() {
-		if (this.hasBcsTypes()) {
+		const needsModuleName =
+			this.hasBcsTypes() && this.#orderedTypes.some((name) => this.#getTypePrefix(name) === null);
+
+		if (needsModuleName) {
 			this.statements.push(
 				...parseTS /* ts */ `
 				const $moduleName = '${this.#getModuleTypeName()}::${this.summary.id.name}';
@@ -331,7 +360,9 @@ export class MoveModuleBuilder extends FileBuilder {
 		const params = struct.type_parameters
 			.map((param, i) => ({ param, originalIndex: i }))
 			.filter(({ param }) => includePhantom || !param.phantom);
-		const structName = `\${$moduleName}::${name}`;
+
+		const prefix = this.#getTypePrefix(name);
+		const structName = prefix !== null ? `${prefix}::${name}` : `\${$moduleName}::${name}`;
 
 		if (params.length === 0) {
 			const hasPhantoms = struct.type_parameters.some((p) => p.phantom);
@@ -415,7 +446,8 @@ export class MoveModuleBuilder extends FileBuilder {
 		const moveEnumName = this.#getImportName('MoveEnum');
 		this.exports.push(name);
 
-		const enumName = `\${$moduleName}::${name}`;
+		const prefix = this.#getTypePrefix(name);
+		const enumName = prefix !== null ? `${prefix}::${name}` : `\${$moduleName}::${name}`;
 
 		const variantsObject = await mapToObject({
 			items: Object.entries(enumDef.variants),

--- a/packages/codegen/src/types/summary.ts
+++ b/packages/codegen/src/types/summary.ts
@@ -1,6 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+export interface TypeOrigin {
+	module_name: string;
+	datatype_name: string;
+	package: string;
+}
+
+export interface RootPackageMetadata {
+	root_package_id?: string;
+	root_package_original_id?: string;
+	dependencies?: Record<string, string>;
+	type_origins?: Record<string, TypeOrigin[]>;
+}
+
 export interface ModuleSummary {
 	id: {
 		address: string;

--- a/packages/codegen/tests/codegen-output.test.ts
+++ b/packages/codegen/tests/codegen-output.test.ts
@@ -1072,3 +1072,105 @@ describe('includePhantomTypeParameters option', () => {
 		`);
 	});
 });
+
+describe('typeOrigins (upgraded packages)', () => {
+	const ORIGIN_V1 = '0x000000000000000000000000000000000000000000000000000000000000aaaa';
+	const ORIGIN_V2 = '0x000000000000000000000000000000000000000000000000000000000000bbbb';
+
+	it('inlines per-struct origin addresses and skips $moduleName when all types have origins', async () => {
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+			new ModuleRegistry(ADDRESS_MAPPINGS),
+			'@test/testpkg',
+			'.js',
+			false,
+			{ Counter: ORIGIN_V1, AdminCap: ORIGIN_V1 },
+		);
+		builder.includeTypes(['Counter', 'AdminCap']);
+		const output = await render(builder, { types: true, functions: false });
+		const body = extractBody(output);
+
+		// No $moduleName declaration when every type has a known origin.
+		expect(body).not.toContain('$moduleName');
+		expect(body).toContain(`name: \`${ORIGIN_V1}::counter::Counter\``);
+		expect(body).toContain(`name: \`${ORIGIN_V1}::counter::AdminCap\``);
+	});
+
+	it('keeps $moduleName when some types lack origins (mixed introducing versions)', async () => {
+		// AdminCap was introduced in v1, Counter in v2. Only AdminCap has an origin entry —
+		// Counter falls back to $moduleName.
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+			new ModuleRegistry(ADDRESS_MAPPINGS),
+			'@test/testpkg',
+			'.js',
+			false,
+			{ AdminCap: ORIGIN_V1 },
+		);
+		builder.includeTypes(['Counter', 'AdminCap']);
+		const output = await render(builder, { types: true, functions: false });
+		const body = extractBody(output);
+
+		expect(body).toContain(`const $moduleName = '@test/testpkg::counter';`);
+		expect(body).toContain(`name: \`${ORIGIN_V1}::counter::AdminCap\``);
+		expect(body).toContain('name: `${$moduleName}::Counter`');
+	});
+
+	it('uses origin address for generic struct (Wrapper<T>) introduced in upgrade', async () => {
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+			new ModuleRegistry(ADDRESS_MAPPINGS),
+			'@test/testpkg',
+			'.js',
+			false,
+			{ Wrapper: ORIGIN_V2 },
+		);
+		builder.includeTypes(['Wrapper']);
+		const output = await render(builder, { types: true, functions: false });
+		const body = extractBody(output);
+
+		expect(body).not.toContain('$moduleName');
+		expect(body).toContain(
+			`name: \`${ORIGIN_V2}::counter::Wrapper<\${typeParameters[0].name as T['name']}>\``,
+		);
+	});
+
+	it('declares $moduleName when an additional type without an origin is added before render', async () => {
+		// Regression guard: `needsModuleName` must reflect the final included set, not a
+		// snapshot taken before the render. Add AdminCap (with origin) first, then Counter
+		// (no origin) — the second include must still trigger the $moduleName declaration.
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+			new ModuleRegistry(ADDRESS_MAPPINGS),
+			'@test/testpkg',
+			'.js',
+			false,
+			{ AdminCap: ORIGIN_V1 },
+		);
+		builder.includeTypes(['AdminCap']);
+		builder.includeTypes(['Counter']);
+		const output = await render(builder, { types: true, functions: false });
+		const body = extractBody(output);
+
+		expect(body).toContain(`const $moduleName = '@test/testpkg::counter';`);
+		expect(body).toContain('name: `${$moduleName}::Counter`');
+	});
+
+	it('falls back to rootPackageId for type names (introducing version, not MVR name) when no per-type origin', async () => {
+		const ROOT_V1 = '0x' + 'b'.repeat(64);
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+			new ModuleRegistry(ADDRESS_MAPPINGS),
+			'@upgraded/pkg',
+			'.js',
+			false,
+			undefined,
+			ROOT_V1,
+		);
+		builder.includeTypes(['Counter']);
+		const output = await render(builder, { types: true, functions: false });
+		const body = extractBody(output);
+
+		expect(body).toContain(`const $moduleName = '${ROOT_V1}::counter';`);
+	});
+});

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { generateFromPackageSummary } from '../src/index.js';
@@ -65,6 +65,62 @@ async function generate(options: {
 
 	return outputDir;
 }
+
+/**
+ * Build a synthetic on-chain summary by copying the local `testpkg` fixture into the layout
+ * `sui move summary --package-id` actually produces. Real-world observation (mainnet SuiNS
+ * upgraded from `0xd22b...` to `0x71af...`): the on-disk root package dir is named after
+ * `root_package_original_id`, not the queried/latest id. The main-package detection therefore
+ * needs to find that dir by elimination, not by matching the user's input.
+ */
+async function buildOnChainFixture(opts: {
+	rootPackageId: string;
+	rootPackageOriginalId?: string;
+	dependencies?: Record<string, string>;
+	typeOrigins?: Record<
+		string,
+		Array<{ module_name: string; datatype_name: string; package: string }>
+	>;
+}): Promise<string> {
+	const path = await mkdtemp(join(tmpdir(), 'codegen-onchain-'));
+	const localSummaries = join(FIXTURE_PATH, 'package_summaries');
+	const onDiskMainDir = opts.rootPackageOriginalId ?? opts.rootPackageId;
+
+	await writeFile(
+		join(path, 'root_package_metadata.json'),
+		JSON.stringify({
+			root_package_id: opts.rootPackageId,
+			root_package_original_id: opts.rootPackageOriginalId ?? opts.rootPackageId,
+			dependencies: opts.dependencies ?? {},
+			...(opts.typeOrigins ? { type_origins: opts.typeOrigins } : {}),
+		}),
+	);
+	await writeFile(
+		join(path, 'address_mapping.json'),
+		JSON.stringify({
+			std: '0x0000000000000000000000000000000000000000000000000000000000000001',
+			sui: '0x0000000000000000000000000000000000000000000000000000000000000002',
+			testpkg: onDiskMainDir,
+		}),
+	);
+	await mkdir(join(path, onDiskMainDir), { recursive: true });
+	await cp(join(localSummaries, 'testpkg'), join(path, onDiskMainDir), { recursive: true });
+	for (const depId of Object.keys(opts.dependencies ?? {})) {
+		const depDir = join(path, depId);
+		await mkdir(depDir, { recursive: true });
+		const local =
+			depId === '0x0000000000000000000000000000000000000000000000000000000000000001'
+				? join(localSummaries, 'std')
+				: join(localSummaries, 'sui');
+		await cp(local, depDir, { recursive: true });
+	}
+	return path;
+}
+
+const LATEST_ID = '0x' + 'a'.repeat(64);
+const V1_ID = '0x' + 'b'.repeat(64);
+const STD_ID = '0x0000000000000000000000000000000000000000000000000000000000000001';
+const SUI_ID = '0x0000000000000000000000000000000000000000000000000000000000000002';
 
 async function getGeneratedFiles(outputDir: string): Promise<string[]> {
 	const files: string[] = [];
@@ -640,6 +696,139 @@ describe('generate options', () => {
 			expect(files).toContain('testpkg/registry.ts');
 			// Dependencies should be generated in deps/
 			expect(files.some((f) => f.startsWith('testpkg/deps/'))).toBe(true);
+		});
+	});
+
+	describe('on-chain (upgraded) packages', () => {
+		let onChainPath: string;
+
+		afterEach(async () => {
+			if (onChainPath) await rm(onChainPath, { recursive: true, force: true });
+		});
+
+		it('emits modules and uses original id for type names when queried by raw upgraded id', async () => {
+			onChainPath = await buildOnChainFixture({
+				rootPackageId: LATEST_ID,
+				rootPackageOriginalId: V1_ID,
+				dependencies: { [STD_ID]: STD_ID, [SUI_ID]: SUI_ID },
+			});
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await generateFromPackageSummary({
+				package: { package: LATEST_ID, packageName: 'testpkg', path: onChainPath },
+				prune: true,
+				outputDir,
+			});
+
+			const files = await getGeneratedFiles(outputDir);
+			expect(files).toContain('testpkg/counter.ts');
+			expect(files).toContain('testpkg/registry.ts');
+
+			const counter = await getFileContent(outputDir, 'testpkg/counter.ts');
+			// BCS type tags must use the *introducing* version, which here means original v1
+			// (no per-type origins, so every type goes through the $moduleName fallback).
+			expect(counter).toContain(`const $moduleName = '${V1_ID}::counter';`);
+			// Function helpers should target the latest queried id so calls hit the upgrade.
+			expect(counter).toContain(`options.package ?? '${LATEST_ID}'`);
+		});
+
+		it('uses original id for type names even when queried by MVR name', async () => {
+			onChainPath = await buildOnChainFixture({
+				rootPackageId: LATEST_ID,
+				rootPackageOriginalId: V1_ID,
+				dependencies: { [STD_ID]: STD_ID, [SUI_ID]: SUI_ID },
+			});
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await generateFromPackageSummary({
+				package: { package: '@test/testpkg', packageName: 'testpkg', path: onChainPath },
+				prune: true,
+				outputDir,
+			});
+
+			const counter = await getFileContent(outputDir, 'testpkg/counter.ts');
+			// MVR names resolve to the latest version at runtime — that wouldn't match on-chain
+			// type tags for upgraded packages. Type names must always use the original id.
+			expect(counter).toContain(`const $moduleName = '${V1_ID}::counter';`);
+			// Function helpers can use the MVR name (it resolves to latest at call time).
+			expect(counter).toContain(`options.package ?? '@test/testpkg'`);
+		});
+
+		it('inlines per-type origin addresses from type_origins (across multiple versions)', async () => {
+			// Real metadata keys all of a package's entries under its `original_id`; the
+			// introducing version of each individual type lives in the entry's `package` field.
+			onChainPath = await buildOnChainFixture({
+				rootPackageId: LATEST_ID,
+				rootPackageOriginalId: V1_ID,
+				dependencies: { [STD_ID]: STD_ID, [SUI_ID]: SUI_ID },
+				typeOrigins: {
+					[V1_ID]: [
+						{ module_name: 'counter', datatype_name: 'Counter', package: V1_ID },
+						{ module_name: 'counter', datatype_name: 'AdminCap', package: LATEST_ID },
+					],
+				},
+			});
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await generateFromPackageSummary({
+				package: { package: LATEST_ID, packageName: 'testpkg', path: onChainPath },
+				prune: true,
+				outputDir,
+				globalGenerate: { types: true, functions: false },
+			});
+
+			const counter = await getFileContent(outputDir, 'testpkg/counter.ts');
+			// Counter's origin equals the module's own address — falls through to $moduleName
+			// (which is `${V1_ID}::counter`) instead of emitting a redundant inline prefix.
+			expect(counter).toContain('name: `${$moduleName}::Counter`');
+			expect(counter).toContain(`const $moduleName = '${V1_ID}::counter';`);
+			// AdminCap's origin is the upgrade version — must be inlined since it differs.
+			expect(counter).toContain(`name: \`${LATEST_ID}::counter::AdminCap\``);
+		});
+
+		it('passes per-dep type_origins through to dep modules (e.g. upgraded deps)', async () => {
+			// std `option::Option` is at 0x1 in reality — pretend it was introduced at a
+			// different address (some hypothetical earlier version) to verify the dep builder
+			// honours the per-type origin from the metadata rather than always using its own
+			// `summary.id.address`.
+			const FAKE_STD_V0 = '0x' + 'c'.repeat(64);
+			onChainPath = await buildOnChainFixture({
+				rootPackageId: LATEST_ID,
+				dependencies: { [STD_ID]: STD_ID, [SUI_ID]: SUI_ID },
+				typeOrigins: {
+					[STD_ID]: [{ module_name: 'option', datatype_name: 'Option', package: FAKE_STD_V0 }],
+				},
+			});
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await generateFromPackageSummary({
+				package: { package: LATEST_ID, packageName: 'testpkg', path: onChainPath },
+				prune: false,
+				outputDir,
+				globalGenerate: { types: true, functions: false },
+			});
+
+			const files = await getGeneratedFiles(outputDir);
+			const optionFile = files.find((f) => f.endsWith('/option.ts'));
+			if (optionFile) {
+				const content = await getFileContent(outputDir, optionFile);
+				expect(content).toContain(`name: \`${FAKE_STD_V0}::option::Option`);
+			}
+		});
+
+		it("throws when root_package_metadata.json is missing 'root_package_id'", async () => {
+			onChainPath = await mkdtemp(join(tmpdir(), 'codegen-onchain-'));
+			await writeFile(join(onChainPath, 'root_package_metadata.json'), '{}');
+			await writeFile(join(onChainPath, 'address_mapping.json'), '{}');
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await expect(
+				generateFromPackageSummary({
+					package: { package: LATEST_ID, packageName: 'testpkg', path: onChainPath },
+					prune: true,
+					outputDir,
+				}),
+			).rejects.toThrow(/root_package_id/);
 		});
 	});
 });

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -810,10 +810,31 @@ describe('generate options', () => {
 
 			const files = await getGeneratedFiles(outputDir);
 			const optionFile = files.find((f) => f.endsWith('/option.ts'));
-			if (optionFile) {
-				const content = await getFileContent(outputDir, optionFile);
-				expect(content).toContain(`name: \`${FAKE_STD_V0}::option::Option`);
-			}
+			expect(optionFile).toBeDefined();
+			const content = await getFileContent(outputDir, optionFile!);
+			expect(content).toContain(`name: \`${FAKE_STD_V0}::option::Option`);
+		});
+
+		it('throws when the on-disk listing is missing the root package dir', async () => {
+			onChainPath = await mkdtemp(join(tmpdir(), 'codegen-onchain-'));
+			await writeFile(
+				join(onChainPath, 'root_package_metadata.json'),
+				JSON.stringify({
+					root_package_id: LATEST_ID,
+					root_package_original_id: V1_ID,
+				}),
+			);
+			await writeFile(join(onChainPath, 'address_mapping.json'), '{}');
+			// No directories on disk — main dir match must fail.
+			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+
+			await expect(
+				generateFromPackageSummary({
+					package: { package: LATEST_ID, packageName: 'testpkg', path: onChainPath },
+					prune: true,
+					outputDir,
+				}),
+			).rejects.toThrow(/Root package dir .* not found/);
 		});
 
 		it("throws when root_package_metadata.json is missing 'root_package_id'", async () => {

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
 import { join } from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
-import { utilsContent } from '../src/generate-utils.js';
+import { getUtilsContent } from '../src/generate-utils.js';
 
 const GENERATED_DIR = join(import.meta.dirname, 'generated');
 
@@ -16,7 +16,7 @@ let normalizeMoveArguments: (
 
 beforeAll(async () => {
 	await mkdir(join(GENERATED_DIR, 'utils'), { recursive: true });
-	await writeFile(join(GENERATED_DIR, 'utils', 'index.ts'), utilsContent);
+	await writeFile(join(GENERATED_DIR, 'utils', 'index.ts'), getUtilsContent());
 	const modPath = join(GENERATED_DIR, 'utils', 'index.js');
 	const mod = await import(modPath);
 	normalizeMoveArguments = mod.normalizeMoveArguments;
@@ -322,6 +322,64 @@ describe('normalizeMoveArguments', () => {
     }
   ]
 }"`);
+	});
+
+	it('throws the configured error class when errorClass option is provided', () => {
+		const out = getUtilsContent({ name: 'MyError', source: '../../my-error.js' });
+		// Source is JSON.stringified (double-quoted) to escape special chars safely.
+		expect(out).toContain(`import { MyError } from "../../my-error.js";`);
+		expect(out).toContain('throw new MyError(');
+		expect(out).not.toMatch(/throw new Error\(/);
+		expect(out).toContain('if (obj instanceof Error)');
+	});
+
+	it('escapes the import source so quotes/backslashes cannot break out', () => {
+		const out = getUtilsContent({ name: 'MyError', source: `weird"path\\file.js` });
+		expect(out).toContain(`import { MyError } from "weird\\"path\\\\file.js";`);
+	});
+
+	it("treats errorClass.name === 'Error' as no-op (no import emitted)", () => {
+		const out = getUtilsContent({ name: 'Error', source: 'irrelevant' });
+		expect(out).not.toContain(`from "irrelevant"`);
+		expect(out).toContain('throw new Error(');
+	});
+
+	it('defaults to throwing built-in Error when errorClass is not provided', () => {
+		const out = getUtilsContent();
+		expect(out).toContain('throw new Error(');
+		// Sentinel placeholders must not leak through.
+		expect(out).not.toContain('__ERROR_CLASS__');
+		expect(out).not.toContain('__ERROR_IMPORT__');
+		// File starts with the bcs import (no leading custom-error import).
+		expect(out.trimStart().startsWith('import {')).toBe(true);
+	});
+
+	it('emits GetOptions / GetManyOptions as type aliases (not interfaces)', () => {
+		const out = getUtilsContent();
+		expect(out).toContain(
+			"export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =",
+		);
+		expect(out).toContain(
+			"export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =",
+		);
+	});
+
+	it('actually throws the configured class at runtime', async () => {
+		const dir = join(import.meta.dirname, 'generated-error-class');
+		await mkdir(join(dir, 'utils'), { recursive: true });
+		await writeFile(join(dir, 'my-error.ts'), `export class MyError extends Error {}\n`);
+		// Source is relative to the generated utils file, not to the config.
+		await writeFile(
+			join(dir, 'utils', 'index.ts'),
+			getUtilsContent({ name: 'MyError', source: '../my-error.js' }),
+		);
+		try {
+			const utils = await import(join(dir, 'utils', 'index.js'));
+			const myError = await import(join(dir, 'my-error.js'));
+			expect(() => utils.normalizeMoveArguments({}, ['u32'], ['x'])).toThrow(myError.MyError);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
 	});
 
 	it('accepts raw object-id strings for `key` object types', async () => {

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../tsconfig.shared.json",
 	"include": ["src"],
 	"compilerOptions": {
-		"noEmit": true
+		"noEmit": true,
+		"types": ["node"]
 	}
 }

--- a/packages/deepbook-v3/src/contracts/utils/index.ts
+++ b/packages/deepbook-v3/src/contracts/utils/index.ts
@@ -16,17 +16,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;

--- a/packages/kiosk/src/contracts/utils/index.ts
+++ b/packages/kiosk/src/contracts/utils/index.ts
@@ -16,17 +16,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;

--- a/packages/pas/src/contracts/pas/account.ts
+++ b/packages/pas/src/contracts/pas/account.ts
@@ -11,7 +11,7 @@ import {
 	type RawTransactionArgument,
 } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 import * as versioning from './versioning.js';
 const $moduleName = '@mysten/pas::account';
 export const Account = new MoveStruct({
@@ -105,7 +105,7 @@ export function createAndShare(options: CreateAndShareOptions) {
 }
 export interface UnlockBalanceArguments {
 	account: RawTransactionArgument<string>;
-	auth: RawTransactionArgument<string>;
+	auth: TransactionArgument;
 	amount: RawTransactionArgument<number | bigint>;
 }
 export interface UnlockBalanceOptions {
@@ -114,7 +114,7 @@ export interface UnlockBalanceOptions {
 		| UnlockBalanceArguments
 		| [
 				account: RawTransactionArgument<string>,
-				auth: RawTransactionArgument<string>,
+				auth: TransactionArgument,
 				amount: RawTransactionArgument<number | bigint>,
 		  ];
 	typeArguments: [string];
@@ -139,7 +139,7 @@ export function unlockBalance(options: UnlockBalanceOptions) {
 }
 export interface SendBalanceArguments {
 	from: RawTransactionArgument<string>;
-	auth: RawTransactionArgument<string>;
+	auth: TransactionArgument;
 	to: RawTransactionArgument<string>;
 	amount: RawTransactionArgument<number | bigint>;
 }
@@ -149,7 +149,7 @@ export interface SendBalanceOptions {
 		| SendBalanceArguments
 		| [
 				from: RawTransactionArgument<string>,
-				auth: RawTransactionArgument<string>,
+				auth: TransactionArgument,
 				to: RawTransactionArgument<string>,
 				amount: RawTransactionArgument<number | bigint>,
 		  ];
@@ -201,7 +201,7 @@ export function clawbackBalance(options: ClawbackBalanceOptions) {
 }
 export interface UnsafeSendBalanceArguments {
 	from: RawTransactionArgument<string>;
-	auth: RawTransactionArgument<string>;
+	auth: TransactionArgument;
 	recipientAddress: RawTransactionArgument<string>;
 	amount: RawTransactionArgument<number | bigint>;
 }
@@ -211,7 +211,7 @@ export interface UnsafeSendBalanceOptions {
 		| UnsafeSendBalanceArguments
 		| [
 				from: RawTransactionArgument<string>,
-				auth: RawTransactionArgument<string>,
+				auth: TransactionArgument,
 				recipientAddress: RawTransactionArgument<string>,
 				amount: RawTransactionArgument<number | bigint>,
 		  ];
@@ -296,13 +296,13 @@ export function owner(options: OwnerOptions) {
 }
 export interface DepositBalanceArguments {
 	account: RawTransactionArgument<string>;
-	balance: RawTransactionArgument<string>;
+	balance: TransactionArgument;
 }
 export interface DepositBalanceOptions {
 	package?: string;
 	arguments:
 		| DepositBalanceArguments
-		| [account: RawTransactionArgument<string>, balance: RawTransactionArgument<string>];
+		| [account: RawTransactionArgument<string>, balance: TransactionArgument];
 	typeArguments: [string];
 }
 export function depositBalance(options: DepositBalanceOptions) {

--- a/packages/pas/src/contracts/pas/clawback_funds.ts
+++ b/packages/pas/src/contracts/pas/clawback_funds.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 import { type BcsType, bcs } from '@mysten/sui/bcs';
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 const $moduleName = '@mysten/pas::clawback_funds';
 export function ClawbackFunds<T extends BcsType<any>>(...typeParameters: [T]) {
 	return new MoveStruct({
@@ -19,11 +19,11 @@ export function ClawbackFunds<T extends BcsType<any>>(...typeParameters: [T]) {
 	});
 }
 export interface OwnerArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface OwnerOptions {
 	package?: string;
-	arguments: OwnerArguments | [request: RawTransactionArgument<string>];
+	arguments: OwnerArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function owner(options: OwnerOptions) {
@@ -40,11 +40,11 @@ export function owner(options: OwnerOptions) {
 		});
 }
 export interface AccountIdArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface AccountIdOptions {
 	package?: string;
-	arguments: AccountIdArguments | [request: RawTransactionArgument<string>];
+	arguments: AccountIdArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function accountId(options: AccountIdOptions) {
@@ -61,11 +61,11 @@ export function accountId(options: AccountIdOptions) {
 		});
 }
 export interface FundsArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface FundsOptions {
 	package?: string;
-	arguments: FundsArguments | [request: RawTransactionArgument<string>];
+	arguments: FundsArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function funds(options: FundsOptions) {
@@ -82,14 +82,14 @@ export function funds(options: FundsOptions) {
 		});
 }
 export interface ResolveArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 	policy: RawTransactionArgument<string>;
 }
 export interface ResolveOptions {
 	package?: string;
 	arguments:
 		| ResolveArguments
-		| [request: RawTransactionArgument<string>, policy: RawTransactionArgument<string>];
+		| [request: TransactionArgument, policy: RawTransactionArgument<string>];
 	typeArguments: [string];
 }
 /**

--- a/packages/pas/src/contracts/pas/request.ts
+++ b/packages/pas/src/contracts/pas/request.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 import { type BcsType } from '@mysten/sui/bcs';
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 import * as vec_set from './deps/sui/vec_set.js';
 import * as type_name from './deps/std/type_name.js';
 const $moduleName = '@mysten/pas::request';
@@ -19,14 +19,14 @@ export function Request<K extends BcsType<any>>(...typeParameters: [K]) {
 	});
 }
 export interface ApproveArguments<U extends BcsType<any>> {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 	Approval: RawTransactionArgument<U>;
 }
 export interface ApproveOptions<U extends BcsType<any>> {
 	package?: string;
 	arguments:
 		| ApproveArguments<U>
-		| [request: RawTransactionArgument<string>, Approval: RawTransactionArgument<U>];
+		| [request: TransactionArgument, Approval: RawTransactionArgument<U>];
 	typeArguments: [string, string];
 }
 /** Adds an approval to a request. Can be called to resolve rules */
@@ -44,11 +44,11 @@ export function approve<U extends BcsType<any>>(options: ApproveOptions<U>) {
 		});
 }
 export interface DataArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface DataOptions {
 	package?: string;
-	arguments: DataArguments | [request: RawTransactionArgument<string>];
+	arguments: DataArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function data(options: DataOptions) {
@@ -65,11 +65,11 @@ export function data(options: DataOptions) {
 		});
 }
 export interface ApprovalsArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface ApprovalsOptions {
 	package?: string;
-	arguments: ApprovalsArguments | [request: RawTransactionArgument<string>];
+	arguments: ApprovalsArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function approvals(options: ApprovalsOptions) {

--- a/packages/pas/src/contracts/pas/send_funds.ts
+++ b/packages/pas/src/contracts/pas/send_funds.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 import { type BcsType, bcs } from '@mysten/sui/bcs';
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 const $moduleName = '@mysten/pas::send_funds';
 /**
  * A transfer request that is generated once a send funds request is initialized.
@@ -40,11 +40,11 @@ export function SendFunds<T extends BcsType<any>>(...typeParameters: [T]) {
 	});
 }
 export interface SenderArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface SenderOptions {
 	package?: string;
-	arguments: SenderArguments | [request: RawTransactionArgument<string>];
+	arguments: SenderArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function sender(options: SenderOptions) {
@@ -61,11 +61,11 @@ export function sender(options: SenderOptions) {
 		});
 }
 export interface RecipientArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface RecipientOptions {
 	package?: string;
-	arguments: RecipientArguments | [request: RawTransactionArgument<string>];
+	arguments: RecipientArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function recipient(options: RecipientOptions) {
@@ -82,11 +82,11 @@ export function recipient(options: RecipientOptions) {
 		});
 }
 export interface SenderAccountIdArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface SenderAccountIdOptions {
 	package?: string;
-	arguments: SenderAccountIdArguments | [request: RawTransactionArgument<string>];
+	arguments: SenderAccountIdArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function senderAccountId(options: SenderAccountIdOptions) {
@@ -103,11 +103,11 @@ export function senderAccountId(options: SenderAccountIdOptions) {
 		});
 }
 export interface RecipientAccountIdArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface RecipientAccountIdOptions {
 	package?: string;
-	arguments: RecipientAccountIdArguments | [request: RawTransactionArgument<string>];
+	arguments: RecipientAccountIdArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function recipientAccountId(options: RecipientAccountIdOptions) {
@@ -124,11 +124,11 @@ export function recipientAccountId(options: RecipientAccountIdOptions) {
 		});
 }
 export interface FundsArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface FundsOptions {
 	package?: string;
-	arguments: FundsArguments | [request: RawTransactionArgument<string>];
+	arguments: FundsArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function funds(options: FundsOptions) {
@@ -145,14 +145,14 @@ export function funds(options: FundsOptions) {
 		});
 }
 export interface ResolveBalanceArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 	policy: RawTransactionArgument<string>;
 }
 export interface ResolveBalanceOptions {
 	package?: string;
 	arguments:
 		| ResolveBalanceArguments
-		| [request: RawTransactionArgument<string>, policy: RawTransactionArgument<string>];
+		| [request: TransactionArgument, policy: RawTransactionArgument<string>];
 	typeArguments: [string];
 }
 /**

--- a/packages/pas/src/contracts/pas/templates.ts
+++ b/packages/pas/src/contracts/pas/templates.ts
@@ -11,7 +11,7 @@
 
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 const $moduleName = '@mysten/pas::templates';
 export const PAS = new MoveStruct({
 	name: `${$moduleName}::PAS`,
@@ -47,8 +47,8 @@ export function setup(options: SetupOptions) {
 }
 export interface SetTemplateCommandArguments {
 	templates: RawTransactionArgument<string>;
-	_: RawTransactionArgument<string>;
-	command: RawTransactionArgument<string>;
+	_: TransactionArgument;
+	command: TransactionArgument;
 }
 export interface SetTemplateCommandOptions {
 	package?: string;
@@ -56,8 +56,8 @@ export interface SetTemplateCommandOptions {
 		| SetTemplateCommandArguments
 		| [
 				templates: RawTransactionArgument<string>,
-				_: RawTransactionArgument<string>,
-				command: RawTransactionArgument<string>,
+				_: TransactionArgument,
+				command: TransactionArgument,
 		  ];
 	typeArguments: [string];
 }
@@ -77,13 +77,13 @@ export function setTemplateCommand(options: SetTemplateCommandOptions) {
 }
 export interface UnsetTemplateCommandArguments {
 	templates: RawTransactionArgument<string>;
-	_: RawTransactionArgument<string>;
+	_: TransactionArgument;
 }
 export interface UnsetTemplateCommandOptions {
 	package?: string;
 	arguments:
 		| UnsetTemplateCommandArguments
-		| [templates: RawTransactionArgument<string>, _: RawTransactionArgument<string>];
+		| [templates: RawTransactionArgument<string>, _: TransactionArgument];
 	typeArguments: [string];
 }
 export function unsetTemplateCommand(options: UnsetTemplateCommandOptions) {

--- a/packages/pas/src/contracts/pas/unlock_funds.ts
+++ b/packages/pas/src/contracts/pas/unlock_funds.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 import { type BcsType, bcs } from '@mysten/sui/bcs';
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 const $moduleName = '@mysten/pas::unlock_funds';
 /**
  * An unlock funds request that is generated once a Permissioned Funds Transfer is
@@ -31,11 +31,11 @@ export function UnlockFunds<T extends BcsType<any>>(...typeParameters: [T]) {
 	});
 }
 export interface OwnerArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface OwnerOptions {
 	package?: string;
-	arguments: OwnerArguments | [request: RawTransactionArgument<string>];
+	arguments: OwnerArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function owner(options: OwnerOptions) {
@@ -52,11 +52,11 @@ export function owner(options: OwnerOptions) {
 		});
 }
 export interface AccountIdArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface AccountIdOptions {
 	package?: string;
-	arguments: AccountIdArguments | [request: RawTransactionArgument<string>];
+	arguments: AccountIdArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function accountId(options: AccountIdOptions) {
@@ -73,11 +73,11 @@ export function accountId(options: AccountIdOptions) {
 		});
 }
 export interface FundsArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 }
 export interface FundsOptions {
 	package?: string;
-	arguments: FundsArguments | [request: RawTransactionArgument<string>];
+	arguments: FundsArguments | [request: TransactionArgument];
 	typeArguments: [string];
 }
 export function funds(options: FundsOptions) {
@@ -94,14 +94,14 @@ export function funds(options: FundsOptions) {
 		});
 }
 export interface ResolveUnrestrictedBalanceArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 	namespace: RawTransactionArgument<string>;
 }
 export interface ResolveUnrestrictedBalanceOptions {
 	package?: string;
 	arguments:
 		| ResolveUnrestrictedBalanceArguments
-		| [request: RawTransactionArgument<string>, namespace: RawTransactionArgument<string>];
+		| [request: TransactionArgument, namespace: RawTransactionArgument<string>];
 	typeArguments: [string];
 }
 /**
@@ -126,14 +126,14 @@ export function resolveUnrestrictedBalance(options: ResolveUnrestrictedBalanceOp
 		});
 }
 export interface ResolveArguments {
-	request: RawTransactionArgument<string>;
+	request: TransactionArgument;
 	policy: RawTransactionArgument<string>;
 }
 export interface ResolveOptions {
 	package?: string;
 	arguments:
 		| ResolveArguments
-		| [request: RawTransactionArgument<string>, policy: RawTransactionArgument<string>];
+		| [request: TransactionArgument, policy: RawTransactionArgument<string>];
 	typeArguments: [string];
 }
 /**

--- a/packages/pas/src/contracts/pas/versioning.ts
+++ b/packages/pas/src/contracts/pas/versioning.ts
@@ -13,7 +13,7 @@
 
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
-import { type Transaction } from '@mysten/sui/transactions';
+import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 import * as vec_set from './deps/sui/vec_set.js';
 const $moduleName = '@mysten/pas::versioning';
 export const Versioning = new MoveStruct({
@@ -23,17 +23,14 @@ export const Versioning = new MoveStruct({
 	},
 });
 export interface IsValidVersionArguments {
-	versioning: RawTransactionArgument<string>;
+	versioning: TransactionArgument;
 	version: RawTransactionArgument<number | bigint>;
 }
 export interface IsValidVersionOptions {
 	package?: string;
 	arguments:
 		| IsValidVersionArguments
-		| [
-				versioning: RawTransactionArgument<string>,
-				version: RawTransactionArgument<number | bigint>,
-		  ];
+		| [versioning: TransactionArgument, version: RawTransactionArgument<number | bigint>];
 }
 /** Verify that a version is not part of the blocked version list. */
 export function isValidVersion(options: IsValidVersionOptions) {
@@ -49,11 +46,11 @@ export function isValidVersion(options: IsValidVersionOptions) {
 		});
 }
 export interface AssertIsValidVersionArguments {
-	versioning: RawTransactionArgument<string>;
+	versioning: TransactionArgument;
 }
 export interface AssertIsValidVersionOptions {
 	package?: string;
-	arguments: AssertIsValidVersionArguments | [versioning: RawTransactionArgument<string>];
+	arguments: AssertIsValidVersionArguments | [versioning: TransactionArgument];
 }
 export function assertIsValidVersion(options: AssertIsValidVersionOptions) {
 	const packageAddress = options.package ?? '@mysten/pas';

--- a/packages/pas/src/contracts/ptb/ptb.ts
+++ b/packages/pas/src/contracts/ptb/ptb.ts
@@ -12,7 +12,10 @@ import {
 	type RawTransactionArgument,
 } from '../utils/index.js';
 import { bcs, type BcsType } from '@mysten/sui/bcs';
-import { type Transaction as Transaction_1 } from '@mysten/sui/transactions';
+import {
+	type Transaction as Transaction_1,
+	type TransactionArgument,
+} from '@mysten/sui/transactions';
 const $moduleName = '@mysten/ptb::ptb';
 export const Command = new MoveTuple({
 	name: `${$moduleName}::Command`,
@@ -532,14 +535,12 @@ export function extInputRaw(options: ExtInputRawOptions) {
 		});
 }
 export interface CommandArguments {
-	self: RawTransactionArgument<string>;
-	command: RawTransactionArgument<string>;
+	self: TransactionArgument;
+	command: TransactionArgument;
 }
 export interface CommandOptions {
 	package?: string;
-	arguments:
-		| CommandArguments
-		| [self: RawTransactionArgument<string>, command: RawTransactionArgument<string>];
+	arguments: CommandArguments | [self: TransactionArgument, command: TransactionArgument];
 }
 /**
  * Register a command in the Transaction builder. Returns the Argument, which is
@@ -559,14 +560,12 @@ export function command(options: CommandOptions) {
 		});
 }
 export interface NestedArguments {
-	self: RawTransactionArgument<string>;
+	self: TransactionArgument;
 	subIdx: RawTransactionArgument<number>;
 }
 export interface NestedOptions {
 	package?: string;
-	arguments:
-		| NestedArguments
-		| [self: RawTransactionArgument<string>, subIdx: RawTransactionArgument<number>];
+	arguments: NestedArguments | [self: TransactionArgument, subIdx: RawTransactionArgument<number>];
 }
 /**
  * Spawn a nested result out of a (just) `Result`. Simple result is a command
@@ -588,8 +587,8 @@ export interface MoveCallArguments {
 	packageId: RawTransactionArgument<string>;
 	moduleName: RawTransactionArgument<string>;
 	function: RawTransactionArgument<string>;
-	arguments: RawTransactionArgument<string[]>;
-	typeArguments: RawTransactionArgument<string[]>;
+	arguments: TransactionArgument;
+	typeArguments: RawTransactionArgument<Array<string>>;
 }
 export interface MoveCallOptions {
 	package?: string;
@@ -599,8 +598,8 @@ export interface MoveCallOptions {
 				packageId: RawTransactionArgument<string>,
 				moduleName: RawTransactionArgument<string>,
 				function: RawTransactionArgument<string>,
-				arguments: RawTransactionArgument<string[]>,
-				typeArguments: RawTransactionArgument<string[]>,
+				arguments: TransactionArgument,
+				typeArguments: RawTransactionArgument<Array<string>>,
 		  ];
 }
 /** Create a `MoveCall` command. */
@@ -623,14 +622,12 @@ export function moveCall(options: MoveCallOptions) {
 		});
 }
 export interface TransferObjectsArguments {
-	objects: RawTransactionArgument<string[]>;
-	to: RawTransactionArgument<string>;
+	objects: TransactionArgument;
+	to: TransactionArgument;
 }
 export interface TransferObjectsOptions {
 	package?: string;
-	arguments:
-		| TransferObjectsArguments
-		| [objects: RawTransactionArgument<string[]>, to: RawTransactionArgument<string>];
+	arguments: TransferObjectsArguments | [objects: TransactionArgument, to: TransactionArgument];
 }
 /**
  * Create a `TransferObjects` command Expects a vector of arguments to transfer and
@@ -649,14 +646,12 @@ export function transferObjects(options: TransferObjectsOptions) {
 		});
 }
 export interface SplitCoinsArguments {
-	coin: RawTransactionArgument<string>;
-	amounts: RawTransactionArgument<string[]>;
+	coin: TransactionArgument;
+	amounts: TransactionArgument;
 }
 export interface SplitCoinsOptions {
 	package?: string;
-	arguments:
-		| SplitCoinsArguments
-		| [coin: RawTransactionArgument<string>, amounts: RawTransactionArgument<string[]>];
+	arguments: SplitCoinsArguments | [coin: TransactionArgument, amounts: TransactionArgument];
 }
 /** Create a `SplitCoins` command. */
 export function splitCoins(options: SplitCoinsOptions) {
@@ -672,14 +667,12 @@ export function splitCoins(options: SplitCoinsOptions) {
 		});
 }
 export interface MergeCoinsArguments {
-	coin: RawTransactionArgument<string>;
-	coins: RawTransactionArgument<string[]>;
+	coin: TransactionArgument;
+	coins: TransactionArgument;
 }
 export interface MergeCoinsOptions {
 	package?: string;
-	arguments:
-		| MergeCoinsArguments
-		| [coin: RawTransactionArgument<string>, coins: RawTransactionArgument<string[]>];
+	arguments: MergeCoinsArguments | [coin: TransactionArgument, coins: TransactionArgument];
 }
 /**
  * Create a `MergeCoins` command. Takes a Coin Argument and a vector of other coin
@@ -698,16 +691,16 @@ export function mergeCoins(options: MergeCoinsOptions) {
 		});
 }
 export interface PublishArguments {
-	modulesBytes: RawTransactionArgument<number[][]>;
-	dependencies: RawTransactionArgument<string[]>;
+	modulesBytes: RawTransactionArgument<Array<Array<number>>>;
+	dependencies: RawTransactionArgument<Array<string>>;
 }
 export interface PublishOptions {
 	package?: string;
 	arguments:
 		| PublishArguments
 		| [
-				modulesBytes: RawTransactionArgument<number[][]>,
-				dependencies: RawTransactionArgument<string[]>,
+				modulesBytes: RawTransactionArgument<Array<Array<number>>>,
+				dependencies: RawTransactionArgument<Array<string>>,
 		  ];
 }
 /**
@@ -731,16 +724,13 @@ export function publish(options: PublishOptions) {
 }
 export interface MakeMoveVecArguments {
 	elementType: RawTransactionArgument<string | null>;
-	elements: RawTransactionArgument<string[]>;
+	elements: TransactionArgument;
 }
 export interface MakeMoveVecOptions {
 	package?: string;
 	arguments:
 		| MakeMoveVecArguments
-		| [
-				elementType: RawTransactionArgument<string | null>,
-				elements: RawTransactionArgument<string[]>,
-		  ];
+		| [elementType: RawTransactionArgument<string | null>, elements: TransactionArgument];
 }
 /**
  * Create a `MakeMoveVec` command. Takes an optional element type and a vector of
@@ -762,20 +752,20 @@ export function makeMoveVec(options: MakeMoveVecOptions) {
 		});
 }
 export interface UpgradeArguments {
-	modulesBytes: RawTransactionArgument<number[][]>;
-	dependencies: RawTransactionArgument<string[]>;
+	modulesBytes: RawTransactionArgument<Array<Array<number>>>;
+	dependencies: RawTransactionArgument<Array<string>>;
 	objectId: RawTransactionArgument<string>;
-	upgradeTicket: RawTransactionArgument<string>;
+	upgradeTicket: TransactionArgument;
 }
 export interface UpgradeOptions {
 	package?: string;
 	arguments:
 		| UpgradeArguments
 		| [
-				modulesBytes: RawTransactionArgument<number[][]>,
-				dependencies: RawTransactionArgument<string[]>,
+				modulesBytes: RawTransactionArgument<Array<Array<number>>>,
+				dependencies: RawTransactionArgument<Array<string>>,
 				objectId: RawTransactionArgument<string>,
-				upgradeTicket: RawTransactionArgument<string>,
+				upgradeTicket: TransactionArgument,
 		  ];
 }
 /**
@@ -800,11 +790,11 @@ export function upgrade(options: UpgradeOptions) {
 		});
 }
 export interface ExtArguments {
-	data: RawTransactionArgument<number[]>;
+	data: RawTransactionArgument<Array<number>>;
 }
 export interface ExtOptions {
 	package?: string;
-	arguments: ExtArguments | [data: RawTransactionArgument<number[]>];
+	arguments: ExtArguments | [data: RawTransactionArgument<Array<number>>];
 }
 /** Create an `Ext` command. */
 export function ext(options: ExtOptions) {

--- a/packages/pas/src/contracts/utils/index.ts
+++ b/packages/pas/src/contracts/utils/index.ts
@@ -1,3 +1,5 @@
+import { PASClientError } from '../../error.js';
+
 import {
 	bcs,
 	type BcsType,
@@ -10,24 +12,17 @@ import {
 import { normalizeSuiAddress } from '@mysten/sui/utils';
 import { type TransactionArgument, isArgument } from '@mysten/sui/transactions';
 import { type ClientWithCoreApi, type SuiClientTypes } from '@mysten/sui/client';
-import { PASClientError } from '../../error.js';
 
 const MOVE_STDLIB_ADDRESS = normalizeSuiAddress('0x1');
 const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;
@@ -151,7 +146,9 @@ export function normalizeMoveArguments(
 			const bytes = bcsType.serialize(arg as never);
 			normalizedArgs.push((tx) => tx.pure(bytes));
 			continue;
-		} else if (typeof arg === 'string') {
+		}
+
+		if (typeof arg === 'string') {
 			normalizedArgs.push((tx) => tx.object(arg));
 			continue;
 		}

--- a/packages/pas/sui-codegen.config.ts
+++ b/packages/pas/sui-codegen.config.ts
@@ -5,6 +5,10 @@ import type { SuiCodegenConfig } from '@mysten/codegen';
 
 const config: SuiCodegenConfig = {
 	output: './src/contracts',
+	errorClass: {
+		name: 'PASClientError',
+		source: '../../error.js',
+	},
 	packages: [
 		{
 			package: '@mysten/pas',

--- a/packages/payment-kit/src/contracts/utils/index.ts
+++ b/packages/payment-kit/src/contracts/utils/index.ts
@@ -16,17 +16,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;

--- a/packages/suins/src/contracts/suins/controller.ts
+++ b/packages/suins/src/contracts/suins/controller.ts
@@ -2,14 +2,22 @@
  * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
  **************************************************************/
 import {
-	MoveTuple,
 	MoveStruct,
+	MoveTuple,
 	normalizeMoveArguments,
 	type RawTransactionArgument,
 } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
 import { type Transaction } from '@mysten/sui/transactions';
+import * as domain from './domain.js';
 const $moduleName = '@suins/core::controller';
+export const SubnamePrunedEvent = new MoveStruct({
+	name: `${$moduleName}::SubnamePrunedEvent`,
+	fields: {
+		subdomain: domain.Domain,
+		parent_domain: domain.Domain,
+	},
+});
 export const ControllerV2 = new MoveTuple({
 	name: `${$moduleName}::ControllerV2`,
 	fields: [bcs.bool()],
@@ -264,6 +272,92 @@ export function burnExpiredSubname(options: BurnExpiredSubnameOptions) {
 			package: packageAddress,
 			module: 'controller',
 			function: 'burn_expired_subname',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface PruneExpiredSubnameArguments {
+	suins: RawTransactionArgument<string>;
+	parent: RawTransactionArgument<string>;
+	subdomainName: RawTransactionArgument<string>;
+}
+export interface PruneExpiredSubnameOptions {
+	package?: string;
+	arguments:
+		| PruneExpiredSubnameArguments
+		| [
+				suins: RawTransactionArgument<string>,
+				parent: RawTransactionArgument<string>,
+				subdomainName: RawTransactionArgument<string>,
+		  ];
+}
+/**
+ * Prunes an expired subdomain record from the registry by name, gated by ownership
+ * of the parent. This allows the parent holder to clean up expired subdomain
+ * records even when they don't possess the SubDomainRegistration object. After
+ * pruning, the subdomain name becomes available for re-registration. The orphaned
+ * SubDomainRegistration object (if it still exists) becomes useless.
+ *
+ * Use this when you control the parent domain but someone else holds the expired
+ * subdomain NFT.
+ */
+export function pruneExpiredSubname(options: PruneExpiredSubnameOptions) {
+	const packageAddress = options.package ?? '@suins/core';
+	const argumentsTypes = [null, null, '0x1::string::String', '0x2::clock::Clock'] satisfies (
+		| string
+		| null
+	)[];
+	const parameterNames = ['suins', 'parent', 'subdomainName'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'controller',
+			function: 'prune_expired_subname',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface PruneExpiredSubnamesArguments {
+	suins: RawTransactionArgument<string>;
+	parent: RawTransactionArgument<string>;
+	subdomainNames: RawTransactionArgument<Array<string>>;
+}
+export interface PruneExpiredSubnamesOptions {
+	package?: string;
+	arguments:
+		| PruneExpiredSubnamesArguments
+		| [
+				suins: RawTransactionArgument<string>,
+				parent: RawTransactionArgument<string>,
+				subdomainNames: RawTransactionArgument<Array<string>>,
+		  ];
+}
+/**
+ * Best-effort pruning of multiple expired subdomain records for a given parent.
+ *
+ * This function does **not** abort if individual entries are:
+ *
+ * - not subdomains,
+ * - not direct children of the parent,
+ * - missing from the registry,
+ * - not expired,
+ * - leaf records.
+ *
+ * It prunes what it can, emitting `SubnamePrunedEvent` for each successfully
+ * pruned record, and returns the total count of pruned entries.
+ */
+export function pruneExpiredSubnames(options: PruneExpiredSubnamesOptions) {
+	const packageAddress = options.package ?? '@suins/core';
+	const argumentsTypes = [
+		null,
+		null,
+		'vector<0x1::string::String>',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['suins', 'parent', 'subdomainNames'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'controller',
+			function: 'prune_expired_subnames',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
 		});
 }

--- a/packages/suins/src/contracts/utils/index.ts
+++ b/packages/suins/src/contracts/utils/index.ts
@@ -16,17 +16,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -16,17 +16,11 @@ const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress('0x2');
 
 export type RawTransactionArgument<T> = T | TransactionArgument;
 
-export interface GetOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectOptions<Include> & { client: ClientWithCoreApi };
 
-export interface GetManyOptions<
-	Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {},
-> extends SuiClientTypes.GetObjectsOptions<Include> {
-	client: ClientWithCoreApi;
-}
+export type GetManyOptions<Include extends Omit<SuiClientTypes.ObjectInclude, 'content'> = {}> =
+	SuiClientTypes.GetObjectsOptions<Include> & { client: ClientWithCoreApi };
 
 export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null {
 	const parsedTag = typeof typeTag === 'string' ? TypeTagSerializer.parseFromStr(typeTag) : typeTag;

--- a/packages/walrus/src/contracts/walrus/init.ts
+++ b/packages/walrus/src/contracts/walrus/init.ts
@@ -112,7 +112,8 @@ export interface MigrateV2Options {
  * Migrate to version 3:
  *
  * - Create the slashing manager shared object.
- * - Do not use migration epoch.
+ * - Do not use migration epoch. Migrate to version 4:
+ * - No additional steps beyond version bump.
  */
 export function migrateV2(options: MigrateV2Options) {
 	const packageAddress = options.package ?? '@local-pkg/walrus';


### PR DESCRIPTION
## Description

`sui-ts-codegen generate` emitted only the `utils/` folder for upgraded on-chain packages. Root cause: `isMainPackage()` matched the summary dir name against `root_package_id` (the queried/latest id), but `sui move summary --package-id` writes that dir under `root_package_original_id` (v1) — so the match always failed and every module was pruned.

This PR:

- Detects the main package directory by elimination from the on-disk listing using `metadata.dependencies`. Works for raw ids, MVR names, upgraded, and non-upgraded packages alike.
- Uses each type's introducing package version for BCS type names. Type origins are read per-(package, module) from the summary metadata, so structs added in upgrades — for both the root and any upgraded deps — render with the correct on-chain address. Verified against real upgraded SuiNS and DeepBook v3 mainnet packages: the `EWMAUpdate` type tag we generate (`0x00c1a56e...`) matches the on-chain event tag exactly.
- Falls back to `root_package_original_id` for the root when per-type origins aren't in the summary. Correct for packages whose every type was introduced at v1; older `sui` CLI versions drop the root's `type_origin_table` from the summary, so structs added in later upgrades will be wrong until the user moves to a CLI with the upstream fix in <https://github.com/MystenLabs/sui/pull/26391>.
- Adds an `errorClass` config option so consumers can throw a custom error class from `normalizeMoveArguments` in the generated `utils/index.ts`. The pas SDK uses this to keep `PASClientError` after regen.
- Regenerates `pas`, `suins`, `walrus`, `kiosk`, `payment-kit`, and `deepbook-v3` against latest contract sources.

## Test plan

- [x] 90 unit tests pass (added 14 new ones covering the upgraded-package paths, type-origin scoping, errorClass substitution, and a regression guard for `$moduleName` ordering)
- [x] Typecheck + lint clean
- [x] All 6 SDK packages rebuild cleanly (24/24 turbo tasks)
- [x] End-to-end validated against real upgraded mainnet packages (SuiNS, DeepBook v3): generated BCS type addresses match on-chain `objType` / event-tag addresses exactly
- [x] Local-source regeneration produces zero unwanted diff in dep modules — `0x2`/`0x3` framework shortcuts and MVR-name prefixes preserved when type origins match the module's own address

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)