### PR TITLE
Fix codegen utils import off-by-one for multi-segment packageName

### DIFF
--- a/.changeset/fix-codegen-utils-import-multi-segment.md
+++ b/.changeset/fix-codegen-utils-import-multi-segment.md
@@ -1,0 +1,10 @@
+---
+'@mysten/codegen': patch
+---
+
+Fix off-by-one in utils/ import paths for multi-segment package names. Generated modules
+imported utils as `../utils/index.js`, anchored to a virtual single-segment package directory.
+When `packageName` contains a slash (e.g. callers nesting output under `move/<pkg>/` to mirror
+Move source layout), the import resolved into a sibling subdirectory of `outputDir` instead of
+to the actual `outputDir/utils/`. Utils imports are now anchored at the codegen output root, so
+they work regardless of `packageName` depth.

--- a/packages/codegen/src/file-builder.ts
+++ b/packages/codegen/src/file-builder.ts
@@ -65,7 +65,7 @@ export class FileBuilder {
 		].join('\n');
 	}
 
-	async toString(modDir: string, filePath: string) {
+	async toString(packageDir: string, filePath: string, outputDir: string = packageDir) {
 		const importStatements = [...this.imports.entries()].flatMap(
 			([module, names]) =>
 				parseTS`import { ${[...names].join(', ')} } from '${modulePath(module)}'`,
@@ -77,12 +77,20 @@ export class FileBuilder {
 		return `${await this.getHeader()}${printNodes(...importStatements, ...starImportStatements, ...this.statements)}`;
 
 		function modulePath(mod: string) {
-			if (!mod.startsWith('~root/')) {
-				return mod;
-			}
+			// `~root/` is anchored at the package's own output directory (where deps/ lives).
+			// `~outputRoot/` is anchored at the codegen output directory (where utils/ lives).
+			// Splitting these matters when packageName contains a slash — `~root/../utils` would
+			// only escape one segment and land in a sibling subdirectory rather than at outputDir.
+			const anchor = mod.startsWith('~outputRoot/')
+				? outputDir
+				: mod.startsWith('~root/')
+					? packageDir
+					: null;
+			if (anchor === null) return mod;
 
-			const sourcePath = resolve(modDir, filePath);
-			const destPath = resolve(modDir, mod.replace('~root/', './'));
+			const placeholder = mod.startsWith('~outputRoot/') ? '~outputRoot/' : '~root/';
+			const sourcePath = resolve(packageDir, filePath);
+			const destPath = resolve(anchor, mod.replace(placeholder, './'));
 			const sourceDirectory = sourcePath.split('/').slice(0, -1).join('/');
 			const relativePath = relative(sourceDirectory, destPath);
 			return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -208,14 +208,14 @@ export async function generateFromPackageSummary({
 				{ recursive: true },
 			);
 
+			const packageDir = join(outputDir, packageName);
+			const fileRelToPackage = mod.isMainPackage
+				? `${mod.module}.ts`
+				: join('deps', mod.package, `${mod.module}.ts`);
+
 			await writeFile(
-				mod.isMainPackage
-					? join(outputDir, packageName, `${mod.module}.ts`)
-					: join(outputDir, packageName, 'deps', mod.package, `${mod.module}.ts`),
-				await mod.builder.toString(
-					'./',
-					mod.isMainPackage ? `./${mod.module}.ts` : `./deps/${mod.package}/${mod.module}.ts`,
-				),
+				join(packageDir, fileRelToPackage),
+				await mod.builder.toString(packageDir, fileRelToPackage, outputDir),
 			);
 		}),
 	);

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -30,11 +30,11 @@ const IMPORT_MAP = {
 	TransactionArgument: { module: '@mysten/sui/transactions', isType: true },
 	BcsType: { module: '@mysten/sui/bcs', isType: true },
 	bcs: { module: '@mysten/sui/bcs', isType: false },
-	MoveStruct: { module: '~root/../utils/index', isType: false },
-	MoveTuple: { module: '~root/../utils/index', isType: false },
-	MoveEnum: { module: '~root/../utils/index', isType: false },
-	normalizeMoveArguments: { module: '~root/../utils/index', isType: false },
-	RawTransactionArgument: { module: '~root/../utils/index', isType: true },
+	MoveStruct: { module: '~outputRoot/utils/index', isType: false },
+	MoveTuple: { module: '~outputRoot/utils/index', isType: false },
+	MoveEnum: { module: '~outputRoot/utils/index', isType: false },
+	normalizeMoveArguments: { module: '~outputRoot/utils/index', isType: false },
+	RawTransactionArgument: { module: '~outputRoot/utils/index', isType: true },
 } as const;
 
 type ImportName = keyof typeof IMPORT_MAP;
@@ -135,9 +135,10 @@ export class MoveModuleBuilder extends FileBuilder {
 			const config = IMPORT_MAP[name];
 			const importSpec = config.isType ? `type ${name}` : name;
 			// Add extension for relative imports (utils)
-			const module = config.module.startsWith('~root')
-				? `${config.module}${this.#importExtension}`
-				: config.module;
+			const module =
+				config.module.startsWith('~root') || config.module.startsWith('~outputRoot')
+					? `${config.module}${this.#importExtension}`
+					: config.module;
 			this.#importNames[name] = this.addImport(module, importSpec);
 		}
 		return this.#importNames[name]!;

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -761,6 +761,60 @@ describe('generate options', () => {
 		});
 	});
 
+	describe('utils import paths', () => {
+		// Set up a fixture once for all import-path tests.
+		let fixturePath: string;
+		let testFixtureOutput: string;
+
+		afterEach(async () => {
+			if (fixturePath) await rm(fixturePath, { recursive: true, force: true });
+			if (testFixtureOutput) await rm(testFixtureOutput, { recursive: true, force: true });
+		});
+
+		async function generateWithPackageName(packageName: string, prune: boolean): Promise<string> {
+			fixturePath = await mkdtemp(join(tmpdir(), 'codegen-pkgname-'));
+			const summaryDir = join(fixturePath, 'package_summaries');
+			await mkdir(summaryDir, { recursive: true });
+			await writeFile(
+				join(fixturePath, 'Move.toml'),
+				'[package]\nname = "testpkg"\nedition = "2024.beta"\n\n[addresses]\ntestpkg = "0x0"\n',
+			);
+			await cp(join(FIXTURE_PATH, 'package_summaries'), summaryDir, { recursive: true });
+			testFixtureOutput = await mkdtemp(join(tmpdir(), 'codegen-test-'));
+			await generateFromPackageSummary({
+				package: { package: '@test/testpkg', path: fixturePath, packageName },
+				prune,
+				outputDir: testFixtureOutput,
+			});
+			return testFixtureOutput;
+		}
+
+		it('emits correct utils import for single-segment packageName', async () => {
+			outputDir = await generateWithPackageName('testpkg', true);
+			const counter = await getFileContent(outputDir, 'testpkg/counter.ts');
+			// File at outputDir/testpkg/counter.ts — utils at outputDir/utils/index.ts → ../utils/index.js
+			expect(counter).toContain("from '../utils/index.js'");
+		});
+
+		it('emits correct utils import for multi-segment packageName (regression)', async () => {
+			// Regression: when packageName has slashes (e.g. when callers nest output under a
+			// `move/` parent dir to mirror Move source layout), the import path must escape every
+			// segment to reach the outputDir-level utils/. Previously it always used a single `..`
+			// and resolved into a sibling subdirectory of outputDir.
+			outputDir = await generateWithPackageName('move/mock_usdc', false);
+			const counter = await getFileContent(outputDir, 'move/mock_usdc/counter.ts');
+			// File at outputDir/move/mock_usdc/counter.ts → ../../utils/index.js
+			expect(counter).toContain("from '../../utils/index.js'");
+			expect(counter).not.toContain("from '../utils/index.js'");
+
+			// Dep modules nest one further under deps/<addr>/ — must add another level too.
+			const ascii = await getFileContent(outputDir, 'move/mock_usdc/deps/std/ascii.ts');
+			// File at outputDir/move/mock_usdc/deps/std/ascii.ts → ../../../../utils/index.js
+			expect(ascii).toContain("from '../../../../utils/index.js'");
+			expect(ascii).not.toContain("from '../../../utils/index.js'");
+		});
+	});
+
 	describe('on-chain (upgraded) packages', () => {
 		let onChainPath: string;
 


### PR DESCRIPTION
## Description

Generated modules imported `utils/` as `../utils/index.js`, hard-coding a single `..` to escape what was assumed to be a single-segment package directory. When `packageName` contains a slash — e.g. when callers nest codegen output under a `move/<pkg>/` parent dir to mirror the Move source layout — the import resolves into a sibling subdirectory of `outputDir` instead of `outputDir/utils/`.

Concretely (from a `packageName: 'move/mock_usdc'` setup):

```
outputDir/move/mock_usdc/counter.ts
  import … from '../utils/index.js'        → outputDir/move/utils  ❌
outputDir/move/mock_usdc/deps/std/ascii.ts
  import … from '../../../utils/index.js'  → outputDir/move/utils  ❌
```

Utils imports are now anchored at the codegen output root via a new `~outputRoot/` placeholder, so the relative path correctly escapes every segment of `packageName`:

```
outputDir/move/mock_usdc/counter.ts
  import … from '../../utils/index.js'         → outputDir/utils  ✓
outputDir/move/mock_usdc/deps/std/ascii.ts
  import … from '../../../../utils/index.js'   → outputDir/utils  ✓
```

Cross-dep imports continue to resolve against the package directory via the existing `~root/` placeholder.

## Test plan

- [x] New regression test in `tests/generate-options.test.ts`: asserts the utils import string is correct for both single-segment (`testpkg`) and multi-segment (`move/mock_usdc`) `packageName`, for both main modules and nested deps.
- [x] All 95 codegen tests pass.
- [x] Re-ran codegen on `payment-kit`, `pas`, `walrus`, `suins`, `deepbook-v3`, and `kiosk` — zero diff in `src/contracts/` (all use single-segment package names, so the relative path `../utils/...` is unchanged for them).

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)