### PR TITLE
Bump codegen multi-segment regression test timeout to 30s

### DIFF
--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -796,23 +796,31 @@ describe('generate options', () => {
 			expect(counter).toContain("from '../utils/index.js'");
 		});
 
-		it('emits correct utils import for multi-segment packageName (regression)', async () => {
-			// Regression: when packageName has slashes (e.g. when callers nest output under a
-			// `move/` parent dir to mirror Move source layout), the import path must escape every
-			// segment to reach the outputDir-level utils/. Previously it always used a single `..`
-			// and resolved into a sibling subdirectory of outputDir.
-			outputDir = await generateWithPackageName('move/mock_usdc', false);
-			const counter = await getFileContent(outputDir, 'move/mock_usdc/counter.ts');
-			// File at outputDir/move/mock_usdc/counter.ts → ../../utils/index.js
-			expect(counter).toContain("from '../../utils/index.js'");
-			expect(counter).not.toContain("from '../utils/index.js'");
+		it(
+			'emits correct utils import for multi-segment packageName (regression)',
+			{ timeout: 30_000 },
+			async () => {
+				// Regression: when packageName has slashes (e.g. when callers nest output under a
+				// `move/` parent dir to mirror Move source layout), the import path must escape every
+				// segment to reach the outputDir-level utils/. Previously it always used a single `..`
+				// and resolved into a sibling subdirectory of outputDir.
+				//
+				// `prune: false` here so we can exercise both the main-module and the deeper
+				// `deps/<addr>/<mod>.ts` paths, which adds enough I/O that the default 5s timeout
+				// can be tight under CI load — match the existing `prune: false` test's budget.
+				outputDir = await generateWithPackageName('move/mock_usdc', false);
+				const counter = await getFileContent(outputDir, 'move/mock_usdc/counter.ts');
+				// File at outputDir/move/mock_usdc/counter.ts → ../../utils/index.js
+				expect(counter).toContain("from '../../utils/index.js'");
+				expect(counter).not.toContain("from '../utils/index.js'");
 
-			// Dep modules nest one further under deps/<addr>/ — must add another level too.
-			const ascii = await getFileContent(outputDir, 'move/mock_usdc/deps/std/ascii.ts');
-			// File at outputDir/move/mock_usdc/deps/std/ascii.ts → ../../../../utils/index.js
-			expect(ascii).toContain("from '../../../../utils/index.js'");
-			expect(ascii).not.toContain("from '../../../utils/index.js'");
-		});
+				// Dep modules nest one further under deps/<addr>/ — must add another level too.
+				const ascii = await getFileContent(outputDir, 'move/mock_usdc/deps/std/ascii.ts');
+				// File at outputDir/move/mock_usdc/deps/std/ascii.ts → ../../../../utils/index.js
+				expect(ascii).toContain("from '../../../../utils/index.js'");
+				expect(ascii).not.toContain("from '../../../utils/index.js'");
+			},
+		);
 	});
 
 	describe('on-chain (upgraded) packages', () => {


### PR DESCRIPTION
## Description

The `emits correct utils import for multi-segment packageName` regression test added in #1040 exercises `prune: false`, which copies and renders every std/sui dep module. Local runs finish under 1s, but the I/O budget pushes past vitest's default 5s timeout on CI, breaking `Turborepo CI` on `main`.

Matches the existing `prune: false includes dependency modules in deps/` test's `{ timeout: 30_000 }` so this case has the same headroom.

No production code changes — just the test timeout.

## Test plan

- [x] `pnpm --filter @mysten/codegen test` — 95/95 pass.
- [x] Lint clean.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)