### PR TITLE
Fix latent type errors in generated utils/index.ts and typecheck it in tests

### DIFF
--- a/.changeset/fix-codegen-utils-strict-noUncheckedIndexedAccess.md
+++ b/.changeset/fix-codegen-utils-strict-noUncheckedIndexedAccess.md
@@ -1,0 +1,27 @@
+---
+'@mysten/codegen': patch
+'@mysten/deepbook-v3': patch
+'@mysten/kiosk': patch
+'@mysten/pas': patch
+'@mysten/payment-kit': patch
+'@mysten/suins': patch
+'@mysten/walrus': patch
+---
+
+Fix three latent type errors in the generated `utils/index.ts` that surfaced for consumers
+with `noUncheckedIndexedAccess: true`:
+
+- `getPureBcsSchema(structTag.typeParams[0])` passed `TypeTag | undefined` to a parameter
+  typed `string | TypeTag`. Now null-checks the inner tag before passing it.
+- `argTypes[i]` was redundantly re-indexed inside a `for…of entries()` loop, returning
+  `string | null | undefined` and being passed back to `getPureBcsSchema`. Switched to the
+  loop variable, which is `string | null`.
+- `MoveStruct.get()` returned the destructured `[res]` from `getMany([objectId])` without
+  asserting it was defined. Now throws if no object was returned.
+
+The codegen test suite gained a `tsc`-based check that compiles the generated `utils/index.ts`
+under strict + `noUncheckedIndexedAccess`, so embedded-template type bugs are caught before
+release rather than by downstream consumers.
+
+All consumer packages (`payment-kit`, `pas`, `walrus`, `suins`, `deepbook-v3`, `kiosk`) have
+been regenerated with the fix.

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -77,7 +77,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -157,8 +158,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -171,7 +171,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new __ERROR_CLASS__(\`Invalid argument \${stringify(arg)} for type \${type}\`);
+		throw new __ERROR_CLASS__(\`Invalid argument \${stringify(arg)} for type \${argType}\`);
 	}
 
 	return normalizedArgs;
@@ -191,6 +191,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new __ERROR_CLASS__(\`No object found for id \${objectId}\`);
+		}
 
 		return res;
 	}

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -110,7 +110,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -796,23 +796,31 @@ describe('generate options', () => {
 			expect(counter).toContain("from '../utils/index.js'");
 		});
 
-		it('emits correct utils import for multi-segment packageName (regression)', async () => {
-			// Regression: when packageName has slashes (e.g. when callers nest output under a
-			// `move/` parent dir to mirror Move source layout), the import path must escape every
-			// segment to reach the outputDir-level utils/. Previously it always used a single `..`
-			// and resolved into a sibling subdirectory of outputDir.
-			outputDir = await generateWithPackageName('move/mock_usdc', false);
-			const counter = await getFileContent(outputDir, 'move/mock_usdc/counter.ts');
-			// File at outputDir/move/mock_usdc/counter.ts → ../../utils/index.js
-			expect(counter).toContain("from '../../utils/index.js'");
-			expect(counter).not.toContain("from '../utils/index.js'");
+		it(
+			'emits correct utils import for multi-segment packageName (regression)',
+			{ timeout: 30_000 },
+			async () => {
+				// Regression: when packageName has slashes (e.g. when callers nest output under a
+				// `move/` parent dir to mirror Move source layout), the import path must escape every
+				// segment to reach the outputDir-level utils/. Previously it always used a single `..`
+				// and resolved into a sibling subdirectory of outputDir.
+				//
+				// `prune: false` here so we can exercise both the main-module and the deeper
+				// `deps/<addr>/<mod>.ts` paths, which adds enough I/O that the default 5s timeout
+				// can be tight under CI load — match the existing `prune: false` test's budget.
+				outputDir = await generateWithPackageName('move/mock_usdc', false);
+				const counter = await getFileContent(outputDir, 'move/mock_usdc/counter.ts');
+				// File at outputDir/move/mock_usdc/counter.ts → ../../utils/index.js
+				expect(counter).toContain("from '../../utils/index.js'");
+				expect(counter).not.toContain("from '../utils/index.js'");
 
-			// Dep modules nest one further under deps/<addr>/ — must add another level too.
-			const ascii = await getFileContent(outputDir, 'move/mock_usdc/deps/std/ascii.ts');
-			// File at outputDir/move/mock_usdc/deps/std/ascii.ts → ../../../../utils/index.js
-			expect(ascii).toContain("from '../../../../utils/index.js'");
-			expect(ascii).not.toContain("from '../../../utils/index.js'");
-		});
+				// Dep modules nest one further under deps/<addr>/ — must add another level too.
+				const ascii = await getFileContent(outputDir, 'move/mock_usdc/deps/std/ascii.ts');
+				// File at outputDir/move/mock_usdc/deps/std/ascii.ts → ../../../../utils/index.js
+				expect(ascii).toContain("from '../../../../utils/index.js'");
+				expect(ascii).not.toContain("from '../../../utils/index.js'");
+			},
+		);
 	});
 
 	describe('on-chain (upgraded) packages', () => {

--- a/packages/codegen/tests/generated-utils-typecheck.test.ts
+++ b/packages/codegen/tests/generated-utils-typecheck.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { getUtilsContent } from '../src/generate-utils.js';
+
+// Type-check the generated `utils/index.ts` content against the strictest reasonable consumer
+// tsconfig (project `strict` + `noUncheckedIndexedAccess`). The utils content lives inside a
+// JS template literal in `generate-utils.ts`, so it is invisible to the codegen package's own
+// `tsc --noEmit` — without this test, embedded-TS bugs only surface when downstream consumers
+// with strict tsconfigs build the generated output.
+//
+// The temp file is written under `tests/` so module resolution finds `@mysten/sui` via the
+// codegen package's own `node_modules` (workspace symlinks).
+describe('generated utils/index.ts typechecks', () => {
+	it('passes strict + noUncheckedIndexedAccess', async () => {
+		const tempPath = join(__dirname, '__generated_utils_typecheck.ts');
+		await writeFile(tempPath, getUtilsContent());
+
+		try {
+			const program = ts.createProgram({
+				rootNames: [tempPath],
+				options: {
+					target: ts.ScriptTarget.ES2020,
+					module: ts.ModuleKind.NodeNext,
+					moduleResolution: ts.ModuleResolutionKind.NodeNext,
+					strict: true,
+					noUncheckedIndexedAccess: true,
+					noEmit: true,
+					skipLibCheck: true,
+					esModuleInterop: true,
+					resolveJsonModule: true,
+					lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
+				},
+			});
+
+			const diagnostics = ts
+				.getPreEmitDiagnostics(program)
+				.filter((d) => d.file?.fileName === tempPath);
+
+			const messages = diagnostics.map((d) => {
+				const text = ts.flattenDiagnosticMessageText(d.messageText, '\n');
+				if (d.file && d.start !== undefined) {
+					const { line, character } = d.file.getLineAndCharacterOfPosition(d.start);
+					return `[utils/index.ts:${line + 1}:${character + 1}] ${text}`;
+				}
+				return text;
+			});
+
+			expect(messages, `Generated utils/index.ts has type errors:\n${messages.join('\n')}`).toEqual(
+				[],
+			);
+		} finally {
+			await rm(tempPath, { force: true });
+		}
+	});
+});

--- a/packages/codegen/tests/generated-utils-typecheck.test.ts
+++ b/packages/codegen/tests/generated-utils-typecheck.test.ts
@@ -16,7 +16,9 @@ import { getUtilsContent } from '../src/generate-utils.js';
 // The temp file is written under `tests/` so module resolution finds `@mysten/sui` via the
 // codegen package's own `node_modules` (workspace symlinks).
 describe('generated utils/index.ts typechecks', () => {
-	it('passes strict + noUncheckedIndexedAccess', async () => {
+	// `ts.createProgram` plus `getPreEmitDiagnostics` over the @mysten/sui type tree
+	// runs ~700ms locally but pushes past vitest's 5s default on CI. Give it room.
+	it('passes strict + noUncheckedIndexedAccess', { timeout: 30_000 }, async () => {
 		const tempPath = join(__dirname, '__generated_utils_typecheck.ts');
 		await writeFile(tempPath, getUtilsContent());
 

--- a/packages/codegen/tests/generated-utils-typecheck.test.ts
+++ b/packages/codegen/tests/generated-utils-typecheck.test.ts
@@ -27,7 +27,14 @@ describe('generated utils/index.ts typechecks', () => {
 					target: ts.ScriptTarget.ES2020,
 					module: ts.ModuleKind.NodeNext,
 					moduleResolution: ts.ModuleResolutionKind.NodeNext,
+					// Mirror tsconfig.shared.json's strictness so consumer-build failures (e.g.
+					// TS6133 unused locals) are caught here, plus `noUncheckedIndexedAccess` for
+					// the strictest reasonable consumer.
 					strict: true,
+					noUnusedLocals: true,
+					noUnusedParameters: true,
+					noImplicitReturns: true,
+					noFallthroughCasesInSwitch: true,
 					noUncheckedIndexedAccess: true,
 					noEmit: true,
 					skipLibCheck: true,

--- a/packages/deepbook-v3/src/contracts/utils/index.ts
+++ b/packages/deepbook-v3/src/contracts/utils/index.ts
@@ -90,7 +90,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/deepbook-v3/src/contracts/utils/index.ts
+++ b/packages/deepbook-v3/src/contracts/utils/index.ts
@@ -57,7 +57,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -137,8 +138,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -151,7 +151,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new Error(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -173,6 +173,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new Error(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}

--- a/packages/kiosk/src/contracts/utils/index.ts
+++ b/packages/kiosk/src/contracts/utils/index.ts
@@ -90,7 +90,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/kiosk/src/contracts/utils/index.ts
+++ b/packages/kiosk/src/contracts/utils/index.ts
@@ -57,7 +57,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -137,8 +138,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -151,7 +151,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new Error(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -173,6 +173,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new Error(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}

--- a/packages/pas/src/contracts/utils/index.ts
+++ b/packages/pas/src/contracts/utils/index.ts
@@ -92,7 +92,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/pas/src/contracts/utils/index.ts
+++ b/packages/pas/src/contracts/utils/index.ts
@@ -59,7 +59,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -139,8 +140,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -153,7 +153,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new PASClientError(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new PASClientError(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -175,6 +175,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new PASClientError(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}

--- a/packages/payment-kit/src/contracts/utils/index.ts
+++ b/packages/payment-kit/src/contracts/utils/index.ts
@@ -90,7 +90,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/payment-kit/src/contracts/utils/index.ts
+++ b/packages/payment-kit/src/contracts/utils/index.ts
@@ -57,7 +57,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -137,8 +138,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -151,7 +151,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new Error(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -173,6 +173,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new Error(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}

--- a/packages/suins/src/contracts/utils/index.ts
+++ b/packages/suins/src/contracts/utils/index.ts
@@ -90,7 +90,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/suins/src/contracts/utils/index.ts
+++ b/packages/suins/src/contracts/utils/index.ts
@@ -57,7 +57,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -137,8 +138,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -151,7 +151,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new Error(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -173,6 +173,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new Error(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -90,7 +90,7 @@ export function normalizeMoveArguments(
 	const normalizedArgs: TransactionArgument[] = [];
 
 	let index = 0;
-	for (const [i, argType] of argTypes.entries()) {
+	for (const argType of argTypes) {
 		if (argType === '0x2::clock::Clock') {
 			normalizedArgs.push((tx) => tx.object.clock());
 			continue;

--- a/packages/walrus/src/contracts/utils/index.ts
+++ b/packages/walrus/src/contracts/utils/index.ts
@@ -57,7 +57,8 @@ export function getPureBcsSchema(typeTag: string | TypeTag): BcsType<any> | null
 			}
 
 			if (structTag.module === 'option' && structTag.name === 'Option') {
-				const type = getPureBcsSchema(structTag.typeParams[0]);
+				const inner = structTag.typeParams[0];
+				const type = inner ? getPureBcsSchema(inner) : null;
 				return type ? bcs.option(type) : null;
 			}
 		}
@@ -137,8 +138,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		const type = argTypes[i];
-		const bcsType = type === null ? null : getPureBcsSchema(type);
+		const bcsType = argType === null ? null : getPureBcsSchema(argType);
 
 		if (bcsType) {
 			const bytes = bcsType.serialize(arg as never);
@@ -151,7 +151,7 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
-		throw new Error(`Invalid argument ${stringify(arg)} for type ${type}`);
+		throw new Error(`Invalid argument ${stringify(arg)} for type ${argType}`);
 	}
 
 	return normalizedArgs;
@@ -173,6 +173,10 @@ export class MoveStruct<
 			...options,
 			objectIds: [objectId],
 		});
+
+		if (!res) {
+			throw new Error(`No object found for id ${objectId}`);
+		}
 
 		return res;
 	}


### PR DESCRIPTION
## Description

Three latent type errors in the generated `utils/index.ts` surfaced for downstream consumers running `tsc` with `noUncheckedIndexedAccess: true`, but were invisible in this monorepo because:

- The utils content is a JS template literal in `generate-utils.ts` — `tsc --noEmit` on the codegen package only sees a `string`, never the embedded TS.
- The shared tsconfig (`tsconfig.shared.json`) has `strict: true` but not `noUncheckedIndexedAccess`.
- Codegen tests rendered output and substring-matched, never compiling the generated file.

### The three bugs

| Line | Code | Issue |
|---|---|---|
| 80 | `getPureBcsSchema(structTag.typeParams[0])` | `typeParams[0]` is `TypeTag \| undefined` under strict indexing; param expects `string \| TypeTag`. |
| 161 | `const type = argTypes[i];` followed by `getPureBcsSchema(type)` | `argTypes[i]` is redundantly re-indexed inside a `for…of entries()` loop, returning `string \| null \| undefined`. Switched to the iteration variable (typed `string \| null`). |
| 195 | `const [res] = await this.getMany(...); return res;` | Destructured array element is `T \| undefined`; the function's return type is non-nullable. Throw if `getMany` returned nothing. |

### How we now catch this

Added `tests/generated-utils-typecheck.test.ts`. It runs the TypeScript compiler API over a fresh `getUtilsContent()` rendering with strict + `noUncheckedIndexedAccess: true` and asserts zero diagnostics. Embedded-template type bugs will now fail in codegen CI rather than reach strict consumers. (Confirmed: this test reports all three errors against the unfixed source and passes after the fixes.)

This stays scoped to `@mysten/codegen` — we do not flip `noUncheckedIndexedAccess` on for the in-repo SDK packages (would be a much larger cleanup).

## Test plan

- [x] New typecheck test fails on the unfixed `generate-utils.ts` (caught all three issues with line/column).
- [x] Test passes after the fixes — 96/96 codegen tests green.
- [x] Lint clean (oxlint + prettier).
- [x] Re-ran codegen on `payment-kit`, `pas`, `walrus`, `suins`, `deepbook-v3`, and `kiosk`. Diff in each is **exactly** the three utils fixes — no other unintended changes.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)