### PR TITLE
docs: add sitemap and middleware for serving `Accept: text/markdown` header

### DIFF
--- a/packages/docs/app/sitemap.ts
+++ b/packages/docs/app/sitemap.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MetadataRoute } from 'next';
+
+import { source } from '@/lib/source';
+
+const BASE_URL = 'https://sdk.mystenlabs.com';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	return source.getPages().map((page) => ({
+		url: `${BASE_URL}${page.url}`,
+		changeFrequency: 'weekly',
+	}));
+}

--- a/packages/docs/middleware.ts
+++ b/packages/docs/middleware.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { type NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+	const accept = request.headers.get('accept') ?? '';
+
+	if (accept.includes('text/markdown')) {
+		const url = request.nextUrl.clone();
+		url.pathname = `/api/md${request.nextUrl.pathname}`;
+		return NextResponse.rewrite(url);
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: ['/((?!api/|_next/|llms\\.txt|.*\\.(?:md|txt|ico|png|jpg|svg|css|js)$).*)'],
+};


### PR DESCRIPTION
## Description

2 fixes to make the following agent-friendly docs tests pass:

FAIL: content-negotiation                                                                                                        
                           
  Server ignores Accept: text/markdown header — 0/82 pages return markdown when requested via content negotiation. All return
  text/html; charset=utf-8. 
  
  SKIP: llms-txt-coverage          
  No sitemap found; cannot assess llms.txt coverage
  
  
## Test plan

Run tests against Vercel preview

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
