### PR TITLE
docs: add Plausible analytics and fix llms.txt coverage

### DIFF
--- a/packages/docs/app/layout.tsx
+++ b/packages/docs/app/layout.tsx
@@ -7,6 +7,7 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import Link from 'next/link';
+import Script from 'next/script';
 import CloudFlareAnalytics from '@/components/CloudFlareAnalytics';
 
 export const metadata: Metadata = {
@@ -41,6 +42,13 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 				/>
 				<meta httpEquiv="Content-Language" content="en" />
 				<meta name="algolia-site-verification" content="BCA21DA2879818D2" />
+				<Script
+					src="https://plausible.io/js/pa-T9dmzJpMQ4mBp3o0cRu9L.js"
+					strategy="afterInteractive"
+				/>
+				<Script id="plausible-init" strategy="afterInteractive">
+					{`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`}
+				</Script>
 			</head>
 			<body className="flex flex-col min-h-screen">
 				<a

--- a/packages/docs/app/llms.txt/[[...path]]/route.ts
+++ b/packages/docs/app/llms.txt/[[...path]]/route.ts
@@ -49,8 +49,11 @@ function buildIndex(baseUrl: string) {
 	const distIndex = path.resolve(process.cwd(), 'dist', 'llms-index.md');
 	if (fs.existsSync(distIndex)) {
 		let content = fs.readFileSync(distIndex, 'utf-8');
-		// Rewrite relative links (./section/page.md) to absolute URLs
-		content = content.replace(/\(\.\/([^)]+\.md)\)/g, `(${baseUrl}/$1)`);
+		// Rewrite relative links (./section/page.md) to absolute URLs (strip .md to match sitemap)
+		content = content.replace(
+			/\(\.\/([^)]+)\.md\)/g,
+			(_match, p) => `(${baseUrl}/${p})`,
+		);
 		return new Response(content, {
 			headers: {
 				'Content-Type': 'text/plain; charset=utf-8',
@@ -94,7 +97,7 @@ function buildIndex(baseUrl: string) {
 
 		const indent = parts.length > 2 ? '  ' : '';
 		const desc = page.data.description ? `: ${page.data.description}` : '';
-		lines.push(`${indent}- [${page.data.title}](${baseUrl}${page.url}.md)${desc}`);
+		lines.push(`${indent}- [${page.data.title}](${baseUrl}${page.url})${desc}`);
 	}
 
 	lines.push('');

--- a/packages/docs/app/llms.txt/[[...path]]/route.ts
+++ b/packages/docs/app/llms.txt/[[...path]]/route.ts
@@ -50,10 +50,7 @@ function buildIndex(baseUrl: string) {
 	if (fs.existsSync(distIndex)) {
 		let content = fs.readFileSync(distIndex, 'utf-8');
 		// Rewrite relative links (./section/page.md) to absolute URLs (strip .md to match sitemap)
-		content = content.replace(
-			/\(\.\/([^)]+)\.md\)/g,
-			(_match, p) => `(${baseUrl}/${p})`,
-		);
+		content = content.replace(/\(\.\/([^)]+)\.md\)/g, (_match, p) => `(${baseUrl}/${p})`);
 		return new Response(content, {
 			headers: {
 				'Content-Type': 'text/plain; charset=utf-8',

--- a/packages/docs/content/sui/cryptography/_meta.json
+++ b/packages/docs/content/sui/cryptography/_meta.json
@@ -2,5 +2,5 @@
 	"keypairs": "Key pairs",
 	"multisig": "Multi-Signature Transactions",
 	"passkey": "Passkey",
-	"webcrypto": "Web Crypto Signer"
+	"webcrypto-signer": "Web Crypto Signer"
 }

--- a/packages/docs/scripts/docs-utils.ts
+++ b/packages/docs/scripts/docs-utils.ts
@@ -150,8 +150,21 @@ export interface PageInfo {
 
 export function readMetaJson(dir: string): MetaJson | null {
 	const metaPath = path.join(dir, 'meta.json');
-	if (!fs.existsSync(metaPath)) return null;
-	return JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as MetaJson;
+	if (fs.existsSync(metaPath)) {
+		return JSON.parse(fs.readFileSync(metaPath, 'utf-8')) as MetaJson;
+	}
+
+	// Fumadocs also supports _meta.json with a { "pageName": "Title" } format
+	const altMetaPath = path.join(dir, '_meta.json');
+	if (fs.existsSync(altMetaPath)) {
+		const raw = JSON.parse(fs.readFileSync(altMetaPath, 'utf-8')) as Record<string, unknown>;
+		if (!raw.pages) {
+			return { pages: Object.keys(raw) };
+		}
+		return raw as MetaJson;
+	}
+
+	return null;
 }
 
 export function readMdxFrontmatter(filePath: string): { title?: string; description?: string } {
@@ -177,8 +190,40 @@ export function getPageEntries(
 
 	if (meta?.pages) {
 		for (const pageName of meta.pages) {
-			// Skip "..." (rest pages marker used by fumadocs)
-			if (pageName === '...') continue;
+			// "..." is fumadocs' rest marker — include all entries not explicitly listed
+			if (pageName === '...') {
+				const explicitPages = new Set(meta.pages!.filter((p) => p !== '...'));
+				const dirEntries = fs.readdirSync(dir, { withFileTypes: true });
+				for (const dirEntry of dirEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+					const entryName = dirEntry.name.replace(/\.mdx$/, '');
+					if (explicitPages.has(entryName) || entryName === 'index') continue;
+					if (dirEntry.name === 'meta.json' || dirEntry.name === '_meta.json') continue;
+
+					if (dirEntry.isDirectory()) {
+						const subDir = path.join(dir, dirEntry.name);
+						const indexFile = path.join(subDir, 'index.mdx');
+						if (fs.existsSync(indexFile)) {
+							const fm = readMdxFrontmatter(indexFile);
+							const subMeta = readMetaJson(subDir);
+							addEntry({
+								title: fm.title || subMeta?.title || dirEntry.name,
+								description: fm.description || subMeta?.description || '',
+								relativePath: `${basePath}/${dirEntry.name}.md`,
+							});
+						}
+						const subEntries = getPageEntries(subDir, `${basePath}/${dirEntry.name}`, seen);
+						entries.push(...subEntries);
+					} else if (dirEntry.name.endsWith('.mdx')) {
+						const fm = readMdxFrontmatter(path.join(dir, dirEntry.name));
+						addEntry({
+							title: fm.title || entryName,
+							description: fm.description || '',
+							relativePath: `${basePath}/${entryName}.md`,
+						});
+					}
+				}
+				continue;
+			}
 
 			const pageDir = path.join(dir, pageName);
 			const mdxFile = path.join(dir, `${pageName}.mdx`);
@@ -234,7 +279,7 @@ export function getPageEntries(
 }
 
 /** Directories excluded from all generated docs and indices. */
-export const EXCLUDED_SUBDIRS = ['dapp-kit/legacy'];
+export const EXCLUDED_SUBDIRS: string[] = [];
 
 /**
  * Generate a markdown index for a single content section (e.g. "sui", "dapp-kit").

--- a/packages/docs/scripts/docs-utils.ts
+++ b/packages/docs/scripts/docs-utils.ts
@@ -279,7 +279,7 @@ export function getPageEntries(
 }
 
 /** Directories excluded from all generated docs and indices. */
-export const EXCLUDED_SUBDIRS: string[] = [];
+export const EXCLUDED_SUBDIRS = ['dapp-kit/legacy'];
 
 /**
  * Generate a markdown index for a single content section (e.g. "sui", "dapp-kit").


### PR DESCRIPTION
## Summary
- Install Plausible analytics in the docs site root layout
- Fix llms.txt coverage to 100% by:
  - Correcting `webcrypto` → `webcrypto-signer` key in `_meta.json`
  - Stripping `.md` extension from llms.txt links so they match sitemap URLs
  - Adding `_meta.json` and `...` rest marker support in docs-utils

## Test plan
- [ ] Verify Plausible script loads on the docs site
- [ ] Run `npx tsx scripts/generate-llms-index.ts` and confirm all content pages are indexed
- [ ] Verify `/llms.txt` links match sitemap URLs (no `.md` extension)
- [ ] Run llms-txt-coverage check and confirm ≥95% pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.