### PR TITLE
chore: release all packages via the new flow

### DIFF
--- a/.changeset/release-all-with-new-flow.md
+++ b/.changeset/release-all-with-new-flow.md
@@ -1,0 +1,40 @@
+---
+'@mysten/aws-kms-signer': patch
+'@mysten/bcs': patch
+'@mysten/codegen': patch
+'@mysten/create-dapp': patch
+'@mysten/dapp-kit': patch
+'@mysten/dapp-kit-core': patch
+'@mysten/dapp-kit-react': patch
+'@mysten/deepbook-v3': patch
+'@mysten/docs': patch
+'@mysten/enoki': patch
+'@mysten/enoki-connect': patch
+'@mysten/gcp-kms-signer': patch
+'@mysten/kiosk': patch
+'@mysten/ledger-signer': patch
+'@mysten/ledgerjs-hw-app-sui': patch
+'@mysten/move-bytecode-template': patch
+'@mysten/mvr-static': patch
+'@mysten/pas': patch
+'@mysten/payment-kit': patch
+'@mysten/seal': patch
+'@mysten/signers': patch
+'@mysten/slush-wallet': patch
+'@mysten/sui': patch
+'@mysten/suins': patch
+'@mysten/utils': patch
+'@mysten/wallet-sdk': patch
+'@mysten/wallet-standard': patch
+'@mysten/walletconnect-wallet': patch
+'@mysten/walrus': patch
+'@mysten/walrus-wasm': patch
+'@mysten/webcrypto-signer': patch
+'@mysten/window-wallet-core': patch
+'@mysten/zksend': patch
+---
+
+Validate the new per-package release flow end-to-end across every public
+@mysten package. No functional changes — empty patch bump to force the
+orchestrator to dispatch every release-<pkg>.yml workflow with
+`dry_run=false` so each package publishes via OIDC trusted publishing.

--- a/.github/workflows/_release-package.yml
+++ b/.github/workflows/_release-package.yml
@@ -32,7 +32,7 @@ on:
       dry_run:
         description: 'Run pnpm publish with --dry-run'
         type: string
-        default: 'true'
+        default: 'false'
       full_install:
         description: 'Use full pnpm install instead of minimal --prod + sandboxed tools'
         type: string
@@ -163,6 +163,34 @@ jobs:
             # pnpm forwards it to the script and breaks `tsc --build` etc.
             pnpm --filter "${PACKAGE}..." --if-present run build
           fi
+
+      - name: Drop workspace devDeps from manifest before publish
+        working-directory: ${{ inputs.dir }}
+        run: |
+          set -euo pipefail
+          # `pnpm publish` rewrites every `workspace:` ref in the published
+          # manifest, including in devDependencies. Under our `--prod` install,
+          # workspace devDeps aren't symlinked into node_modules, so pnpm can't
+          # read their version and bails with
+          # ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL. Drop just those entries
+          # — npm doesn't install devDependencies for consumers, so removing
+          # them from the published manifest is functionally invisible.
+          # Third-party devDeps (vitest, @types/*, etc.) have real ranges and
+          # are left intact for any tooling that reads them.
+          node -e "
+            const fs = require('node:fs');
+            const pj = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const dropped = [];
+            for (const [k, v] of Object.entries(pj.devDependencies ?? {})) {
+              if (typeof v === 'string' && v.startsWith('workspace:')) {
+                delete pj.devDependencies[k];
+                dropped.push(k);
+              }
+            }
+            if (Object.keys(pj.devDependencies ?? {}).length === 0) delete pj.devDependencies;
+            if (dropped.length) console.log('dropped: ' + dropped.join(', '));
+            fs.writeFileSync('package.json', JSON.stringify(pj, null, '\t') + '\n');
+          "
 
       - name: Publish to npm
         working-directory: ${{ inputs.dir }}

--- a/.github/workflows/release-aws-kms-signer.yml
+++ b/.github/workflows/release-aws-kms-signer.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/aws-kms-signer'
       dir: 'packages/signers/aws'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-bcs.yml
+++ b/.github/workflows/release-bcs.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/bcs'
       dir: 'packages/bcs'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-codegen.yml
+++ b/.github/workflows/release-codegen.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/codegen'
       dir: 'packages/codegen'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-create-dapp.yml
+++ b/.github/workflows/release-create-dapp.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/create-dapp'
       dir: 'packages/create-dapp'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-dapp-kit-core.yml
+++ b/.github/workflows/release-dapp-kit-core.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/dapp-kit-core'
       dir: 'packages/dapp-kit/packages/dapp-kit-core'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-dapp-kit-react.yml
+++ b/.github/workflows/release-dapp-kit-react.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,6 +31,6 @@ jobs:
     with:
       package: '@mysten/dapp-kit-react'
       dir: 'packages/dapp-kit/packages/dapp-kit-react'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       tools: 'tsdown@0.20.0-beta.1 typescript@5.9.3 @types/node@25.0.8 @types/react@19.2.8'

--- a/.github/workflows/release-dapp-kit.yml
+++ b/.github/workflows/release-dapp-kit.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -32,6 +32,6 @@ jobs:
     with:
       package: '@mysten/dapp-kit'
       dir: 'packages/dapp-kit/packages/legacy'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       full_install: 'true'

--- a/.github/workflows/release-deepbook-v3.yml
+++ b/.github/workflows/release-deepbook-v3.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/deepbook-v3'
       dir: 'packages/deepbook-v3'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -32,7 +32,7 @@ jobs:
     with:
       package: '@mysten/docs'
       dir: 'packages/docs'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       build_command: 'pnpm --filter @mysten/docs run build:docs'
       # build:docs is just `node scripts/build-docs.ts --all` — no extra tooling needed.

--- a/.github/workflows/release-enoki-connect.yml
+++ b/.github/workflows/release-enoki-connect.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/enoki-connect'
       dir: 'packages/enoki-connect'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-enoki.yml
+++ b/.github/workflows/release-enoki.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,7 +31,7 @@ jobs:
     with:
       package: '@mysten/enoki'
       dir: 'packages/enoki'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       # enoki imports React types — needs @types/react for dts emit
       tools: 'tsdown@0.20.0-beta.1 typescript@5.9.3 @types/node@25.0.8 @types/react@19.2.8'

--- a/.github/workflows/release-gcp-kms-signer.yml
+++ b/.github/workflows/release-gcp-kms-signer.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/gcp-kms-signer'
       dir: 'packages/signers/gcp'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-kiosk.yml
+++ b/.github/workflows/release-kiosk.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/kiosk'
       dir: 'packages/kiosk'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-ledger-signer.yml
+++ b/.github/workflows/release-ledger-signer.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,7 +31,7 @@ jobs:
     with:
       package: '@mysten/ledger-signer'
       dir: 'packages/signers/ledger'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       # @types/semver — needed by ledgerjs-hw-app-sui (workspace dep) for tsc
       # --noEmit; semver itself is a runtime dep already, only the types are

--- a/.github/workflows/release-ledgerjs-hw-app-sui.yml
+++ b/.github/workflows/release-ledgerjs-hw-app-sui.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,7 +31,7 @@ jobs:
     with:
       package: '@mysten/ledgerjs-hw-app-sui'
       dir: 'packages/ledgerjs-hw-app-sui'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       # @types/semver — semver itself is a runtime dep, but its types are
       # devDep-only and tsc --noEmit needs them at build time.

--- a/.github/workflows/release-move-bytecode-template.yml
+++ b/.github/workflows/release-move-bytecode-template.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -32,7 +32,7 @@ jobs:
     with:
       package: '@mysten/move-bytecode-template'
       dir: 'packages/move-bytecode-template'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       build_command: 'echo "wasm artifacts checked in"'
       tools: ''

--- a/.github/workflows/release-mvr-static.yml
+++ b/.github/workflows/release-mvr-static.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/mvr-static'
       dir: 'packages/mvr-static'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-pas.yml
+++ b/.github/workflows/release-pas.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/pas'
       dir: 'packages/pas'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-payment-kit.yml
+++ b/.github/workflows/release-payment-kit.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/payment-kit'
       dir: 'packages/payment-kit'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-seal.yml
+++ b/.github/workflows/release-seal.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/seal'
       dir: 'packages/seal'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-signers.yml
+++ b/.github/workflows/release-signers.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,7 +31,7 @@ jobs:
     with:
       package: '@mysten/signers'
       dir: 'packages/signers'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       # @types/semver — needed transitively via ledgerjs-hw-app-sui for tsc
       # --noEmit; semver itself is a runtime dep already, only types are

--- a/.github/workflows/release-slush-wallet.yml
+++ b/.github/workflows/release-slush-wallet.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/slush-wallet'
       dir: 'packages/slush-wallet'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-sui.yml
+++ b/.github/workflows/release-sui.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/sui'
       dir: 'packages/sui'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-suins.yml
+++ b/.github/workflows/release-suins.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/suins'
       dir: 'packages/suins'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/utils'
       dir: 'packages/utils'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-wallet-sdk.yml
+++ b/.github/workflows/release-wallet-sdk.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/wallet-sdk'
       dir: 'packages/wallet-sdk'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-wallet-standard.yml
+++ b/.github/workflows/release-wallet-standard.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/wallet-standard'
       dir: 'packages/wallet-standard'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-walletconnect-wallet.yml
+++ b/.github/workflows/release-walletconnect-wallet.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/walletconnect-wallet'
       dir: 'packages/walletconnect-wallet'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-walrus-wasm.yml
+++ b/.github/workflows/release-walrus-wasm.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -32,7 +32,7 @@ jobs:
     with:
       package: '@mysten/walrus-wasm'
       dir: 'packages/walrus-wasm'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       build_command: 'echo "wasm artifacts checked in"'
       tools: ''

--- a/.github/workflows/release-walrus.yml
+++ b/.github/workflows/release-walrus.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/walrus'
       dir: 'packages/walrus'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-webcrypto-signer.yml
+++ b/.github/workflows/release-webcrypto-signer.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/webcrypto-signer'
       dir: 'packages/signers/webcrypto'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-window-wallet-core.yml
+++ b/.github/workflows/release-window-wallet-core.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/window-wallet-core'
       dir: 'packages/window-wallet-core'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release-zksend.yml
+++ b/.github/workflows/release-zksend.yml
@@ -6,7 +6,7 @@ on:
       dry_run:
         description: 'Dry-run mode'
         required: false
-        default: 'true'
+        default: 'false'
       ref:
         description: 'Git ref or SHA to publish (defaults to main HEAD)'
         required: false
@@ -31,5 +31,5 @@ jobs:
     with:
       package: '@mysten/zksend'
       dir: 'packages/zksend'
-      dry_run: ${{ inputs.dry_run || 'true' }}
+      dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
       dry_run:
         description: 'Dry-run publishes (passed through to dispatched workflows)'
         required: false
-        default: 'true'
+        default: 'false'
   workflow_run:
     workflows: ['Turborepo CI']
     types: [completed]
@@ -109,7 +109,7 @@ jobs:
         if: steps.changesets.outputs.skip != 'true' && steps.find.outputs.list != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'true' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           # Pin per-package publishes to the SHA we just verified. `--ref main`
           # keeps the workflow *file* on main (security boundary), but the
           # template checks out HEAD_SHA so a newer untested commit on main


### PR DESCRIPTION
## Summary

Three coordinated changes that, together, cause the next Version Packages PR merge to publish every public `@mysten` package via the new orchestrator + per-package workflows for the first time:

### 1. Fix the `pnpm publish` workspace-protocol resolution (`_release-package.yml`)

The first orchestrator run on `main` after #1056 merged dispatched 9 release workflows. Six passed dry-run; **three failed at the `Publish to npm` step** with:

```
ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL  Cannot resolve workspace
protocol of dependency "@mysten/codegen" because this dependency is not
installed.
```

Same root cause for all 3:
- `pnpm publish` rewrites every `workspace:` ref in the published manifest, including ones in `devDependencies`
- Under the publish-time `--prod` install, workspace devDeps aren't symlinked into the target's `node_modules`
- pnpm can't read the dep's version → bail

Audit shows **11 packages** with this pattern (`deepbook-v3`, `enoki`, `kiosk`, `move-bytecode-template`, `pas`, `payment-kit`, `suins`, `wallet-sdk`, `walrus`, `walrus-wasm`, plus the `create-dapp` template). Only 3 surfaced in the last run because only those bumped versions; the other 8 would hit the same wall once they bump.

**Fix**: a 15-line template step that drops just the `workspace:`-prefixed entries from `devDependencies` before `pnpm publish`. Third-party devDeps (`vitest`, `@types/*`, `@iarna/toml`, etc.) keep their real ranges and are left intact for any tooling that reads them. npm doesn't install `devDependencies` for consumers, so the absence in the published manifest is consumer-invisible.

Verified locally for the 3 known-failing packages — all reach `Publishing to https://registry.npmjs.org/ with tag latest (dry-run)` cleanly.

### 2. Flip `dry_run` defaults to `false`

- 33 `release-<pkg>.yml` files: input default + forwarded value
- `release.yml` orchestrator: `DRY_RUN` env default
- `_release-package.yml` template: input default

`workflow_dispatch` still accepts `dry_run: true` for manual validation, but the orchestrator now defaults to real publishes.

### 3. All-packages patch changeset

Empty patch bump for every public `@mysten` package (33 entries). Forces every package to bump versions when the resulting Version Packages PR merges so the orchestrator dispatches all 33 `release-<pkg>.yml` runs in real (non-dry-run) mode, validating the new flow end-to-end.

## Test plan

- [x] Local: minimal-install + strip-devDeps + `pnpm publish --dry-run` succeeds for `@mysten/{deepbook-v3,enoki,suins}` (the three that failed in the post-#1056 orchestrator run).
- [ ] Reviewer to verify: trusted publishing is configured on npm.com for every `@mysten/*` package the orchestrator might dispatch (33 packages). Without this, the real `pnpm publish` step will fail with auth errors.
- [ ] After this PR's resulting Version Packages PR merges: confirm the orchestrator dispatches all 33 release workflows and they reach `Publishing to https://registry.npmjs.org/ with tag latest`.

## What happens after merge

1. Changesets bot opens (or updates) the Version Packages PR using all 33 patch bumps from the changeset in this PR.
2. Reviewer merges the Version Packages PR.
3. Turborepo CI runs on bumped main; on success the orchestrator fires.
4. Orchestrator finds 33 packages with versions not yet on npm; dispatches all 33 `release-<pkg>.yml` workflows in real (non-dry-run) mode.
5. Each runs the now-fixed publish chain → publishes via OIDC trusted publishing.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.