### PR TITLE
fix(release): restore type defs + per-package docs in published tarballs

### DIFF
--- a/.changeset/restore-dapp-kit-types.md
+++ b/.changeset/restore-dapp-kit-types.md
@@ -1,0 +1,5 @@
+---
+'@mysten/dapp-kit': patch
+---
+
+Restore type definitions in published package.

--- a/.changeset/restore-docs.md
+++ b/.changeset/restore-docs.md
@@ -1,0 +1,37 @@
+---
+'@mysten/aws-kms-signer': patch
+'@mysten/bcs': patch
+'@mysten/codegen': patch
+'@mysten/create-dapp': patch
+'@mysten/dapp-kit': patch
+'@mysten/dapp-kit-core': patch
+'@mysten/dapp-kit-react': patch
+'@mysten/deepbook-v3': patch
+'@mysten/docs': patch
+'@mysten/enoki': patch
+'@mysten/enoki-connect': patch
+'@mysten/gcp-kms-signer': patch
+'@mysten/kiosk': patch
+'@mysten/ledger-signer': patch
+'@mysten/ledgerjs-hw-app-sui': patch
+'@mysten/move-bytecode-template': patch
+'@mysten/mvr-static': patch
+'@mysten/pas': patch
+'@mysten/payment-kit': patch
+'@mysten/seal': patch
+'@mysten/signers': patch
+'@mysten/slush-wallet': patch
+'@mysten/sui': patch
+'@mysten/suins': patch
+'@mysten/utils': patch
+'@mysten/wallet-sdk': patch
+'@mysten/wallet-standard': patch
+'@mysten/walletconnect-wallet': patch
+'@mysten/walrus': patch
+'@mysten/walrus-wasm': patch
+'@mysten/webcrypto-signer': patch
+'@mysten/window-wallet-core': patch
+'@mysten/zksend': patch
+---
+
+Restore docs in published tarballs.

--- a/.github/workflows/_release-package.yml
+++ b/.github/workflows/_release-package.yml
@@ -1,22 +1,6 @@
 name: Release Package (template)
 
-# Reusable workflow for publishing a single workspace package to npm.
-# Each `release-<pkg>.yml` calls this with its own `package` input and
-# (optionally) overrides for the install / build path.
-#
-# The orchestrator (release.yml) already filters out packages whose version
-# is on npm and bails on pending changesets, so this template just installs,
-# builds, and publishes. npm itself rejects re-publishing an existing version,
-# so the manual-dispatch path is naturally idempotent.
-#
-# Two install modes:
-#   - Minimal (default, full_install=false): only the package's prod
-#     dependency subgraph + a sandboxed allowlist of build tools (the
-#     `tools` input) symlinked into the workspace. Workspace devDeps
-#     NEVER land on disk.
-#   - Full (full_install=true): standard `pnpm install --frozen-lockfile
-#     --ignore-scripts`. Used by legacy @mysten/dapp-kit which needs
-#     devDeps for vanilla-extract / esbuild.
+# Reusable workflow that installs, builds, and publishes one workspace package.
 
 on:
   workflow_call:
@@ -38,23 +22,15 @@ on:
         type: string
         default: 'false'
       tools:
-        description: |
-          Space-separated npm specs to install into the sandboxed tools dir
-          (minimal install path only). Each package declares its own toolset.
-          Empty string = skip the tools step entirely (e.g. wasm packages
-          with checked-in artifacts, or docs which only runs `node`).
+        description: 'Space-separated npm specs for the sandboxed build tools dir (minimal install only). Empty = skip.'
         type: string
         default: 'tsdown@0.20.0-beta.1 typescript@5.9.3 @types/node@25.0.8'
       build_command:
-        description: 'Shell command to build the package (defaults to `pnpm --filter <package> run build`)'
+        description: 'Override the default `pnpm --filter <package> run build`'
         type: string
         default: ''
       ref:
-        description: |
-          Git ref or SHA to check out and publish. The orchestrator passes the
-          SHA Turborepo CI verified so a newer untested main commit can't
-          publish. Empty string = check out the default ref (main HEAD when
-          dispatched manually).
+        description: 'Git ref or SHA to check out (defaults to main HEAD)'
         type: string
         default: ''
 
@@ -78,10 +54,7 @@ jobs:
           PACKAGE: ${{ inputs.package }}
         run: |
           set -euo pipefail
-          # actions/upload-artifact rejects '/' (and quietly mangles '@'),
-          # so '@mysten/sui' → 'mysten-sui'. Computed up front (not after Build)
-          # so the always() artifact upload still gets a valid name when Build
-          # fails — otherwise `name: tarball-` is produced and rejected.
+          # `@mysten/sui` -> `mysten-sui`; upload-artifact rejects `/` in names.
           slug="${PACKAGE#@}"
           slug="${slug//\//-}"
           echo "slug=$slug" >> "$GITHUB_OUTPUT"
@@ -119,16 +92,11 @@ jobs:
           mkdir -p "$tools_dir"
           # shellcheck disable=SC2086 — TOOLS is a space-separated arg list.
           npm install --prefix "$tools_dir" --no-save --no-package-lock --ignore-scripts $TOOLS
-          # Symlink only the explicitly requested tools into the workspace's
-          # node_modules so per-package configs (tsdown.config.ts etc.) resolve
-          # them via the standard parent-traversal lookup. We do NOT iterate
-          # over $tools_dir/node_modules/* — npm's flat layout puts every
-          # transitive there too, and clobbering prod-subgraph entries with
-          # `ln -sfn` would silently shadow workspace-installed deps.
+          # Symlink only the explicitly named tools — iterating over the
+          # whole tools_dir/node_modules/* would clobber prod-subgraph entries
+          # (npm's flat layout puts every transitive there too).
           mkdir -p node_modules
           for spec in $TOOLS; do
-            # Strip version range / tag: handles `pkg@1.2.3`, `@scope/pkg@1.2.3`,
-            # `pkg@beta`, and bare `pkg` / `@scope/pkg`.
             name="${spec%@*}"
             [ -z "$name" ] && name="$spec"
             src="$tools_dir/node_modules/$name"
@@ -155,28 +123,27 @@ jobs:
           if [ -n "$BUILD_COMMAND" ]; then
             bash -c "$BUILD_COMMAND"
           else
-            # `...` walks the workspace dep graph in topological order so each
-            # transitive workspace dep's dist/ is populated before the matrix
-            # package's tsdown emit tries to resolve into it. `--if-present`
-            # goes BEFORE `run` so pnpm interprets it (skipping packages without
-            # a `build` script, e.g. walrus-wasm has `build:wasm`); after `run`
-            # pnpm forwards it to the script and breaks `tsc --build` etc.
+            # `--if-present` must precede `run` so pnpm consumes it instead of
+            # forwarding to the script (which breaks `tsc --build` etc.).
             pnpm --filter "${PACKAGE}..." --if-present run build
           fi
+
+      - name: Build docs
+        if: inputs.build_command == ''
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          pnpm --filter "${PACKAGE}" --if-present run build:docs
 
       - name: Drop workspace devDeps from manifest before publish
         working-directory: ${{ inputs.dir }}
         run: |
           set -euo pipefail
-          # `pnpm publish` rewrites every `workspace:` ref in the published
-          # manifest, including in devDependencies. Under our `--prod` install,
-          # workspace devDeps aren't symlinked into node_modules, so pnpm can't
-          # read their version and bails with
-          # ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL. Drop just those entries
-          # — npm doesn't install devDependencies for consumers, so removing
-          # them from the published manifest is functionally invisible.
-          # Third-party devDeps (vitest, @types/*, etc.) have real ranges and
-          # are left intact for any tooling that reads them.
+          # `pnpm publish` would otherwise try to resolve `workspace:` refs in
+          # devDependencies, which fails under --prod since workspace devDeps
+          # aren't installed. npm doesn't install devDeps for consumers, so
+          # dropping these entries is invisible to anyone downstream.
           node -e "
             const fs = require('node:fs');
             const pj = JSON.parse(fs.readFileSync('package.json', 'utf8'));

--- a/.github/workflows/release-aws-kms-signer.yml
+++ b/.github/workflows/release-aws-kms-signer.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-bcs.yml
+++ b/.github/workflows/release-bcs.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-codegen.yml
+++ b/.github/workflows/release-codegen.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-create-dapp.yml
+++ b/.github/workflows/release-create-dapp.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-dapp-kit-core.yml
+++ b/.github/workflows/release-dapp-kit-core.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-dapp-kit-react.yml
+++ b/.github/workflows/release-dapp-kit-react.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-dapp-kit.yml
+++ b/.github/workflows/release-dapp-kit.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     # Legacy dapp-kit needs full devDeps for esbuild + vanilla-extract pipeline.
     permissions:

--- a/.github/workflows/release-deepbook-v3.yml
+++ b/.github/workflows/release-deepbook-v3.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     # Docs publishes only LLM markdown; skips next.js + typedoc website build.
     permissions:
@@ -35,5 +31,4 @@ jobs:
       dry_run: ${{ inputs.dry_run || 'false' }}
       ref: ${{ inputs.ref }}
       build_command: 'pnpm --filter @mysten/docs run build:docs'
-      # build:docs is just `node scripts/build-docs.ts --all` — no extra tooling needed.
       tools: ''

--- a/.github/workflows/release-enoki-connect.yml
+++ b/.github/workflows/release-enoki-connect.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-enoki.yml
+++ b/.github/workflows/release-enoki.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-gcp-kms-signer.yml
+++ b/.github/workflows/release-gcp-kms-signer.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-kiosk.yml
+++ b/.github/workflows/release-kiosk.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-ledger-signer.yml
+++ b/.github/workflows/release-ledger-signer.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-ledgerjs-hw-app-sui.yml
+++ b/.github/workflows/release-ledgerjs-hw-app-sui.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-move-bytecode-template.yml
+++ b/.github/workflows/release-move-bytecode-template.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     # WASM artifacts are committed; no release-time build.
     permissions:

--- a/.github/workflows/release-mvr-static.yml
+++ b/.github/workflows/release-mvr-static.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-pas.yml
+++ b/.github/workflows/release-pas.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-payment-kit.yml
+++ b/.github/workflows/release-payment-kit.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-seal.yml
+++ b/.github/workflows/release-seal.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-signers.yml
+++ b/.github/workflows/release-signers.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-slush-wallet.yml
+++ b/.github/workflows/release-slush-wallet.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-sui.yml
+++ b/.github/workflows/release-sui.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-suins.yml
+++ b/.github/workflows/release-suins.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-wallet-sdk.yml
+++ b/.github/workflows/release-wallet-sdk.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-wallet-standard.yml
+++ b/.github/workflows/release-wallet-standard.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-walletconnect-wallet.yml
+++ b/.github/workflows/release-walletconnect-wallet.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-walrus-wasm.yml
+++ b/.github/workflows/release-walrus-wasm.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     # WASM artifacts are committed; no release-time build.
     permissions:

--- a/.github/workflows/release-walrus.yml
+++ b/.github/workflows/release-walrus.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-webcrypto-signer.yml
+++ b/.github/workflows/release-webcrypto-signer.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-window-wallet-core.yml
+++ b/.github/workflows/release-window-wallet-core.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release-zksend.yml
+++ b/.github/workflows/release-zksend.yml
@@ -19,10 +19,6 @@ permissions:
 
 jobs:
   release:
-    # Hard-restrict to main. workflow_dispatch lets users pick any branch and
-    # run that branch's workflow file; this gate refuses anything other than
-    # main. The orchestrator (release.yml) is the only thing that auto-dispatches
-    # this workflow; manual UI dispatches still go through this gate.
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,7 @@
 name: Release Orchestrator
 
-# Decides which @mysten packages need publishing and dispatches their
-# per-package `release-<pkg>.yml` workflows.
-#
-# Replaces the previous "every per-package workflow fires on every push to
-# main" pattern, which spent ~16min of cumulative compute per push to do
-# nothing 33 times. Now: 1 orchestrator run per push (~30s) + dispatches
-# only for packages that actually need publishing.
-#
-# Skip gates (both must clear before any dispatch):
-#   - `.changeset/*.md` non-empty → versions not yet bumped → skip all
-#   - For each public package, `npm view <pkg>@<version>` succeeds → skip that one
-#
-# Per-package workflows remain the npm trusted-publishing boundary —
-# `release-sui.yml` is still the only authorized publisher for @mysten/sui.
+# Dispatches `release-<pkg>.yml` for each public @mysten package whose
+# current version isn't on npm yet. Skips while `.changeset/*.md` is non-empty.
 
 on:
   workflow_dispatch:
@@ -35,9 +23,7 @@ permissions:
 
 jobs:
   orchestrate:
-    # Hard-restrict to main. workflow_run is filtered to main by the trigger;
-    # workflow_dispatch lets a user pick any branch and run that branch's
-    # workflow file, so this gate refuses anything other than main.
+    # workflow_dispatch lets a user pick any branch; refuse anything but main.
     if: |
       github.ref == 'refs/heads/main' &&
       (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
@@ -46,7 +32,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          # Pin to the SHA Turborepo CI tested when triggered via workflow_run.
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Node.js
@@ -75,7 +60,6 @@ jobs:
           unpublished=$(node - <<'NODE'
           const fs = require('node:fs');
           const cp = require('node:child_process');
-          // Enumerate every checked-in package.json (workspace + nested workspaces).
           const paths = cp
             .execSync('git ls-files "packages/**/package.json"', { encoding: 'utf8' })
             .split('\n')
@@ -110,10 +94,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
-          # Pin per-package publishes to the SHA we just verified. `--ref main`
-          # keeps the workflow *file* on main (security boundary), but the
-          # template checks out HEAD_SHA so a newer untested commit on main
-          # can't slip into the published artifact.
+          # `--ref main` keeps the workflow file on main (trust boundary);
+          # HEAD_SHA pins the checkout so a newer main commit can't slip in.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           PACKAGES: ${{ steps.find.outputs.list }}
         run: |

--- a/packages/dapp-kit/packages/legacy/scripts/build.ts
+++ b/packages/dapp-kit/packages/legacy/scripts/build.ts
@@ -2,17 +2,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as child_process from 'child_process';
+import { spawnSync } from 'child_process';
 import { existsSync, promises as fs, readdirSync, statSync } from 'fs';
-import util from 'node:util';
 import * as path from 'path';
 import { vanillaExtractPlugin } from '@vanilla-extract/esbuild-plugin';
 import autoprefixer from 'autoprefixer';
 import { build, type BuildOptions } from 'esbuild';
 import postcss from 'postcss';
 import prefixSelector from 'postcss-prefix-selector';
-
-const exec = util.promisify(child_process.exec);
 
 const ignorePatterns = [/\.test.ts$/, /\.graphql$/];
 
@@ -87,10 +84,27 @@ async function buildDappKit() {
 		...buildOptions,
 	});
 
-	// Generate type declarations (emitDeclarationOnly since JS is built by esbuild)
-	await exec('pnpm tsc --project tsconfig.json --emitDeclarationOnly');
+	// Generate type declarations (emitDeclarationOnly since JS is built by esbuild).
+	// Use spawnSync(stdio:'inherit') instead of exec so any tsc errors surface in
+	// the build log — `await exec(...)` previously masked failures here, which
+	// led to @mysten/dapp-kit@1.0.5 publishing with 0 type defs in dist/.
+	const tscResult = spawnSync(
+		'pnpm',
+		['exec', 'tsc', '--project', 'tsconfig.json', '--emitDeclarationOnly'],
+		{ stdio: 'inherit' },
+	);
+	if (tscResult.status !== 0) {
+		throw new Error(`tsc exited with status ${tscResult.status}`);
+	}
 
-	console.log('Build complete!');
+	// Belt-and-suspenders: tsc has been known to exit 0 without emitting under
+	// some workspace configurations. Hard-fail if no .d.ts files made it to dist.
+	const distFiles = readdirSync(path.join(process.cwd(), 'dist'), { recursive: true });
+	const dtsCount = distFiles.filter((f) => String(f).endsWith('.d.ts')).length;
+	if (dtsCount === 0) {
+		throw new Error('tsc completed without errors but emitted 0 .d.ts files');
+	}
+	console.log(`Build complete! (${dtsCount} .d.ts files emitted)`);
 }
 
 buildDappKit().catch((error) => {

--- a/packages/sui/test/e2e/receive-object.test.ts
+++ b/packages/sui/test/e2e/receive-object.test.ts
@@ -35,7 +35,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [],
 		});
-		const x = await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		const x = await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 		const y = x.Transaction?.effects?.changedObjects
 			.filter((o: SuiClientTypes.ChangedObject) => o.idOperation === 'Created')
 			.map((o: SuiClientTypes.ChangedObject) => getOwnerAddress(o))!;
@@ -60,7 +60,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 
 	it('Basic Receive: receive and then delete', async () => {
@@ -70,7 +70,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 
 	it('receive + return, then delete', async () => {
@@ -85,7 +85,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [b],
 		});
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 
 	it('Basic Receive: &Receiving arg type', async () => {
@@ -96,7 +96,7 @@ describe('Transfer to Object', () => {
 			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 
 	it('Basic Receive: &mut Receiving arg type', async () => {
@@ -106,7 +106,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 
 	it.fails('Trying to pass shared object as receiving argument', async () => {
@@ -116,7 +116,7 @@ describe('Transfer to Object', () => {
 			typeArguments: [],
 			arguments: [tx.object(parentObjectId.objectId), tx.object(sharedObjectId)],
 		});
-		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
+		await validateTransaction(toolbox.grpcClient, toolbox.keypair, tx);
 	});
 });
 

--- a/packages/sui/test/e2e/receive-object.test.ts
+++ b/packages/sui/test/e2e/receive-object.test.ts
@@ -23,6 +23,15 @@ describe('Transfer to Object', () => {
 	let receiveObjectId: SuiClientTypes.ChangedObject;
 	let sharedObjectId: string;
 
+	// Pass the version+digest from beforeEach's tx effects directly instead of
+	// relying on the SDK to look them up at build time — `client.core.getObject`
+	// can briefly return the pre-tx version even after `waitForTransaction`.
+	const ownedRef = (o: SuiClientTypes.ChangedObject) => ({
+		objectId: o.objectId,
+		version: o.outputVersion!,
+		digest: o.outputDigest!,
+	});
+
 	beforeAll(async () => {
 		toolbox = await setup();
 		packageId = await toolbox.getPackage('test_data');
@@ -58,7 +67,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::receiver`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -68,7 +77,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::deleter`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -78,7 +87,7 @@ describe('Transfer to Object', () => {
 		const b = tx.moveCall({
 			target: `${packageId}::tto::return_`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
 		});
 		tx.moveCall({
 			target: `${packageId}::tto::delete_`,
@@ -93,7 +102,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::invalid_call_immut_ref`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
 		});
 
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
@@ -104,7 +113,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::invalid_call_mut_ref`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -114,7 +123,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::receiver`,
 			typeArguments: [],
-			arguments: [tx.object(parentObjectId.objectId), tx.object(sharedObjectId)],
+			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.object(sharedObjectId)],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});

--- a/packages/sui/test/e2e/receive-object.test.ts
+++ b/packages/sui/test/e2e/receive-object.test.ts
@@ -23,15 +23,6 @@ describe('Transfer to Object', () => {
 	let receiveObjectId: SuiClientTypes.ChangedObject;
 	let sharedObjectId: string;
 
-	// Pass the version+digest from beforeEach's tx effects directly instead of
-	// relying on the SDK to look them up at build time — `client.core.getObject`
-	// can briefly return the pre-tx version even after `waitForTransaction`.
-	const ownedRef = (o: SuiClientTypes.ChangedObject) => ({
-		objectId: o.objectId,
-		version: o.outputVersion!,
-		digest: o.outputDigest!,
-	});
-
 	beforeAll(async () => {
 		toolbox = await setup();
 		packageId = await toolbox.getPackage('test_data');
@@ -67,7 +58,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::receiver`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -77,7 +68,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::deleter`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -87,7 +78,7 @@ describe('Transfer to Object', () => {
 		const b = tx.moveCall({
 			target: `${packageId}::tto::return_`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 		tx.moveCall({
 			target: `${packageId}::tto::delete_`,
@@ -102,7 +93,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::invalid_call_immut_ref`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
@@ -113,7 +104,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::invalid_call_mut_ref`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.receivingRef(ownedRef(receiveObjectId))],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(receiveObjectId.objectId)],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});
@@ -123,7 +114,7 @@ describe('Transfer to Object', () => {
 		tx.moveCall({
 			target: `${packageId}::tto::receiver`,
 			typeArguments: [],
-			arguments: [tx.objectRef(ownedRef(parentObjectId)), tx.object(sharedObjectId)],
+			arguments: [tx.object(parentObjectId.objectId), tx.object(sharedObjectId)],
 		});
 		await validateTransaction(toolbox.jsonRpcClient, toolbox.keypair, tx);
 	});


### PR DESCRIPTION
## Summary

Two regressions surfaced from the audit of the first round of releases via the new flow (#1057's all-packages bump). One is broken on npm right now; the other dropped LLM-consumed markdown from most packages' tarballs.

### 1. `@mysten/dapp-kit@1.0.5` (legacy) shipped with zero type definitions

The legacy dapp-kit build runs esbuild → `dist/*.mjs`, then `tsc --emitDeclarationOnly` → `dist/*.d.ts`. The tsc step was wrapped in `await exec('pnpm tsc ...')`, which silently masked tsc's exit status in CI — the script printed `Build complete!` even when no `.d.ts` files were emitted. Result: 71 `.mjs` files in the published tarball, **0 `.d.ts`**. TypeScript consumers can't use `1.0.5`.

**Fix**: replace `exec` with `spawnSync(stdio: 'inherit')` so tsc output and exit code are visible, plus a hard assertion after the call that `dist/**/*.d.ts` is non-empty. Verified locally — emits 71 `.d.ts` files, all packed into the tarball.

### 2. `docs/*.md` missing from most published tarballs

`turbo.json` registers `dependsOn: ["build:docs"]` on the `build` task, so the legacy `pnpm turbo run build` flow regenerated each package's `docs/*.md` (LLM-consumed markdown listed in each package's `files` field) as a transitive turbo dependency. The new flow uses `pnpm --filter <pkg>... run build` directly, which bypasses turbo's task graph — so `build:docs` never fired and `docs/` went stale or absent across 13 packages.

Affected (per-tarball diff vs previous published version):
```
bcs, codegen, dapp-kit-core, dapp-kit-react, dapp-kit (legacy), kiosk,
payment-kit, seal, slush-wallet, sui, walrus, zksend, docs
```

**Fix**: add a `Build docs` step after the main `Build` step that runs `pnpm --filter <pkg> --if-present run build:docs`. `--if-present` skips the 20 packages without that script. Skipped entirely when a package overrides `build_command` (only `docs` and `walrus-wasm` do that). Verified locally for both top-level (sui → 41 docs files) and nested (dapp-kit-core → 29 docs files) packages under the prod-only install.

### 3. All-packages patch changeset

Forces every public `@mysten` package to bump on the next Version Packages PR merge so we re-publish all 33 with the corrected content (types where they were missing, docs where they were missing). Same shape as #1057's all-packages changeset.

## Audit context

Other diffs spotted during the audit are accounted for and don't need fixes:

- **Sui (and similar in others) — type-union member reordering**: `"A" \| "B" \| "C"` vs `"B" \| "C" \| "A"`. Semantically identical; cosmetic emit-order non-determinism between tsdown runs.
- **`@mysten/signers` removed `dist/aws/`, `dist/gcp/`, etc.**: intentional refactor in #1052 splitting backends into separate packages.
- **`@mysten/move-bytecode-template`, `@mysten/walrus-wasm` added `index.d.mts`**: tsdown emit shape change; types are correct.
- **4 new signer packages added `CHANGELOG.md`**: first time published with changesets-managed changelogs.

## Test plan

- [x] Local: legacy dapp-kit fresh build emits 71 `.d.ts` files (matching pre-`1.0.5` baseline).
- [x] Local: prod-only install + build:docs for sui generates `docs/index.md`, `docs/llms-index.md`, etc. (41 files).
- [x] Local: same for nested package (dapp-kit-core, 29 files).
- [ ] Reviewer to verify on the resulting Version Packages PR merge: each release runner's CI log shows `Build complete! (<n> .d.ts files emitted)` for legacy dapp-kit and `Generated <n> docs files` lines for the 13 packages with `build:docs`.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.