### PR TITLE
feat(walrus): add storageNodeUrlScheme option for non-TLS environments

### DIFF
--- a/.changeset/walrus-storage-node-url-scheme.md
+++ b/.changeset/walrus-storage-node-url-scheme.md
@@ -1,0 +1,5 @@
+---
+'@mysten/walrus': patch
+---
+
+Add `storageNodeUrlScheme` option to `WalrusClient` for configuring the URL scheme used when contacting storage nodes (defaults to `'https'`). Set to `'http'` for local development environments where storage nodes do not terminate TLS.

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -2116,12 +2116,8 @@ export class WalrusClient {
 	}
 
 	#getActiveCommittee() {
-		// Scheme is part of the cache key because `#getCommittee` bakes
-		// it into each `networkUrl`. Without this, two `WalrusClient`s
-		// sharing one `SuiClient` (and therefore the same `#cache`
-		// scope) but configured with different `storageNodeUrlScheme`
-		// values would race for the cache: the first to load the
-		// committee wins, the second silently inherits the wrong scheme.
+		// Scoped by scheme — `#cache` is shared across clients on the same
+		// `SuiClient`, so a mixed-scheme caller mustn't see another's URLs.
 		return this.#cache.read(['getActiveCommittee', this.#storageNodeUrlScheme], async () => {
 			const stakingState = await this.stakingState();
 			return this.#getCommittee(stakingState.committee);

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -165,6 +165,7 @@ export function walrus<const Name = 'walrus'>({
 
 export class WalrusClient {
 	#storageNodeClient: StorageNodeClient;
+	#storageNodeUrlScheme: 'http' | 'https';
 	#wasmUrl: string | undefined;
 
 	#packageConfig: WalrusPackageConfig;
@@ -197,6 +198,7 @@ export class WalrusClient {
 		}
 
 		this.#wasmUrl = config.wasmUrl;
+		this.#storageNodeUrlScheme = config.storageNodeUrlScheme ?? 'https';
 		this.#uploadRelayConfig = config.uploadRelay ?? null;
 		if (this.#uploadRelayConfig) {
 			this.#uploadRelayClient = new UploadRelayClient(this.#uploadRelayConfig);
@@ -2095,7 +2097,7 @@ export class WalrusClient {
 			const node: StorageNode = {
 				id: node_info.node_id,
 				info: node_info,
-				networkUrl: `https://${node_info.network_address}`,
+				networkUrl: `${this.#storageNodeUrlScheme}://${node_info.network_address}`,
 				shardIndices,
 				nodeIndex,
 			};

--- a/packages/walrus/src/client.ts
+++ b/packages/walrus/src/client.ts
@@ -2116,7 +2116,13 @@ export class WalrusClient {
 	}
 
 	#getActiveCommittee() {
-		return this.#cache.read(['getActiveCommittee'], async () => {
+		// Scheme is part of the cache key because `#getCommittee` bakes
+		// it into each `networkUrl`. Without this, two `WalrusClient`s
+		// sharing one `SuiClient` (and therefore the same `#cache`
+		// scope) but configured with different `storageNodeUrlScheme`
+		// values would race for the cache: the first to load the
+		// committee wins, the second silently inherits the wrong scheme.
+		return this.#cache.read(['getActiveCommittee', this.#storageNodeUrlScheme], async () => {
 			const stakingState = await this.stakingState();
 			return this.#getCommittee(stakingState.committee);
 		});

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -71,6 +71,12 @@ interface BaseWalrusClientConfig {
 	storageNodeClientOptions?: StorageNodeClientOptions;
 	wasmUrl?: string;
 	uploadRelay?: UploadRelayConfig;
+	/**
+	 * URL scheme to use when constructing storage-node URLs from each node's
+	 * on-chain `network_address`. Defaults to `'https'`. Set to `'http'` for
+	 * local development environments where storage nodes do not terminate TLS.
+	 */
+	storageNodeUrlScheme?: 'http' | 'https';
 }
 
 /**

--- a/packages/walrus/src/types.ts
+++ b/packages/walrus/src/types.ts
@@ -72,9 +72,9 @@ interface BaseWalrusClientConfig {
 	wasmUrl?: string;
 	uploadRelay?: UploadRelayConfig;
 	/**
-	 * URL scheme to use when constructing storage-node URLs from each node's
-	 * on-chain `network_address`. Defaults to `'https'`. Set to `'http'` for
-	 * local development environments where storage nodes do not terminate TLS.
+	 * URL scheme used when contacting storage nodes. Defaults to `'https'`.
+	 * Set to `'http'` for local development where storage nodes do not
+	 * terminate TLS.
 	 */
 	storageNodeUrlScheme?: 'http' | 'https';
 }


### PR DESCRIPTION
## Description

The Walrus on-chain `network_address` is `host:port` only — no scheme. The TS SDK has always prepended `https://` at `WalrusClient#getCommittee` (`packages/walrus/src/client.ts`), which is correct for testnet/mainnet but breaks local-dev environments where storage nodes don't terminate TLS.

The motivating case is [`MystenLabs/ts-sdks-incubation`](https://github.com/MystenLabs/ts-sdks-incubation)'s devstack: `axum-server` 0.8.0 panics on the self-signed handshake on arm64-darwin, so each storage-node yaml carries `tls.disable_tls: true` and the nodes serve plain HTTP. Today the browser-side `WalrusClient` works around the scheme mismatch by passing a custom `storageNodeClientOptions.fetch` that rewrites `https://...` → `http://...` per request — a layer below where the choice should live, since every URL the SDK emits has the same fixed scheme for that client instance.

Adds `storageNodeUrlScheme?: 'http' | 'https'` (default `'https'`) on `BaseWalrusClientConfig`. Local-dev callers set it to `'http'` and the fetch override goes away. Default behavior on testnet/mainnet is unchanged.

## Test plan

- `pnpm --filter @mysten/walrus run lint` passes
- `pnpm --filter @mysten/walrus exec tsc --noEmit` passes
- Default behavior (no `storageNodeUrlScheme`) still produces `https://` URLs — verified by inspection at the single call site in `client.ts`'s `#getCommittee`
- Setting `storageNodeUrlScheme: 'http'` produces `http://` URLs
- Devstack-side downstream change (separate, not in this PR): with this option set, the existing fetch override deletes cleanly

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.