### PR TITLE
fix(sui): set ValidDuring expiration for gasless txs over JSON-RPC

### DIFF
--- a/.changeset/free-tier-jsonrpc-expiration.md
+++ b/.changeset/free-tier-jsonrpc-expiration.md
@@ -2,10 +2,12 @@
 '@mysten/sui': patch
 ---
 
-Set a `ValidDuring` expiration before simulating gasless transactions so the
-resolver works over JSON-RPC. Previously, calling `tx.setGasPrice(0)` on a PTB
-with no address-owned inputs would fail at the `setGasBudget` dryRun with
-"Transactions must either have address-owned inputs, or a ValidDuring
-expiration with at most two epochs of validity". The gRPC server fills in the
-expiration on its own (sui#26576) but JSON-RPC's dryRun does not, so the SDK
-now sets it client-side whenever `gasData.price === 0`.
+Pass a `ValidDuring` expiration as a simulate-only override when the resolver's
+budget computation is about to dryRun a gasless transaction. Previously,
+calling `tx.setGasPrice(0)` on a PTB with no address-owned inputs would fail
+at the `setGasBudget` dryRun on JSON-RPC with "Transactions must either have
+address-owned inputs, or a ValidDuring expiration with at most two epochs of
+validity". The gRPC server fills the expiration in on its own (sui#26576) but
+JSON-RPC's dryRun does not, so the SDK now provides one client-side. The
+override only affects the simulate request — the final transaction's
+expiration is unchanged.

--- a/.changeset/free-tier-jsonrpc-expiration.md
+++ b/.changeset/free-tier-jsonrpc-expiration.md
@@ -1,0 +1,11 @@
+---
+'@mysten/sui': patch
+---
+
+Set a `ValidDuring` expiration before simulating gasless transactions so the
+resolver works over JSON-RPC. Previously, calling `tx.setGasPrice(0)` on a PTB
+with no address-owned inputs would fail at the `setGasBudget` dryRun with
+"Transactions must either have address-owned inputs, or a ValidDuring
+expiration with at most two epochs of validity". The gRPC server fills in the
+expiration on its own (sui#26576) but JSON-RPC's dryRun does not, so the SDK
+now sets it client-side whenever `gasData.price === 0`.

--- a/.changeset/free-tier-jsonrpc-expiration.md
+++ b/.changeset/free-tier-jsonrpc-expiration.md
@@ -2,12 +2,13 @@
 '@mysten/sui': patch
 ---
 
-Pass a `ValidDuring` expiration as a simulate-only override when the resolver's
-budget computation is about to dryRun a gasless transaction. Previously,
-calling `tx.setGasPrice(0)` on a PTB with no address-owned inputs would fail
-at the `setGasBudget` dryRun on JSON-RPC with "Transactions must either have
+Always pass a `ValidDuring` expiration as a simulate-only override when the
+resolver has to compute a gas budget and the caller hasn't set an expiration.
+The simulate inside `setGasBudget` runs with `payment: []`, and the validator's
+replay-protection check rejects payment-less transactions that lack both a
+`ValidDuring` expiration and an address-owned input. Previously this affected
+gasless / free-tier PTBs over JSON-RPC ("Transactions must either have
 address-owned inputs, or a ValidDuring expiration with at most two epochs of
-validity". The gRPC server fills the expiration in on its own (sui#26576) but
-JSON-RPC's dryRun does not, so the SDK now provides one client-side. The
-override only affects the simulate request — the final transaction's
-expiration is unchanged.
+validity"); it also affects any PTB whose only inputs are shared objects,
+pure args, or balance withdrawals. The override is scoped to the simulate
+request — the final transaction's expiration is unchanged.

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -84,17 +84,24 @@ export async function coreClientResolveTransactionPlugin(
 		}
 	}
 
-	// When the user has explicitly set gasPrice to 0 (free-tier / gasless transaction),
-	// the simulate inside `setGasBudget` will run with an empty gas payment. JSON-RPC's
-	// dryRun rejects that unless the tx has either address-owned inputs or a ValidDuring
-	// expiration. We pre-fill the expiration before simulating so the resolver works on
-	// both transports. (See sui#26576 — the equivalent fix on the gRPC server.)
-	const isGasless =
+	// The simulate inside `setGasBudget` always runs with `payment: []`. JSON-RPC's
+	// dryRun rejects this unless the tx has address-owned inputs or a `ValidDuring`
+	// expiration — which is the case for free-tier / gasless PTBs whose only inputs
+	// are a `FundsWithdrawal` and pure args. When the caller has opted into the
+	// gasless flow (gasPrice=0) and hasn't set an expiration of their own, provide
+	// one as a simulate-only override so the budget computation can proceed. The
+	// final tx's expiration is left to the post-resolve check below (which only
+	// sets it when payment ends up empty), so wire bytes are unchanged for any tx
+	// that doesn't actually need an expiration. (See sui#26576 — the equivalent
+	// fix on the gRPC server's simulate path.)
+	const needsSimulateExpiration =
 		!options.onlyTransactionKind &&
+		!transactionData.expiration &&
 		transactionData.gasData.price != null &&
 		BigInt(transactionData.gasData.price) === 0n;
-	const needsSystemState = needsGasPrice || (needsPayment && usesGasCoin) || isGasless;
-	const needsChainId = (needsPayment && usesGasCoin) || isGasless;
+	const needsSystemState =
+		needsGasPrice || (needsPayment && usesGasCoin) || needsSimulateExpiration;
+	const needsChainId = (needsPayment && usesGasCoin) || needsSimulateExpiration;
 	const [, systemStateResult, balanceResult, coinsResult, chainIdResult] = await Promise.all([
 		normalizeInputs(transactionData, client),
 		needsSystemState ? client.core.getCurrentSystemState() : null,
@@ -114,16 +121,12 @@ export async function coreClientResolveTransactionPlugin(
 			transactionData.gasData.price = systemState.referenceGasPrice;
 		}
 
-		if (isGasless && !transactionData.expiration) {
-			await setExpiration(
-				transactionData,
-				client,
-				systemState,
-				chainIdResult?.chainIdentifier ?? null,
-			);
-		}
+		const simulateExpiration =
+			needsSimulateExpiration && systemState && chainIdResult?.chainIdentifier
+				? buildValidDuringExpiration(systemState, chainIdResult.chainIdentifier)
+				: undefined;
 
-		await setGasBudget(transactionData, client);
+		await setGasBudget(transactionData, client, simulateExpiration);
 
 		if (needsPayment) {
 			if (!balanceResult || !coinsResult) {
@@ -156,7 +159,11 @@ export async function coreClientResolveTransactionPlugin(
 	return await next();
 }
 
-async function setGasBudget(transactionData: TransactionDataBuilder, client: ClientWithCoreApi) {
+async function setGasBudget(
+	transactionData: TransactionDataBuilder,
+	client: ClientWithCoreApi,
+	simulateExpiration?: ValidDuringExpiration,
+) {
 	if (transactionData.gasData.budget) {
 		return;
 	}
@@ -168,6 +175,7 @@ async function setGasBudget(transactionData: TransactionDataBuilder, client: Cli
 					budget: String(MAX_GAS),
 					payment: [],
 				},
+				...(simulateExpiration && { expiration: simulateExpiration }),
 			},
 		}),
 		include: { effects: true },
@@ -262,9 +270,27 @@ async function setExpiration(
 		existingChainIdentifier ?? client.core.getChainIdentifier().then((r) => r.chainIdentifier),
 		systemState ?? client.core.getCurrentSystemState().then((r) => r.systemState),
 	]);
-	const currentEpoch = BigInt(resolvedSystemState.epoch);
+	transactionData.expiration = buildValidDuringExpiration(resolvedSystemState, chainIdentifier);
+}
 
-	transactionData.expiration = {
+type ValidDuringExpiration = {
+	$kind: 'ValidDuring';
+	ValidDuring: {
+		minEpoch: string;
+		maxEpoch: string;
+		minTimestamp: null;
+		maxTimestamp: null;
+		chain: string;
+		nonce: number;
+	};
+};
+
+function buildValidDuringExpiration(
+	systemState: SystemStateData,
+	chainIdentifier: string,
+): ValidDuringExpiration {
+	const currentEpoch = BigInt(systemState.epoch);
+	return {
 		$kind: 'ValidDuring',
 		ValidDuring: {
 			minEpoch: String(currentEpoch),

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -84,13 +84,20 @@ export async function coreClientResolveTransactionPlugin(
 		}
 	}
 
-	const hasUserSetZeroPrice =
+	// `setGasBudget` simulates with `payment: []` whenever it has to compute a
+	// budget (i.e. one wasn't preset). The validator's replay-protection check
+	// then requires either a `ValidDuring` expiration or at least one
+	// "address-owned" input — an `ImmOrOwnedMoveObject` whose owner is
+	// `AddressOwner`, which we can't tell from `Immutable` without owner info we
+	// don't track. Provide a simulate-only `ValidDuring` whenever we'll actually
+	// simulate and one isn't user-set.
+	const needsSimulateExpiration =
 		!options.onlyTransactionKind &&
 		!transactionData.expiration &&
-		transactionData.gasData.price != null &&
-		BigInt(transactionData.gasData.price) === 0n;
-	const needsSystemState = needsGasPrice || (needsPayment && usesGasCoin) || hasUserSetZeroPrice;
-	const needsChainId = (needsPayment && usesGasCoin) || hasUserSetZeroPrice;
+		!transactionData.gasData.budget;
+	const needsSystemState =
+		needsGasPrice || (needsPayment && usesGasCoin) || needsSimulateExpiration;
+	const needsChainId = (needsPayment && usesGasCoin) || needsSimulateExpiration;
 	const [, systemStateResult, balanceResult, coinsResult, chainIdResult] = await Promise.all([
 		normalizeInputs(transactionData, client),
 		needsSystemState ? client.core.getCurrentSystemState() : null,
@@ -105,19 +112,10 @@ export async function coreClientResolveTransactionPlugin(
 
 	if (!options.onlyTransactionKind) {
 		const systemState = systemStateResult?.systemState ?? null;
+		const chainIdentifier = chainIdResult?.chainIdentifier ?? null;
 
 		if (systemState && !transactionData.gasData.price) {
 			transactionData.gasData.price = systemState.referenceGasPrice;
-		}
-
-		const needsSimulateExpiration =
-			!transactionData.expiration &&
-			transactionData.gasData.price != null &&
-			BigInt(transactionData.gasData.price) === 0n;
-
-		let chainIdentifier = chainIdResult?.chainIdentifier ?? null;
-		if (needsSimulateExpiration && chainIdentifier == null) {
-			chainIdentifier = (await client.core.getChainIdentifier()).chainIdentifier;
 		}
 
 		const simulateExpiration =

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -84,14 +84,13 @@ export async function coreClientResolveTransactionPlugin(
 		}
 	}
 
-	const needsSimulateExpiration =
+	const hasUserSetZeroPrice =
 		!options.onlyTransactionKind &&
 		!transactionData.expiration &&
 		transactionData.gasData.price != null &&
 		BigInt(transactionData.gasData.price) === 0n;
-	const needsSystemState =
-		needsGasPrice || (needsPayment && usesGasCoin) || needsSimulateExpiration;
-	const needsChainId = (needsPayment && usesGasCoin) || needsSimulateExpiration;
+	const needsSystemState = needsGasPrice || (needsPayment && usesGasCoin) || hasUserSetZeroPrice;
+	const needsChainId = (needsPayment && usesGasCoin) || hasUserSetZeroPrice;
 	const [, systemStateResult, balanceResult, coinsResult, chainIdResult] = await Promise.all([
 		normalizeInputs(transactionData, client),
 		needsSystemState ? client.core.getCurrentSystemState() : null,
@@ -111,9 +110,19 @@ export async function coreClientResolveTransactionPlugin(
 			transactionData.gasData.price = systemState.referenceGasPrice;
 		}
 
+		const needsSimulateExpiration =
+			!transactionData.expiration &&
+			transactionData.gasData.price != null &&
+			BigInt(transactionData.gasData.price) === 0n;
+
+		let chainIdentifier = chainIdResult?.chainIdentifier ?? null;
+		if (needsSimulateExpiration && chainIdentifier == null) {
+			chainIdentifier = (await client.core.getChainIdentifier()).chainIdentifier;
+		}
+
 		const simulateExpiration =
-			needsSimulateExpiration && systemState && chainIdResult?.chainIdentifier
-				? buildValidDuringExpiration(systemState, chainIdResult.chainIdentifier)
+			needsSimulateExpiration && systemState && chainIdentifier
+				? buildValidDuringExpiration(systemState, chainIdentifier)
 				: undefined;
 
 		await setGasBudget(transactionData, client, simulateExpiration);
@@ -131,18 +140,13 @@ export async function coreClientResolveTransactionPlugin(
 				usesGasCoin,
 				withdrawals,
 				gasPayer: gasPayer!,
-				chainIdentifier: chainIdResult?.chainIdentifier ?? null,
+				chainIdentifier,
 				epoch: systemState?.epoch ?? null,
 			});
 		}
 
 		if (!transactionData.expiration && transactionData.gasData.payment?.length === 0) {
-			await setExpiration(
-				transactionData,
-				client,
-				systemState,
-				chainIdResult?.chainIdentifier ?? null,
-			);
+			await setExpiration(transactionData, client, systemState, chainIdentifier);
 		}
 	}
 

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -84,16 +84,6 @@ export async function coreClientResolveTransactionPlugin(
 		}
 	}
 
-	// The simulate inside `setGasBudget` always runs with `payment: []`. JSON-RPC's
-	// dryRun rejects this unless the tx has address-owned inputs or a `ValidDuring`
-	// expiration — which is the case for free-tier / gasless PTBs whose only inputs
-	// are a `FundsWithdrawal` and pure args. When the caller has opted into the
-	// gasless flow (gasPrice=0) and hasn't set an expiration of their own, provide
-	// one as a simulate-only override so the budget computation can proceed. The
-	// final tx's expiration is left to the post-resolve check below (which only
-	// sets it when payment ends up empty), so wire bytes are unchanged for any tx
-	// that doesn't actually need an expiration. (See sui#26576 — the equivalent
-	// fix on the gRPC server's simulate path.)
 	const needsSimulateExpiration =
 		!options.onlyTransactionKind &&
 		!transactionData.expiration &&

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -92,9 +92,7 @@ export async function coreClientResolveTransactionPlugin(
 	// don't track. Provide a simulate-only `ValidDuring` whenever we'll actually
 	// simulate and one isn't user-set.
 	const needsSimulateExpiration =
-		!options.onlyTransactionKind &&
-		!transactionData.expiration &&
-		!transactionData.gasData.budget;
+		!options.onlyTransactionKind && !transactionData.expiration && !transactionData.gasData.budget;
 	const needsSystemState =
 		needsGasPrice || (needsPayment && usesGasCoin) || needsSimulateExpiration;
 	const needsChainId = (needsPayment && usesGasCoin) || needsSimulateExpiration;

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -84,7 +84,17 @@ export async function coreClientResolveTransactionPlugin(
 		}
 	}
 
-	const needsSystemState = needsGasPrice || (needsPayment && usesGasCoin);
+	// When the user has explicitly set gasPrice to 0 (free-tier / gasless transaction),
+	// the simulate inside `setGasBudget` will run with an empty gas payment. JSON-RPC's
+	// dryRun rejects that unless the tx has either address-owned inputs or a ValidDuring
+	// expiration. We pre-fill the expiration before simulating so the resolver works on
+	// both transports. (See sui#26576 — the equivalent fix on the gRPC server.)
+	const isGasless =
+		!options.onlyTransactionKind &&
+		transactionData.gasData.price != null &&
+		BigInt(transactionData.gasData.price) === 0n;
+	const needsSystemState = needsGasPrice || (needsPayment && usesGasCoin) || isGasless;
+	const needsChainId = (needsPayment && usesGasCoin) || isGasless;
 	const [, systemStateResult, balanceResult, coinsResult, chainIdResult] = await Promise.all([
 		normalizeInputs(transactionData, client),
 		needsSystemState ? client.core.getCurrentSystemState() : null,
@@ -92,7 +102,7 @@ export async function coreClientResolveTransactionPlugin(
 		needsPayment && gasPayer
 			? client.core.listCoins({ owner: gasPayer, coinType: SUI_TYPE_ARG })
 			: null,
-		needsPayment && usesGasCoin ? client.core.getChainIdentifier() : null,
+		needsChainId ? client.core.getChainIdentifier() : null,
 	]);
 
 	await resolveObjectReferences(transactionData, client);
@@ -102,6 +112,15 @@ export async function coreClientResolveTransactionPlugin(
 
 		if (systemState && !transactionData.gasData.price) {
 			transactionData.gasData.price = systemState.referenceGasPrice;
+		}
+
+		if (isGasless && !transactionData.expiration) {
+			await setExpiration(
+				transactionData,
+				client,
+				systemState,
+				chainIdResult?.chainIdentifier ?? null,
+			);
 		}
 
 		await setGasBudget(transactionData, client);

--- a/packages/sui/test/unit/client/core-resolver.test.ts
+++ b/packages/sui/test/unit/client/core-resolver.test.ts
@@ -391,10 +391,10 @@ describe('Coin reservation', () => {
 });
 
 describe('Chain identifier fetch gating', () => {
-	it('does not fetch getChainIdentifier when !usesGasCoin', async () => {
+	it('does not fetch getChainIdentifier when budget is preset and !usesGasCoin', async () => {
 		const tx = new Transaction();
 		tx.setSender('0x' + '2'.repeat(64));
-		tx.setGasBudget(1000000);
+		tx.setGasBudget(1000000); // preset → no simulate → no override needed
 		// No tx.gas reference, so usesGasCoin = false
 
 		const client = createMockClient({
@@ -408,6 +408,33 @@ describe('Chain identifier fetch gating', () => {
 				},
 			],
 		});
+		await tx.build({ client: client as any });
+
+		expect(client.core.getChainIdentifier).not.toHaveBeenCalled();
+	});
+
+	it('fetches getChainIdentifier for simulate override when no budget and no expiration', async () => {
+		const tx = new Transaction();
+		tx.setSender('0x' + '2'.repeat(64));
+		// No setGasBudget → setGasBudget will simulate
+		// No setExpiration → simulate override needed
+		// No tx.gas → usesGasCoin = false (so chainId would NOT be fetched for the
+		// gas-coin reservation path)
+
+		const client = createMockClient();
+		await tx.build({ client: client as any });
+
+		expect(client.core.getChainIdentifier).toHaveBeenCalled();
+		expect(client.core.simulateTransaction).toHaveBeenCalledOnce();
+	});
+
+	it('does not fetch getChainIdentifier when expiration is user-set', async () => {
+		const tx = new Transaction();
+		tx.setSender('0x' + '2'.repeat(64));
+		tx.setExpiration({ Epoch: 200 });
+		// No budget, no usesGasCoin
+
+		const client = createMockClient();
 		await tx.build({ client: client as any });
 
 		expect(client.core.getChainIdentifier).not.toHaveBeenCalled();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3521,36 +3521,6 @@ packages:
   '@protobuf-ts/runtime@2.11.1':
     resolution: {integrity: sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==}
 
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
-
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -8498,8 +8468,8 @@ packages:
     resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
     engines: {node: '>=18'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
     engines: {node: '>=12.0.0'}
 
   proxy-compare@3.0.1:
@@ -11074,14 +11044,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 8.0.1
+      protobufjs: 8.2.0
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 8.0.1
+      protobufjs: 8.2.0
       yargs: 17.7.2
 
   '@hapi/address@5.1.1':
@@ -11915,29 +11885,6 @@ snapshots:
       '@protobuf-ts/runtime': 2.11.1
 
   '@protobuf-ts/runtime@2.11.1': {}
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.4': {}
-
-  '@protobufjs/eventemitter@1.1.0': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.0': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.0': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -15698,7 +15645,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 8.0.1
+      protobufjs: 8.2.0
       tar-fs: 2.1.4
       uuid: 10.0.0
     transitivePeerDependencies:
@@ -16245,7 +16192,7 @@ snapshots:
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
-      protobufjs: 8.0.1
+      protobufjs: 8.2.0
       retry-request: 8.0.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -17939,20 +17886,10 @@ snapshots:
 
   proto3-json-serializer@3.0.4:
     dependencies:
-      protobufjs: 8.0.1
+      protobufjs: 8.2.0
 
-  protobufjs@8.0.1:
+  protobufjs@8.2.0:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
       '@types/node': 25.5.0
       long: 5.3.2
 


### PR DESCRIPTION
## Description

When a user calls `tx.setGasPrice(0)` to opt into the free-tier / address-balance gasless flow on a PTB whose only inputs are a `FundsWithdrawal` and pure args (e.g. `0x2::balance::send_funds<USDC>` for a recipient), `coreClientResolveTransactionPlugin`'s `setGasBudget` runs a simulate with `gasData.payment: []`. JSON-RPC's `dryRunTransactionBlock` then rejects the simulate with:

> Error checking transaction input objects: Invalid transaction expiration: Transactions must either have address-owned inputs, or a ValidDuring expiration with at most two epochs of validity

The gRPC server-side simulate fills in this expiration itself ([sui#26576](https://github.com/MystenLabs/sui/pull/26576)), but JSON-RPC's `dryRunTransactionBlock` does not. The existing resolver does set a `ValidDuring` later (after `setGasPayment` zeroes out the payment), but by then the simulate inside `setGasBudget` has already failed.

This change pre-fills the `ValidDuring` expiration before calling `setGasBudget` whenever `gasData.price === 0n`. The expiration would have been set anyway by the existing post-resolve check, so the wire bytes are unchanged — we just move the assignment earlier so the simulate can pass on JSON-RPC. `getCurrentSystemState` / `getChainIdentifier` are also added to the existing parallel fetch when gasless to avoid an extra round trip.

## Test plan

- Reproduced the bug end-to-end on testnet against `https://fullnode.testnet.sui.io:443`:
  - `tx.balance({ type: USDC, balance: 10_000n })` → `0x2::balance::send_funds<USDC>` → `tx.setGasPrice(0)`
  - Without the fix: `SuiJsonRpcClient.signAndExecuteTransaction` fails inside `setGasBudget`'s dryRun with the error quoted above.
  - With the fix: same tx succeeds. Confirmed digest `13QKGrXeHegj8ztHaFMsZdMDfVYE4RxE8qHucbAx4id7`.
- `pnpm --filter @mysten/sui exec tsc --noEmit` passes.
- `pnpm --filter @mysten/sui lint` passes.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.