### PR TITLE
fix(ci): refresh node_modules state between version bump and codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"test": "turbo run test",
 		"test:e2e": "turbo run test:e2e --concurrency=1",
-		"changeset-version": "pnpm changeset version && pnpm --filter @mysten/* codegen:version",
+		"changeset-version": "pnpm changeset version && pnpm install --frozen-lockfile && pnpm --filter @mysten/* codegen:version",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"prettier:fix:watch": "onchange '**' -i -f add -f change -j 5 -- prettier -w --ignore-unknown {{file}}",


### PR DESCRIPTION
## Description

After PR #1063 added `verifyDepsBeforeRun: 'prompt'` to `pnpm-workspace.yaml`, the `changeset-version` script breaks the moment any package with a `codegen:version` script gets bumped:

1. `pnpm changeset version` mutates the package.json versions.
2. `pnpm --filter @mysten/* codegen:version` then trips the verify check.
3. pnpm prints "Your node_modules directory is out of sync with the pnpm-lock.yaml file" and prompts to install.
4. In CI (no TTY), that prompt hangs the `Changesets` workflow — which is what we're observing right now on `main` after #1070 merged.

### What got merged that broke it

Two commits combined:
- **#1063** ("Add pnpm build script controls", May 8) added `verifyDepsBeforeRun: 'prompt'` — this is what makes pnpm prompt on out-of-sync state.
- **#1070** ("fix(sui): set ValidDuring expiration ...", May 15) was the first PR after #1063 to bump a package that has a `codegen:version` script (`@mysten/sui`). Prior cycles bumped `@mysten/enoki`, which has no `codegen:version`, so the issue stayed dormant.

The bug is in the script ordering, not in either PR's content — but #1070 surfaces it because `pnpm --filter @mysten/sui codegen:version` now sees the bumped `@mysten/sui/package.json` and triggers the verify check.

### Fix

Insert a `pnpm install --frozen-lockfile` between the two steps. After `pnpm changeset version`, workspace dependencies in `pnpm-lock.yaml` remain valid (they're linked, not pinned to a version), so frozen install passes — it just refreshes the `.modules.yaml` state that the verify check looks at. Keeping `--frozen-lockfile` ensures this step can never accidentally mutate the lockfile in CI.

## Test plan

Reproduced and verified locally on `main`:

```
$ pnpm install --frozen-lockfile           # baseline
$ pnpm changeset version                    # bumps @mysten/sui 2.16.2 → 2.16.3
$ pnpm --filter @mysten/sui codegen:version
[?25l? Your "node_modules" directory is out of sync with the "pnpm-lock.yaml" file. …
Would you like to run "pnpm install" to update your "node_modules"? (Y/n) ›       # ← hangs in CI
```

With the fix in `changeset-version`:

```
$ pnpm changeset-version
🦋  All files have been updated. Review them and commit at your leisure
Scope: all 42 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date
…
packages/sui codegen:version$ node genversion.mjs    # ← runs cleanly, no prompt
packages/sui codegen:version: Done
packages/seal codegen:version$ node genversion.mjs
packages/seal codegen:version: Done
```

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.