### PR TITLE
fix(ci): suppress pnpm verify-deps prompt in changesets/action step

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -40,3 +40,10 @@ jobs:
           # release-<pkg>.yml workflows. Do NOT add a `publish:` field here.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # changesets/action does `git checkout changeset-release/main && git reset --hard <main>`
+          # before invoking the version script. The transient working-tree churn invalidates pnpm's
+          # `verifyDepsBeforeRun` tracking even though the final state matches main exactly, and the
+          # 'prompt' setting from pnpm-workspace.yaml then hangs CI waiting for stdin. Disable the
+          # check for just this step; everything the version script does (read package.json, write
+          # version.ts) is independent of node_modules.
+          NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'false'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"test": "turbo run test",
 		"test:e2e": "turbo run test:e2e --concurrency=1",
-		"changeset-version": "pnpm changeset version && pnpm install --frozen-lockfile && pnpm --filter @mysten/* codegen:version",
+		"changeset-version": "pnpm changeset version && pnpm --filter @mysten/* codegen:version",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"prettier:fix:watch": "onchange '**' -i -f add -f change -j 5 -- prettier -w --ignore-unknown {{file}}",


### PR DESCRIPTION
## Description

The \`Changesets\` workflow on \`main\` has been hanging since #1070 merged, eventually canceled by GitHub's 24-min timeout. PR #1071 was an attempted fix that didn't help because it solved a problem one step too late.

### What actually happens

\`changesets/action\` checks out the release branch and resets back before running the version script:

\`\`\`
git checkout changeset-release/main      # working tree briefly shows the stale release branch
git reset --hard <main-HEAD>             # back to main
pnpm changeset-version                   # ← prompt fires here, before any inner command runs
\`\`\`

Both ends of that dance leave the working tree identical to what \`pnpm install --frozen-lockfile\` was just run for, so the lockfile and \`node_modules\` are genuinely consistent. But pnpm's \`verifyDepsBeforeRun\` tracking invalidates when workspace files churn under it, and on the next \`pnpm\` invocation it pessimistically prints:

> Your \"node_modules\" directory is out of sync with the \"pnpm-lock.yaml\" file.
> Would you like to run \"pnpm install\" to update your \"node_modules\"? (Y/n) ›

\`verifyDepsBeforeRun: 'prompt'\` was added in #1063 (May 8). It stayed dormant until #1070 (May 15) became the first cycle to bump a workspace package, which is what trips the action's checkout-then-reset sequence into a state pnpm flags. Until then, no Version Packages PR had bumped @mysten/sui post-#1063.

### Fix

Set \`NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false\` on the \`Create Release Pull Request\` step only. Three reasons this is safe:

1. **The version script doesn't need \`node_modules\`.** \`pnpm changeset version\` only reads/writes \`package.json\` files; \`pnpm --filter @mysten/* codegen:version\` runs \`node genversion.mjs\`, which reads \`package.json\` and writes \`src/version.ts\`. Neither imports anything from \`node_modules\`.
2. **The state is consistent.** I verified locally that after the \`checkout → reset --hard\` sequence, \`pnpm install --frozen-lockfile\` is a no-op — pnpm's verify check is firing on a false positive.
3. **Scope is one step.** Local devs keep the \`'prompt'\` UX; every other CI workflow that relies on deps being in sync is unaffected.

Also reverts #1071's \`pnpm install --frozen-lockfile\` interleave in the \`changeset-version\` script. That step never ran — the prompt fired on the very first \`pnpm\` invocation (the script itself), before it got to any inner command — so it was dead weight.

## Test plan

- Confirmed locally that the version script does no filesystem work that requires \`node_modules\`.
- Reproduced the hang against \`changesets/action\`'s checkout-then-reset behavior locally with \`verifyDepsBeforeRun: 'prompt'\` enabled.
- After this PR lands, the \`Changesets\` workflow run on \`main\` should complete and open the pending Version Packages PR.

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.