### PR TITLE
fix(ci): pass --verify-deps-before-run=false to the version script

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,16 +34,16 @@ jobs:
         with:
           # Generates src/version.ts file using genVersion
           # https://github.com/changesets/action#with-version-script
-          version: pnpm changeset-version
+          #
+          # `--verify-deps-before-run=false` is scoped to this single pnpm invocation.
+          # changesets/action does `git checkout changeset-release/main && git reset --hard <main>`
+          # before invoking the version script, and the transient working-tree churn invalidates
+          # pnpm's verify-deps tracking even though the final state matches main exactly. With
+          # `verifyDepsBeforeRun: 'prompt'` in pnpm-workspace.yaml that hangs CI on stdin.
+          # The script only reads package.json and writes generated files — no node_modules needed.
+          version: pnpm --verify-deps-before-run=false changeset-version
           # Publishing happens via .github/workflows/release.yml (orchestrator),
           # which gates on Turborepo CI success and dispatches per-package
           # release-<pkg>.yml workflows. Do NOT add a `publish:` field here.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # changesets/action does `git checkout changeset-release/main && git reset --hard <main>`
-          # before invoking the version script. The transient working-tree churn invalidates pnpm's
-          # `verifyDepsBeforeRun` tracking even though the final state matches main exactly, and the
-          # 'prompt' setting from pnpm-workspace.yaml then hangs CI waiting for stdin. Disable the
-          # check for just this step; everything the version script does (read package.json, write
-          # version.ts) is independent of node_modules.
-          NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'false'


### PR DESCRIPTION
## Description

PR #1072 set \`NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false\` as a step env on the changesets/action step, but pnpm doesn't honor env-var overrides for workspace settings — \`pnpm-workspace.yaml\`'s \`verifyDepsBeforeRun: 'prompt'\` wins. The Changesets workflow on \`main\` is still hanging on the interactive prompt.

Pass it as a **CLI flag** on the pnpm invocation instead. The flag scope stays the same (only this one step is affected), and pnpm propagates the parsed flag back into the environment so the inner \`pnpm\` calls in the \`changeset-version\` script (\`pnpm changeset version\` and \`pnpm --filter @mysten/* codegen:version\`) also pick it up.

\`\`\`yaml
version: pnpm --verify-deps-before-run=false changeset-version
\`\`\`

(Removed the now-pointless \`NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN\` env added in #1072.)

## Test plan

Reproduced locally on \`main\` (replicates what changesets/action does):

\`\`\`bash
$ pnpm install --frozen-lockfile
$ git checkout changeset-release/main
$ git reset --hard origin/main
$ pnpm changeset-version
[?25l? Your "node_modules" directory is out of sync with the "pnpm-lock.yaml" file. …
Would you like to run "pnpm install" to update your "node_modules"? (Y/n) ›       # ← hangs
\`\`\`

With the flag:

\`\`\`bash
$ pnpm --verify-deps-before-run=false changeset-version
> pnpm changeset version && pnpm --filter @mysten/* codegen:version
🦋  All files have been updated. Review them and commit at your leisure
Scope: 36 of 42 workspace projects
packages/sui codegen:version$ node genversion.mjs
packages/sui codegen:version: Done
packages/seal codegen:version$ node genversion.mjs
packages/seal codegen:version: Done          # ← completes cleanly, no prompt
\`\`\`

Local devs and every other CI workflow that uses pnpm still see the \`'prompt'\` UX from \`pnpm-workspace.yaml\`.

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.