### PR TITLE
fix(docs): append .md extension to URLs in llms.txt

### DIFF
--- a/packages/docs/app/llms.txt/[[...path]]/route.ts
+++ b/packages/docs/app/llms.txt/[[...path]]/route.ts
@@ -50,7 +50,7 @@ function buildIndex(baseUrl: string) {
 	if (fs.existsSync(distIndex)) {
 		let content = fs.readFileSync(distIndex, 'utf-8');
 		// Rewrite relative links (./section/page.md) to absolute URLs (strip .md to match sitemap)
-		content = content.replace(/\(\.\/([^)]+)\.md\)/g, (_match, p) => `(${baseUrl}/${p})`);
+		content = content.replace(/\(\.\/([^)]+)\.md\)/g, (_match, p) => `(${baseUrl}/${p}.md)`);
 		return new Response(content, {
 			headers: {
 				'Content-Type': 'text/plain; charset=utf-8',
@@ -94,7 +94,7 @@ function buildIndex(baseUrl: string) {
 
 		const indent = parts.length > 2 ? '  ' : '';
 		const desc = page.data.description ? `: ${page.data.description}` : '';
-		lines.push(`${indent}- [${page.data.title}](${baseUrl}${page.url})${desc}`);
+		lines.push(`${indent}- [${page.data.title}](${baseUrl}${page.url}.md)${desc}`);
 	}
 
 	lines.push('');


### PR DESCRIPTION
## Description

The `llms.txt` route handler was generating URLs without the `.md` extension in two places:

1. **Pre-built index path** (line 53): The regex that rewrites relative links (`./section/page.md`) to absolute URLs was stripping `.md` instead of preserving it.
2. **Fallback index builder** (line 97): URLs generated from fumadocs source were missing `.md` entirely.

Both now correctly append `.md` to generated URLs.

## Test plan

- Verified the regex replacement produces correct output (e.g. `https://host/sui/page.md` instead of `https://host/sui/page`)
- Verified the fallback builder appends `.md` to page URLs

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)