### PR TITLE
transactions: support custom intents in Transaction.from

### DIFF
--- a/.changeset/transaction-from-custom-intents.md
+++ b/.changeset/transaction-from-custom-intents.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+`Transaction.from` now accepts an optional `intentResolvers` option, a map of intent names to resolvers. This lets you synchronously copy a transaction that still contains unresolved custom intents without first awaiting `prepareForSerialization`. Built-in intents (such as `CoinWithBalance`) continue to be handled automatically.

--- a/packages/docs/content/sui/plugins.mdx
+++ b/packages/docs/content/sui/plugins.mdx
@@ -274,3 +274,28 @@ function transferToSender(objects: TransactionObjectInput[]) {
 const transaction = new Transaction();
 transaction.add(transferToSender(['0x1234']));
 ```
+
+## Copying transactions that use custom intents
+
+`Transaction.from` creates a deep copy of a transaction. Copying is synchronous, so any unresolved
+intents are carried over as-is and resolved later when the copy is built or serialized. To do that,
+the copy needs the intent resolvers, but resolvers are functions and cannot be represented in the
+serialized transaction data.
+
+Built-in intents (such as the `CoinWithBalance` intent added by `tx.coin()`) are re-attached
+automatically. For custom intents, pass the resolvers via the `intentResolvers` option so the copy
+knows how to resolve them:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+const copy = Transaction.from(transaction, {
+	intentResolvers: {
+		TransferToSender: resolveTransferToSender,
+	},
+});
+```
+
+Without this, `Transaction.from` throws if the transaction still contains unresolved custom intents.
+Alternatively, you can `await transaction.prepareForSerialization()` first to resolve the intents
+before copying, but that requires an async call and (for some intents) a client.

--- a/packages/docs/content/sui/plugins.mdx
+++ b/packages/docs/content/sui/plugins.mdx
@@ -283,8 +283,8 @@ the copy needs the intent resolvers, but resolvers are functions and cannot be r
 serialized transaction data.
 
 Built-in intents (such as the `CoinWithBalance` intent added by `tx.coin()`) are re-attached
-automatically. For custom intents, pass the resolvers via the `intentResolvers` option so the copy
-knows how to resolve them:
+automatically. For custom intents, pass the resolvers through the `intentResolvers` option so the
+copy knows how to resolve them:
 
 ```typescript
 import { Transaction } from '@mysten/sui/transactions';

--- a/packages/sui/src/transactions/Transaction.ts
+++ b/packages/sui/src/transactions/Transaction.ts
@@ -139,6 +139,17 @@ type TransactionLike = {
 	getData(): unknown;
 };
 
+export interface TransactionCopyOptions {
+	/**
+	 * A map of intent names to resolvers for any custom intents used in the transaction being copied.
+	 *
+	 * Built-in intents (such as `CoinWithBalance`) are handled automatically. Providing resolvers for
+	 * custom intents lets `Transaction.from` copy a transaction synchronously even when it still
+	 * contains unresolved intents, without first awaiting `prepareForSerialization`.
+	 */
+	intentResolvers?: Record<string, TransactionPlugin>;
+}
+
 /**
  * Transaction Builder
  */
@@ -175,8 +186,15 @@ export class Transaction {
 	 * There are two supported serialized formats:
 	 * - A string returned from `Transaction#serialize`. The serialized format must be compatible, or it will throw an error.
 	 * - A byte array (or base64-encoded bytes) containing BCS transaction data.
+	 *
+	 * When copying an in-memory transaction that uses custom intents, pass resolvers for those intents
+	 * via `options.intentResolvers` so the copy can be created synchronously without first awaiting
+	 * `prepareForSerialization`. Built-in intents (such as `CoinWithBalance`) are handled automatically.
 	 */
-	static from(transaction: string | Uint8Array | TransactionLike) {
+	static from(
+		transaction: string | Uint8Array | TransactionLike,
+		options: TransactionCopyOptions = {},
+	) {
 		const newTransaction = new Transaction();
 
 		if (isTransaction(transaction)) {
@@ -195,14 +213,27 @@ export class Transaction {
 		newTransaction.#commandSection = newTransaction.#data.commands.slice();
 		newTransaction.#availableResults = new Set(newTransaction.#commandSection.map((_, i) => i));
 
-		if (!newTransaction.isPreparedForSerialization({ supportedIntents: [COIN_WITH_BALANCE] })) {
+		// Built-in intents are resolvable by default. Caller-supplied resolvers cover custom intents,
+		// and take precedence so a built-in resolver can be overridden if needed.
+		const intentResolvers = new Map<string, TransactionPlugin>([
+			[COIN_WITH_BALANCE, resolveCoinBalance],
+			...Object.entries(options.intentResolvers ?? {}),
+		]);
+
+		if (
+			!newTransaction.isPreparedForSerialization({
+				supportedIntents: [...intentResolvers.keys()],
+			})
+		) {
 			throw new Error(
-				'Transaction has unresolved intents or async thunks. Call `prepareForSerialization` before copying.',
+				'Transaction has unresolved intents or async thunks. Provide resolvers for any custom intents via the `intentResolvers` option, or call `prepareForSerialization` before copying.',
 			);
 		}
 
-		if (newTransaction.#data.commands.some((cmd) => cmd.$Intent?.name === COIN_WITH_BALANCE)) {
-			newTransaction.addIntentResolver(COIN_WITH_BALANCE, resolveCoinBalance);
+		// Register every resolver so the copy can resolve its intents on build. Resolvers for intents
+		// that aren't present are harmless — a resolver only runs when its intent appears in the data.
+		for (const [intent, resolver] of intentResolvers) {
+			newTransaction.addIntentResolver(intent, resolver);
 		}
 
 		return newTransaction;

--- a/packages/sui/src/transactions/index.ts
+++ b/packages/sui/src/transactions/index.ts
@@ -17,6 +17,7 @@ export {
 	type TransactionObjectInput,
 	type TransactionObjectArgument,
 	type TransactionResult,
+	type TransactionCopyOptions,
 } from './Transaction.js';
 
 export { type SerializedTransactionDataV2 } from './data/v2.js';

--- a/packages/sui/test/unit/transactions/Transaction.test.ts
+++ b/packages/sui/test/unit/transactions/Transaction.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from 'vitest';
 import { bcs } from '../../../src/bcs/index.js';
 import { TransactionCommands, Transaction } from '../../../src/transactions/index.js';
 import { Inputs } from '../../../src/transactions/Inputs.js';
+import type { BuildTransactionOptions } from '../../../src/transactions/resolve.js';
+import type { TransactionDataBuilder } from '../../../src/transactions/TransactionData.js';
 
 it('can construct and serialize an empty tranaction', () => {
 	const tx = new Transaction();
@@ -158,6 +160,104 @@ describe('offline build', () => {
 		const bytes2 = await tx2.build();
 
 		expect(bytes).toEqual(bytes2);
+	});
+});
+
+describe('Transaction.from with custom intents', () => {
+	const TEST_INTENT = 'TestIntent';
+
+	function testIntent() {
+		return (tx: Transaction) => {
+			tx.addIntentResolver(TEST_INTENT, resolveTestIntent);
+			return tx.add(
+				TransactionCommands.Intent({
+					name: TEST_INTENT,
+					inputs: {},
+					data: {},
+				}),
+			);
+		};
+	}
+
+	async function resolveTestIntent(
+		transactionData: TransactionDataBuilder,
+		_buildOptions: BuildTransactionOptions,
+		next: () => Promise<void>,
+	) {
+		for (let i = 0; i < transactionData.commands.length; i++) {
+			const command = transactionData.commands[i];
+			if (command.$kind === '$Intent' && command.$Intent.name === TEST_INTENT) {
+				transactionData.replaceCommand(i, {
+					$kind: 'MoveCall',
+					MoveCall: {
+						package: '0x1',
+						module: 'test',
+						function: 'test',
+						typeArguments: [],
+						arguments: [],
+					},
+				});
+			}
+		}
+
+		await next();
+	}
+
+	it('throws when copying a transaction with a custom intent and no resolver', () => {
+		const tx = new Transaction();
+		tx.add(testIntent());
+
+		expect(() => Transaction.from(tx)).toThrowError(/unresolved intents or async thunks/);
+	});
+
+	it('copies a transaction with a custom intent when a resolver is provided', async () => {
+		const tx = new Transaction();
+		const result = tx.add(testIntent());
+		tx.transferObjects([result], '0x2');
+
+		const copy = Transaction.from(tx, {
+			intentResolvers: { [TEST_INTENT]: resolveTestIntent },
+		});
+
+		// The intent is preserved in the copy until it is resolved.
+		expect(copy.getData().commands.some((cmd) => cmd.$Intent?.name === TEST_INTENT)).toBe(true);
+
+		// Serializing the copy resolves the custom intent into concrete commands, with no client needed.
+		const json = JSON.parse(await copy.toJSON());
+		expect(json.commands.some((cmd: { $Intent?: unknown }) => cmd.$Intent)).toBe(false);
+		expect(
+			json.commands.some(
+				(cmd: { MoveCall?: { function: string } }) => cmd.MoveCall?.function === 'test',
+			),
+		).toBe(true);
+
+		// The copy resolves to the same output the original would have.
+		expect(await copy.toJSON()).toEqual(await tx.toJSON());
+	});
+
+	it('accepts resolvers for intents that are not present without affecting serialization', async () => {
+		const tx = new Transaction();
+		tx.add(TransactionCommands.SplitCoins(tx.gas, [tx.pure.u64(100)]));
+
+		const copy = Transaction.from(tx, {
+			intentResolvers: { [TEST_INTENT]: resolveTestIntent },
+		});
+
+		// An unused resolver is registered but never runs, so the copy serializes unchanged.
+		expect(await copy.toJSON()).toEqual(await tx.toJSON());
+	});
+
+	it('still copies a transaction using the built-in CoinWithBalance intent without extra options', () => {
+		const tx = new Transaction();
+		tx.setSender('0x2');
+		const coin = tx.coin({ balance: 100n });
+		tx.transferObjects([coin], '0x2');
+
+		const copy = Transaction.from(tx);
+
+		expect(
+			copy.getData().commands.filter((cmd) => cmd.$Intent?.name === 'CoinWithBalance'),
+		).toHaveLength(1);
 	});
 });
 


### PR DESCRIPTION
## Description

Resolves #1090.

Today, `Transaction.from` can only copy a non-built transaction synchronously if the only intent it contains is the built-in `CoinWithBalance` intent. Any other (custom) intent causes `Transaction.from` to throw, forcing callers to `await prepareForSerialization()` before copying — which is async and, for some intents, requires a client.

This PR adds an optional `options` argument to `Transaction.from` with an `intentResolvers` map (intent name → resolver), as proposed in the issue:

```ts
const copy = Transaction.from(tx, {
  intentResolvers: {
    MyCustomIntent: resolveMyCustomIntent,
  },
});
```

The copied transaction carries the unresolved intents over as-is and re-attaches the supplied resolvers, so the intents resolve later when the copy is built or serialized — keeping copying fully synchronous.

Details:

- New exported `TransactionCopyOptions` type (from `@mysten/sui/transactions`).
- Built-in intents (e.g. `CoinWithBalance`) are still handled automatically; caller-supplied resolvers take precedence, so a built-in resolver can be overridden if ever needed.
- All provided resolvers (plus the built-in `CoinWithBalance` resolver) are registered on the copy. Registering a resolver for an intent that isn't present is harmless — `prepareForSerialization` only runs a resolver when its intent actually appears in the transaction.
- Unresolved async thunks still throw, since they can't be carried across a synchronous copy. The error message now also points at the new `intentResolvers` option.
- Updated the error message, `plugins.mdx` docs (new "Copying transactions that use custom intents" section), and added a `minor` changeset.

## Test plan

- Added unit tests in `packages/sui/test/unit/transactions/Transaction.test.ts` covering: throwing when a custom intent has no resolver, successfully copying + resolving a custom intent when `intentResolvers` is provided (no client needed), accepting resolvers for intents not present without affecting serialization, and a regression check that the built-in `CoinWithBalance` path still copies without extra options.
- `pnpm --filter @mysten/sui vitest run test/unit/transactions` — 85 passing.
- `pnpm turbo build --filter=@mysten/sui` (runs `tsc --noEmit`), `pnpm --filter @mysten/sui test:typecheck`, prettier, and oxlint all pass.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)