### PR TITLE
feat(dapp-kit-core): allow account and network overrides on sign methods

### DIFF
--- a/.changeset/dapp-kit-sign-account-network.md
+++ b/.changeset/dapp-kit-sign-account-network.md
@@ -1,0 +1,18 @@
+---
+'@mysten/dapp-kit-core': minor
+---
+
+Allow `signTransaction`, `signAndExecuteTransaction`, and `signPersonalMessage` to take optional
+`account` and `network` overrides.
+
+- `account` (a `UiWalletAccount` belonging to the connected wallet) signs with a specific account
+  without changing the globally selected account via `switchAccount`. Throws
+  `WalletAccountNotFoundError` if the account does not belong to the connected wallet.
+- `network` signs/executes against a specific configured network without changing the active
+  network via `switchNetwork`, which is useful for apps that operate on multiple networks (for
+  example mainnet and testnet) at once. The chain is derived from the network and the transaction is
+  built against that network's client. Throws `ChainNotSupportedError` if the signing account does
+  not support the requested network.
+
+Both default to the currently connected account and active network, so existing call sites are
+unaffected.

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/connect-wallet.ts
@@ -9,8 +9,8 @@ import type { StandardConnectFeature } from '@mysten/wallet-standard';
 import { StandardConnect } from '@mysten/wallet-standard';
 import { getWalletFeature, uiWalletAccountBelongsToUiWallet } from '@wallet-standard/ui';
 import {
-	getOrCreateUiWalletAccountForStandardWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getOrCreateUiWalletAccountForStandardWalletAccount,
-	getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle,
+	getOrCreateUiWalletAccountForStandardWalletAccount,
+	getWalletForHandle,
 } from '@wallet-standard/ui-registry';
 import { WalletAccountNotFoundError, WalletNoAccountsConnectedError } from '../../utils/errors.js';
 import { getChain } from '../../utils/networks.js';

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-and-execute-transaction.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-and-execute-transaction.ts
@@ -11,40 +11,52 @@ import type {
 	SuiSignAndExecuteTransactionFeature,
 	SuiSignAndExecuteTransactionInput,
 } from '@mysten/wallet-standard';
-import { getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
-import { FeatureNotSupportedError, WalletNotConnectedError } from '../../utils/errors.js';
+import { getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
+import type { UiWalletAccount } from '@wallet-standard/ui';
+import { FeatureNotSupportedError } from '../../utils/errors.js';
 import { getChain } from '../../utils/networks.js';
+import type { Networks } from '../../utils/networks.js';
 import { Transaction } from '@mysten/sui/transactions';
-import { tryGetAccountFeature } from '../../utils/wallets.js';
+import { resolveSigningAccount, tryGetAccountFeature } from '../../utils/wallets.js';
 import { bcs } from '@mysten/sui/bcs';
 import { fromBase64 } from '@mysten/utils';
 import {
 	buildTransactionResult,
 	type TransactionResultWithEffects,
 } from '../../utils/transaction-result.js';
+import type { DAppKitCompatibleClient } from '../types.js';
 
-export type SignAndExecuteTransactionArgs = {
+export type SignAndExecuteTransactionArgs<TNetworks extends Networks = Networks> = {
 	transaction: Transaction | string;
+	/** The account to sign with. Defaults to the currently connected account. */
+	account?: UiWalletAccount;
+	/** The network to sign and execute against. Defaults to the dApp kit's current network. */
+	network?: TNetworks[number];
 } & Omit<SuiSignAndExecuteTransactionInput, 'account' | 'chain' | 'transaction'>;
 
 export type SignAndExecuteTransactionResult = TransactionResultWithEffects;
 
-export function signAndExecuteTransactionCreator({ $connection, $currentClient }: DAppKitStores) {
+export function signAndExecuteTransactionCreator<TNetworks extends Networks>(
+	{ $connection, $currentNetwork }: DAppKitStores<TNetworks>,
+	getClient: (network: TNetworks[number]) => DAppKitCompatibleClient,
+) {
 	/**
 	 * Prompts the specified wallet account to sign and execute a transaction.
 	 */
 	return async function signAndExecuteTransaction({
 		transaction,
+		account: accountOverride,
+		network,
 		...standardArgs
-	}: SignAndExecuteTransactionArgs): Promise<SignAndExecuteTransactionResult> {
-		const { account, supportedIntents } = $connection.get();
-		if (!account) {
-			throw new WalletNotConnectedError('No wallet is connected.');
-		}
+	}: SignAndExecuteTransactionArgs<TNetworks>): Promise<SignAndExecuteTransactionResult> {
+		const connection = $connection.get();
+		const account = resolveSigningAccount(connection, accountOverride);
+		const supportedIntents = [...connection.supportedIntents];
 
 		const underlyingAccount = getWalletAccountForUiWalletAccount(account);
-		const suiClient = $currentClient.get();
-		const chain = getChain(suiClient.network);
+		const resolvedNetwork = network ?? $currentNetwork.get();
+		const suiClient = getClient(resolvedNetwork);
+		const chain = getChain(resolvedNetwork);
 
 		const transactionWrapper = {
 			toJSON: async () => {
@@ -91,7 +103,7 @@ export function signAndExecuteTransactionCreator({ $connection, $currentClient }
 			const transactionBlock = Transaction.from(await transactionWrapper.toJSON());
 			const { digest, rawEffects, rawTransaction } =
 				await signAndExecuteTransactionBlockFeature.signAndExecuteTransactionBlock({
-					account,
+					account: underlyingAccount,
 					chain,
 					transactionBlock,
 					options: {

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-personal-message.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-personal-message.ts
@@ -7,28 +7,39 @@ import type {
 	SuiSignPersonalMessageFeature,
 	SuiSignPersonalMessageInput,
 } from '@mysten/wallet-standard';
-import { getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
-import { WalletNotConnectedError } from '../../utils/errors.js';
+import { getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
+import type { UiWalletAccount } from '@wallet-standard/ui';
 import { getChain } from '../../utils/networks.js';
-import { getAccountFeature } from '../../utils/wallets.js';
+import type { Networks } from '../../utils/networks.js';
+import { getAccountFeature, resolveSigningAccount } from '../../utils/wallets.js';
 
-export type SignPersonalMessageArgs = Omit<SuiSignPersonalMessageInput, 'account' | 'chain'>;
+export type SignPersonalMessageArgs<TNetworks extends Networks = Networks> = {
+	/** The account to sign with. Defaults to the currently connected account. */
+	account?: UiWalletAccount;
+	/** The network to sign against. Defaults to the dApp kit's current network. */
+	network?: TNetworks[number];
+} & Omit<SuiSignPersonalMessageInput, 'account' | 'chain'>;
 
-export function signPersonalMessageCreator({ $connection, $currentNetwork }: DAppKitStores) {
+export function signPersonalMessageCreator<TNetworks extends Networks>({
+	$connection,
+	$currentNetwork,
+}: DAppKitStores<TNetworks>) {
 	/**
 	 * Prompts the specified wallet account to sign a personal message.
 	 */
-	return async function signPersonalMessage({ ...standardArgs }: SignPersonalMessageArgs) {
-		const { account } = $connection.get();
-		if (!account) {
-			throw new WalletNotConnectedError('No wallet is connected.');
-		}
+	return async function signPersonalMessage({
+		account: accountOverride,
+		network,
+		...standardArgs
+	}: SignPersonalMessageArgs<TNetworks>) {
+		const connection = $connection.get();
+		const account = resolveSigningAccount(connection, accountOverride);
 
-		const currentNetwork = $currentNetwork.get();
-		const chain = getChain(currentNetwork);
+		const resolvedNetwork = network ?? $currentNetwork.get();
+		const chain = getChain(resolvedNetwork);
 
 		const signPersonalMessageFeature = getAccountFeature({
-			account: account,
+			account,
 			chain,
 			featureName: SuiSignPersonalMessage,
 		}) as SuiSignPersonalMessageFeature[typeof SuiSignPersonalMessage];

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-transaction.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/actions/sign-transaction.ts
@@ -8,29 +8,44 @@ import type {
 	SuiSignTransactionFeature,
 	SuiSignTransactionInput,
 } from '@mysten/wallet-standard';
-import { getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
-import { FeatureNotSupportedError, WalletNotConnectedError } from '../../utils/errors.js';
+import { getWalletAccountForUiWalletAccount } from '@wallet-standard/ui-registry';
+import type { UiWalletAccount } from '@wallet-standard/ui';
+import { FeatureNotSupportedError } from '../../utils/errors.js';
 import { getChain } from '../../utils/networks.js';
+import type { Networks } from '../../utils/networks.js';
 import { Transaction } from '@mysten/sui/transactions';
-import { tryGetAccountFeature } from '../../utils/wallets.js';
+import { resolveSigningAccount, tryGetAccountFeature } from '../../utils/wallets.js';
+import type { DAppKitCompatibleClient } from '../types.js';
 
-export type SignTransactionArgs = {
+export type SignTransactionArgs<TNetworks extends Networks = Networks> = {
 	transaction: Transaction | string;
+	/** The account to sign with. Defaults to the currently connected account. */
+	account?: UiWalletAccount;
+	/** The network to sign against. Defaults to the dApp kit's current network. */
+	network?: TNetworks[number];
 } & Omit<SuiSignTransactionInput, 'account' | 'chain' | 'transaction'>;
 
-export function signTransactionCreator({ $connection, $currentClient }: DAppKitStores) {
+export function signTransactionCreator<TNetworks extends Networks>(
+	{ $connection, $currentNetwork }: DAppKitStores<TNetworks>,
+	getClient: (network: TNetworks[number]) => DAppKitCompatibleClient,
+) {
 	/**
 	 * Prompts the specified wallet account to sign a transaction.
 	 */
-	return async function signTransaction({ transaction, ...standardArgs }: SignTransactionArgs) {
-		const { account, supportedIntents } = $connection.get();
-		if (!account) {
-			throw new WalletNotConnectedError('No wallet is connected.');
-		}
+	return async function signTransaction({
+		transaction,
+		account: accountOverride,
+		network,
+		...standardArgs
+	}: SignTransactionArgs<TNetworks>) {
+		const connection = $connection.get();
+		const account = resolveSigningAccount(connection, accountOverride);
+		const supportedIntents = [...connection.supportedIntents];
 
 		const underlyingAccount = getWalletAccountForUiWalletAccount(account);
-		const suiClient = $currentClient.get();
-		const chain = getChain(suiClient.network);
+		const resolvedNetwork = network ?? $currentNetwork.get();
+		const suiClient = getClient(resolvedNetwork);
+		const chain = getChain(resolvedNetwork);
 
 		const transactionWrapper = {
 			toJSON: async () => {

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
@@ -39,11 +39,11 @@ export type DAppKit<
 > = {
 	networks: TNetworks;
 	getClient: (network?: TNetworks[number]) => Client;
-	signTransaction: (args: SignTransactionArgs) => Promise<SignedTransaction>;
+	signTransaction: (args: SignTransactionArgs<TNetworks>) => Promise<SignedTransaction>;
 	signAndExecuteTransaction: (
-		args: SignAndExecuteTransactionArgs,
+		args: SignAndExecuteTransactionArgs<TNetworks>,
 	) => Promise<SignAndExecuteTransactionResult>;
-	signPersonalMessage: (args: SignPersonalMessageArgs) => Promise<SignedPersonalMessage>;
+	signPersonalMessage: (args: SignPersonalMessageArgs<TNetworks>) => Promise<SignedPersonalMessage>;
 	connectWallet: (args: ConnectWalletArgs) => Promise<{
 		accounts: UiWalletAccount[];
 	}>;
@@ -73,7 +73,10 @@ export function createDAppKit<
 	walletInitializers = [],
 }: CreateDAppKitOptions<TNetworks, Client>): DAppKit<TNetworks, Client> {
 	const networkConfig = createNetworkConfig(networks, createClient);
-	const stores = createStores({ defaultNetwork, getClient: networkConfig.getClient });
+	const stores = createStores<TNetworks, Client>({
+		defaultNetwork,
+		getClient: networkConfig.getClient,
+	});
 
 	function getClient<T extends TNetworks[number]>(network?: TNetworks[number] | T): Client {
 		return network ? networkConfig.getClient(network) : stores.$currentClient.get();
@@ -100,8 +103,8 @@ export function createDAppKit<
 	return {
 		networks,
 		getClient,
-		signTransaction: signTransactionCreator(stores),
-		signAndExecuteTransaction: signAndExecuteTransactionCreator(stores),
+		signTransaction: signTransactionCreator(stores, networkConfig.getClient),
+		signAndExecuteTransaction: signAndExecuteTransactionCreator(stores, networkConfig.getClient),
 		signPersonalMessage: signPersonalMessageCreator(stores),
 		connectWallet: connectWalletCreator(stores, networks, { storage, storageKey }),
 		disconnectWallet: disconnectWalletCreator(stores, { storage, storageKey }),

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/registered-wallets.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/registered-wallets.ts
@@ -5,7 +5,7 @@ import { getWallets, StandardEvents } from '@mysten/wallet-standard';
 import { onMount } from 'nanostores';
 import type { DAppKitStores } from '../store.js';
 
-import { getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getOrCreateUiWalletForStandardWallet } from '@wallet-standard/ui-registry';
+import { getOrCreateUiWalletForStandardWallet } from '@wallet-standard/ui-registry';
 import type { StandardEventsFeature, Wallet, WalletWithFeatures } from '@mysten/wallet-standard';
 
 /**

--- a/packages/dapp-kit/packages/dapp-kit-core/src/utils/wallets.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/utils/wallets.ts
@@ -9,10 +9,15 @@ import {
 	WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
 	WalletStandardError,
 } from '@mysten/wallet-standard';
-import type { UiWalletAccount, UiWalletHandle } from '@wallet-standard/ui';
-import { getWalletAccountFeature } from '@wallet-standard/ui';
-import { getWalletForHandle_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getWalletForHandle } from '@wallet-standard/ui-registry';
-import { ChainNotSupportedError, FeatureNotSupportedError } from './errors.js';
+import type { UiWallet, UiWalletAccount, UiWalletHandle } from '@wallet-standard/ui';
+import { getWalletAccountFeature, uiWalletAccountBelongsToUiWallet } from '@wallet-standard/ui';
+import { getWalletForHandle } from '@wallet-standard/ui-registry';
+import {
+	ChainNotSupportedError,
+	FeatureNotSupportedError,
+	WalletAccountNotFoundError,
+	WalletNotConnectedError,
+} from './errors.js';
 
 export const requiredWalletFeatures = [StandardConnect, StandardEvents] as const;
 
@@ -21,6 +26,30 @@ export const signingFeatures = [SuiSignTransaction, SuiSignTransactionBlock] as 
 export function getWalletUniqueIdentifier(walletHandle: UiWalletHandle) {
 	const underlyingWallet = getWalletForHandle(walletHandle);
 	return underlyingWallet.id ?? underlyingWallet.name;
+}
+
+/**
+ * Resolves the account a signing action should use, defaulting to the currently connected account.
+ *
+ * Enforces that the wallet, account, and (downstream) network all stay compatible: a wallet must be
+ * connected, and any explicitly provided account must belong to that connected wallet. The
+ * account-supports-network check happens later in {@link getAccountFeature} via `account.chains`.
+ */
+export function resolveSigningAccount(
+	connection: { wallet: UiWallet | null; account: UiWalletAccount | null },
+	account?: UiWalletAccount,
+): UiWalletAccount {
+	if (!connection.wallet || !connection.account) {
+		throw new WalletNotConnectedError('No wallet is connected.');
+	}
+
+	if (account && !uiWalletAccountBelongsToUiWallet(account, connection.wallet)) {
+		throw new WalletAccountNotFoundError(
+			`No account with address ${account.address} is connected to ${connection.wallet.name}.`,
+		);
+	}
+
+	return account ?? connection.account;
 }
 
 export function getAccountFeature<TAccount extends UiWalletAccount>({

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-and-execute-transaction.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-and-execute-transaction.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import {
+	GRPC_URLS,
+	TEST_DEFAULT_NETWORK,
+	TEST_NETWORKS,
+	TestWalletInitializeResult,
+} from '../../test-utils.js';
+import { createMockWallets, MockWallet } from '../../mocks/mock-wallet.js';
+import { createDAppKit, DAppKit } from '../../../src/index.js';
+import { createInMemoryStorage } from '../../../src/utils/storage.js';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { getWallets } from '@mysten/wallet-standard';
+import type { ReadonlyWalletAccount } from '@mysten/wallet-standard';
+import { createMockAccount } from '../../mocks/mock-account.js';
+import { ChainNotSupportedError, WalletAccountNotFoundError } from '../../../src/utils/errors.js';
+
+describe('[Integration] signAndExecuteTransaction action', () => {
+	let dAppKit: DAppKit<typeof TEST_NETWORKS>;
+	let wallets: MockWallet[];
+	const cleanups: (() => void)[] = [];
+	const signAndExecuteTransaction = vi.fn();
+
+	function registerWallets(...newWallets: MockWallet[]) {
+		const unregister = getWallets().register(...newWallets);
+		cleanups.push(unregister);
+		return unregister;
+	}
+
+	function setup(accounts: ReadonlyWalletAccount[] = [createMockAccount(), createMockAccount()]) {
+		dAppKit = createDAppKit({
+			networks: TEST_NETWORKS,
+			defaultNetwork: TEST_DEFAULT_NETWORK,
+			createClient(network) {
+				return new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] });
+			},
+			storage: createInMemoryStorage(),
+			storageKey: 'test-storage-key',
+			walletInitializers: [
+				{
+					id: 'Test Wallets',
+					initialize(): TestWalletInitializeResult {
+						wallets = createMockWallets({
+							name: 'Mock Wallet',
+							accounts,
+							addedFeatures: {
+								'sui:signAndExecuteTransaction': { version: '2.0.0', signAndExecuteTransaction },
+							},
+						});
+						return { unregister: registerWallets(...wallets) };
+					},
+				},
+			],
+			slushWalletConfig: null,
+		});
+		return dAppKit.stores.$wallets.get();
+	}
+
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()!();
+		signAndExecuteTransaction.mockReset();
+	});
+
+	test('Passes the overridden account and network through to the wallet feature', async () => {
+		const [uiWallet] = setup();
+		// Reject after capturing the call so we can assert wiring without building real BCS effects:
+		signAndExecuteTransaction.mockRejectedValue(new Error('STOP'));
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		await expect(
+			dAppKit.signAndExecuteTransaction({
+				transaction: 'TX_BYTES',
+				account: uiWallet.accounts[1],
+				network: 'testnet',
+			}),
+		).rejects.toThrow('STOP');
+
+		const [input] = signAndExecuteTransaction.mock.calls[0];
+		expect(input.account.address).toBe(uiWallet.accounts[1].address);
+		expect(input.chain).toBe('sui:testnet');
+		// Neither the globally selected account nor network changed:
+		expect(dAppKit.stores.$connection.get().account?.address).toBe(uiWallet.accounts[0].address);
+		expect(dAppKit.stores.$currentNetwork.get()).toBe(TEST_DEFAULT_NETWORK);
+	});
+
+	test('Throws when the provided account does not belong to the connected wallet', async () => {
+		const [uiWallet] = setup([createMockAccount()]);
+		const otherWallet = createMockWallets({
+			name: 'Other Wallet',
+			accounts: [createMockAccount()],
+		});
+		registerWallets(...otherWallet);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		const otherUiWallet = dAppKit.stores.$wallets.get().find((w) => w.name === 'Other Wallet')!;
+		await expect(
+			dAppKit.signAndExecuteTransaction({
+				transaction: 'TX_BYTES',
+				account: otherUiWallet.accounts[0],
+			}),
+		).rejects.toBeInstanceOf(WalletAccountNotFoundError);
+	});
+
+	test('Throws when the connected account does not support the requested network', async () => {
+		const [uiWallet] = setup([createMockAccount({ chains: ['sui:mainnet'] })]);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		await expect(
+			dAppKit.signAndExecuteTransaction({ transaction: 'TX_BYTES', network: 'testnet' }),
+		).rejects.toBeInstanceOf(ChainNotSupportedError);
+	});
+});

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-personal-message.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-personal-message.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import {
+	GRPC_URLS,
+	TEST_DEFAULT_NETWORK,
+	TEST_NETWORKS,
+	TestWalletInitializeResult,
+} from '../../test-utils.js';
+import { createMockWallets, MockWallet } from '../../mocks/mock-wallet.js';
+import { createDAppKit, DAppKit } from '../../../src/index.js';
+import { createInMemoryStorage } from '../../../src/utils/storage.js';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { getWallets } from '@mysten/wallet-standard';
+import type { ReadonlyWalletAccount } from '@mysten/wallet-standard';
+import { createMockAccount } from '../../mocks/mock-account.js';
+import { ChainNotSupportedError, WalletAccountNotFoundError } from '../../../src/utils/errors.js';
+
+const ACCOUNT_FEATURES = [
+	'sui:signTransaction',
+	'sui:signAndExecuteTransaction',
+	'sui:signPersonalMessage',
+] as const;
+
+describe('[Integration] signPersonalMessage action', () => {
+	let dAppKit: DAppKit<typeof TEST_NETWORKS>;
+	let wallets: MockWallet[];
+	const cleanups: (() => void)[] = [];
+	const signPersonalMessage = vi.fn();
+
+	function registerWallets(...newWallets: MockWallet[]) {
+		const unregister = getWallets().register(...newWallets);
+		cleanups.push(unregister);
+		return unregister;
+	}
+
+	function account(overrides = {}) {
+		return createMockAccount({ features: ACCOUNT_FEATURES, ...overrides });
+	}
+
+	function setup(accounts: ReadonlyWalletAccount[] = [account(), account()]) {
+		dAppKit = createDAppKit({
+			networks: TEST_NETWORKS,
+			defaultNetwork: TEST_DEFAULT_NETWORK,
+			createClient(network) {
+				return new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] });
+			},
+			storage: createInMemoryStorage(),
+			storageKey: 'test-storage-key',
+			walletInitializers: [
+				{
+					id: 'Test Wallets',
+					initialize(): TestWalletInitializeResult {
+						wallets = createMockWallets({
+							name: 'Mock Wallet',
+							accounts,
+							addedFeatures: {
+								'sui:signPersonalMessage': { version: '1.0.0', signPersonalMessage },
+							},
+						});
+						return { unregister: registerWallets(...wallets) };
+					},
+				},
+			],
+			slushWalletConfig: null,
+		});
+		return dAppKit.stores.$wallets.get();
+	}
+
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()!();
+		signPersonalMessage.mockReset();
+	});
+
+	test('Signs with the connected account on the current network by default', async () => {
+		const [uiWallet] = setup();
+		signPersonalMessage.mockResolvedValue({ bytes: 'MSG', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+		const message = new Uint8Array([1, 2, 3]);
+		await dAppKit.signPersonalMessage({ message });
+
+		expect(signPersonalMessage).toHaveBeenCalledTimes(1);
+		const [input] = signPersonalMessage.mock.calls[0];
+		expect(input.account.address).toBe(uiWallet.accounts[0].address);
+		expect(input.chain).toBe(`sui:${TEST_DEFAULT_NETWORK}`);
+		expect(input.message).toBe(message);
+	});
+
+	test('Signs with an explicitly provided account belonging to the connected wallet', async () => {
+		const [uiWallet] = setup();
+		signPersonalMessage.mockResolvedValue({ bytes: 'MSG', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+		await dAppKit.signPersonalMessage({
+			message: new Uint8Array([1, 2, 3]),
+			account: uiWallet.accounts[1],
+		});
+
+		const [input] = signPersonalMessage.mock.calls[0];
+		expect(input.account.address).toBe(uiWallet.accounts[1].address);
+		// The globally selected account is unchanged:
+		expect(dAppKit.stores.$connection.get().account?.address).toBe(uiWallet.accounts[0].address);
+	});
+
+	test('Signs against an explicitly provided network without changing the active network', async () => {
+		const [uiWallet] = setup();
+		signPersonalMessage.mockResolvedValue({ bytes: 'MSG', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+		await dAppKit.signPersonalMessage({ message: new Uint8Array([1, 2, 3]), network: 'testnet' });
+
+		const [input] = signPersonalMessage.mock.calls[0];
+		expect(input.chain).toBe('sui:testnet');
+		// The globally selected network is unchanged:
+		expect(dAppKit.stores.$currentNetwork.get()).toBe(TEST_DEFAULT_NETWORK);
+	});
+
+	test('Throws when the provided account does not belong to the connected wallet', async () => {
+		const [uiWallet] = setup([account()]);
+		const otherWallet = createMockWallets({ name: 'Other Wallet', accounts: [account()] });
+		registerWallets(...otherWallet);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		const otherUiWallet = dAppKit.stores.$wallets.get().find((w) => w.name === 'Other Wallet')!;
+		await expect(
+			dAppKit.signPersonalMessage({
+				message: new Uint8Array([1, 2, 3]),
+				account: otherUiWallet.accounts[0],
+			}),
+		).rejects.toBeInstanceOf(WalletAccountNotFoundError);
+	});
+
+	test('Throws when the connected account does not support the requested network', async () => {
+		const [uiWallet] = setup([account({ chains: ['sui:mainnet'] })]);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		await expect(
+			dAppKit.signPersonalMessage({ message: new Uint8Array([1, 2, 3]), network: 'testnet' }),
+		).rejects.toBeInstanceOf(ChainNotSupportedError);
+	});
+});

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-transaction.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/actions/sign-transaction.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test, afterEach } from 'vitest';
+import {
+	GRPC_URLS,
+	TEST_DEFAULT_NETWORK,
+	TEST_NETWORKS,
+	TestWalletInitializeResult,
+} from '../../test-utils.js';
+import { createMockWallets, MockWallet } from '../../mocks/mock-wallet.js';
+import { createDAppKit, DAppKit } from '../../../src/index.js';
+import { createInMemoryStorage } from '../../../src/utils/storage.js';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { getWallets } from '@mysten/wallet-standard';
+import type { ReadonlyWalletAccount } from '@mysten/wallet-standard';
+import { createMockAccount } from '../../mocks/mock-account.js';
+import { ChainNotSupportedError, WalletAccountNotFoundError } from '../../../src/utils/errors.js';
+
+describe('[Integration] signTransaction action', () => {
+	let dAppKit: DAppKit<typeof TEST_NETWORKS>;
+	let wallets: MockWallet[];
+	const cleanups: (() => void)[] = [];
+
+	function registerWallets(...newWallets: MockWallet[]) {
+		const unregister = getWallets().register(...newWallets);
+		cleanups.push(unregister);
+		return unregister;
+	}
+
+	function setup(accounts: ReadonlyWalletAccount[] = [createMockAccount(), createMockAccount()]) {
+		dAppKit = createDAppKit({
+			networks: TEST_NETWORKS,
+			defaultNetwork: TEST_DEFAULT_NETWORK,
+			createClient(network) {
+				return new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] });
+			},
+			storage: createInMemoryStorage(),
+			storageKey: 'test-storage-key',
+			walletInitializers: [
+				{
+					id: 'Test Wallets',
+					initialize(): TestWalletInitializeResult {
+						wallets = createMockWallets({ name: 'Mock Wallet', accounts });
+						return { unregister: registerWallets(...wallets) };
+					},
+				},
+			],
+			slushWalletConfig: null,
+		});
+		return dAppKit.stores.$wallets.get();
+	}
+
+	afterEach(() => {
+		while (cleanups.length) cleanups.pop()!();
+	});
+
+	test('Signs with the connected account on the current network by default', async () => {
+		const [uiWallet] = setup();
+		wallets[0].mocks.signTransaction.mockResolvedValue({ bytes: 'AAA=', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+		await dAppKit.signTransaction({ transaction: 'TX_BYTES' });
+
+		expect(wallets[0].mocks.signTransaction).toHaveBeenCalledTimes(1);
+		const [input] = wallets[0].mocks.signTransaction.mock.calls[0];
+		expect(input.account.address).toBe(uiWallet.accounts[0].address);
+		expect(input.chain).toBe(`sui:${TEST_DEFAULT_NETWORK}`);
+	});
+
+	test('Signs with an explicitly provided account belonging to the connected wallet', async () => {
+		const [uiWallet] = setup();
+		wallets[0].mocks.signTransaction.mockResolvedValue({ bytes: 'AAA=', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		// Connected to the first account, but sign with the second without switching:
+		await dAppKit.signTransaction({ transaction: 'TX_BYTES', account: uiWallet.accounts[1] });
+
+		const [input] = wallets[0].mocks.signTransaction.mock.calls[0];
+		expect(input.account.address).toBe(uiWallet.accounts[1].address);
+		// The globally selected account is unchanged:
+		expect(dAppKit.stores.$connection.get().account?.address).toBe(uiWallet.accounts[0].address);
+	});
+
+	test('Signs against an explicitly provided network without changing the active network', async () => {
+		const [uiWallet] = setup();
+		wallets[0].mocks.signTransaction.mockResolvedValue({ bytes: 'AAA=', signature: 'SIG' });
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+		await dAppKit.signTransaction({ transaction: 'TX_BYTES', network: 'testnet' });
+
+		const [input] = wallets[0].mocks.signTransaction.mock.calls[0];
+		expect(input.chain).toBe('sui:testnet');
+		// The globally selected network is unchanged:
+		expect(dAppKit.stores.$currentNetwork.get()).toBe(TEST_DEFAULT_NETWORK);
+	});
+
+	test('Throws when the provided account does not belong to the connected wallet', async () => {
+		const [uiWallet] = setup([createMockAccount()]);
+		const otherWallet = createMockWallets({
+			name: 'Other Wallet',
+			accounts: [createMockAccount()],
+		});
+		registerWallets(...otherWallet);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		const otherUiWallet = dAppKit.stores.$wallets.get().find((w) => w.name === 'Other Wallet')!;
+		await expect(
+			dAppKit.signTransaction({ transaction: 'TX_BYTES', account: otherUiWallet.accounts[0] }),
+		).rejects.toBeInstanceOf(WalletAccountNotFoundError);
+	});
+
+	test('Throws when the connected account does not support the requested network', async () => {
+		const [uiWallet] = setup([createMockAccount({ chains: ['sui:mainnet'] })]);
+
+		await dAppKit.connectWallet({ wallet: uiWallet });
+
+		await expect(
+			dAppKit.signTransaction({ transaction: 'TX_BYTES', network: 'testnet' }),
+		).rejects.toBeInstanceOf(ChainNotSupportedError);
+	});
+});

--- a/packages/dapp-kit/packages/dapp-kit-core/test/mocks/mock-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/mocks/mock-wallet.ts
@@ -20,7 +20,7 @@ export type MockWalletOptions = {
 	name: string;
 	accounts?: ReadonlyWalletAccount[];
 	skippedFeatures?: IdentifierArray;
-	addedFeatures?: IdentifierArray;
+	addedFeatures?: IdentifierRecord<any>;
 	chains?: IdentifierArray;
 };
 

--- a/packages/dapp-kit/packages/dapp-kit-core/test/test-utils.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/test-utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getOrCreateUiWalletForStandardWallet_DO_NOT_USE_OR_YOU_WILL_BE_FIRED as getOrCreateUiWalletForStandardWallet } from '@wallet-standard/ui-registry';
+import { getOrCreateUiWalletForStandardWallet } from '@wallet-standard/ui-registry';
 
 import type { DAppKitStores } from '../src/core/store.js';
 import type { UiWallet } from '@wallet-standard/ui';

--- a/packages/docs/content/dapp-kit/actions/sign-and-execute-transaction.mdx
+++ b/packages/docs/content/dapp-kit/actions/sign-and-execute-transaction.mdx
@@ -36,6 +36,15 @@ console.log('Transaction digest:', result.Transaction.digest);
 
 - **`transaction`:** `Transaction | string`: The transaction to sign and execute. Can be either a
   Transaction instance or base64-encoded bcs bytes for the transaction.
+- **`account`** (optional): `UiWalletAccount`: The account to sign with. Defaults to the currently
+  connected account. Must belong to the connected wallet, otherwise a `WalletAccountNotFoundError`
+  is thrown. Lets you sign with a specific account without changing the selected account via
+  `switchAccount`.
+- **`network`** (optional): The network to sign and execute against (a configured network identifier
+  such as `'mainnet'`). Defaults to the active network. The chain and the client used to build the
+  transaction are derived from it, so you can target a network without changing the active network
+  via `switchNetwork`. Throws a `ChainNotSupportedError` if the signing account does not support the
+  network.
 - **`signal`** (optional): `AbortSignal`: An abort signal to cancel the transaction request.
 
 ## Return value

--- a/packages/docs/content/dapp-kit/actions/sign-personal-message.mdx
+++ b/packages/docs/content/dapp-kit/actions/sign-personal-message.mdx
@@ -31,6 +31,15 @@ console.log('Signature:', result.signature);
 ## Parameters
 
 - **`message`:** `Uint8Array` - The message to sign as a byte array
+- **`account`** (optional) - `UiWalletAccount` - The account to sign with. Defaults to the currently
+  connected account. Must belong to the connected wallet, otherwise a `WalletAccountNotFoundError`
+  is thrown. Lets you sign with a specific account without changing the selected account via
+  `switchAccount`.
+- **`network`** (optional) - The network to sign against (a configured network identifier such as
+  `'mainnet'`). Defaults to the active network. The signing chain is derived from it, so you can
+  sign against a network without changing the active network via `switchNetwork`. Throws a
+  `ChainNotSupportedError` if the signing account does not support the network. This matters for
+  network-bound signatures such as zkLogin.
 
 ## Return value
 

--- a/packages/docs/content/dapp-kit/actions/sign-transaction.mdx
+++ b/packages/docs/content/dapp-kit/actions/sign-transaction.mdx
@@ -33,6 +33,15 @@ const { bytes, signature } = await dAppKit.signTransaction({
 
 - **`transaction`:** `Transaction | string` - The transaction to sign. Can be either a Transaction
   instance or base64-encoded bcs bytes for the transaction.
+- **`account`** (optional) - `UiWalletAccount` - The account to sign with. Defaults to the currently
+  connected account. Must belong to the connected wallet, otherwise a `WalletAccountNotFoundError`
+  is thrown. Lets you sign with a specific account without changing the selected account via
+  `switchAccount`.
+- **`network`** (optional) - The network to sign against (a configured network identifier such as
+  `'mainnet'`). Defaults to the active network. The chain and the client used to build the
+  transaction are derived from it, so you can sign against a network without changing the active
+  network via `switchNetwork`. Throws a `ChainNotSupportedError` if the signing account does not
+  support the network.
 - **`signal`** (optional) - `AbortSignal` - An abort signal to cancel the signing request.
 
 ## Return value

--- a/packages/docs/content/sui/migrations/sui-2.0/dapp-kit.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/dapp-kit.mdx
@@ -202,7 +202,11 @@ The built-in mutation hooks have been removed. Use TanStack Query's `useMutation
 
 In the old dApp kit, you could optionally pass a `chain` parameter (for example, `sui:mainnet`) to
 methods like `signTransaction` and `signAndExecuteTransaction`. In the new dApp kit, use the
-`network` parameter instead - the chain is automatically derived from the network.
+`network` parameter instead - the chain is automatically derived from the network. It is optional
+and defaults to the active network, so you only need it when targeting a network other than the
+active one (for example, an app that operates on both mainnet and testnet). Likewise, the
+per-account `account` override is preserved as an optional parameter that defaults to the connected
+account.
 
 ```diff
 - const { mutateAsync: signAndExecute } = useSignAndExecuteTransaction();


### PR DESCRIPTION
## Description

Restores the ability — present in legacy dApp Kit but dropped in the dapp-kit-core rewrite — to target a specific **account** and **network** on a per-call basis for the signing methods, without mutating the global connection or active-network state.

`signTransaction`, `signAndExecuteTransaction`, and `signPersonalMessage` now accept two optional parameters:

- **`account`** (`UiWalletAccount`) — sign with a specific account belonging to the connected wallet, without changing the selected account via `switchAccount`. Defaults to the connected account.
- **`network`** (a configured network identifier, e.g. `'mainnet'`) — sign/execute against a specific network without changing the active network via `switchNetwork`. The chain and the client used to build the transaction are derived from it. Defaults to the active network.

Both default to current behavior, so existing call sites are unaffected (additive, `minor`).

### Why

The single-active-network model forced multi-network apps (e.g. ones managing objects on both mainnet and testnet) to call `switchNetwork()` around every sign — global, reactive, and able to drop the wallet connection. This restores the per-call escape hatch the legacy kit had, and makes the 2.0 migration doc's already-documented `network` parameter actually work.

### Compatibility is preserved, not weakened

The wallet/network sync invariant is enforced without touching any global reactive state:

- `resolveSigningAccount` validates the override account belongs to the connected wallet → `WalletAccountNotFoundError`.
- The existing per-account chain check in `getAccountFeature` (`account.chains`) validates the account supports the requested network → `ChainNotSupportedError`.

No mutation of `$currentNetwork`/`$connection`, so none of the re-render churn or disconnection of the `switchNetwork`-per-call workaround.

### Also included

De-aliases the `_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` wallet-standard registry imports within dapp-kit-core, and corrects the `MockWalletOptions.addedFeatures` test type (was `IdentifierArray`, the class uses it as a record). Updates the three action doc pages and the 2.0 migration doc.

## Test plan

- Added integration tests for all three actions covering: default account/network, `account` override, `network` override (asserting global account/network are unchanged), foreign-account rejection (`WalletAccountNotFoundError`), and unsupported-network rejection (`ChainNotSupportedError`).
- `pnpm --filter @mysten/dapp-kit-core test` → 34 passed (9 files); `typecheck`, `test:typecheck`, oxlint, and prettier all clean.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)