### PR TITLE
fix(dapp-kit-core): report isReconnecting during initial session restore

### DIFF
--- a/.changeset/dapp-kit-reconnecting-during-restore.md
+++ b/.changeset/dapp-kit-reconnecting-during-restore.md
@@ -12,9 +12,13 @@ identical to a logged-out user (`account: null`, `isConnecting: false`, `isRecon
 
 Auto-connect now eagerly enters the `reconnecting` state on mount whenever a persisted session
 exists — independent of wallet-registration timing, so the window is covered even before the saved
-wallet registers (e.g. async-registered zkLogin wallets) — and settles back to `disconnected` if
-the restore can't complete. The `reconnecting` state also now reports `isReconnecting: true` while
-the target wallet/account is still resolving, instead of being suppressed to `disconnected`.
+wallet registers (default wallets such as Slush register asynchronously). The restore window is
+bounded by a real lifecycle signal — it stays `reconnecting` until every configured wallet
+initializer has finished registering, then settles to `disconnected` if the saved session still
+hasn't been restored — rather than a wall-clock timeout, so a slow-but-valid wallet is never cut off
+and a genuinely-absent wallet never hangs. The `reconnecting` state also now reports
+`isReconnecting: true` while the target wallet/account is still resolving, instead of being
+suppressed to `disconnected`.
 
 Consumers can rely on `isReconnecting` to distinguish restoring from logged-out, e.g.
 `if (!isReconnecting && !account) redirect()`.

--- a/.changeset/dapp-kit-reconnecting-during-restore.md
+++ b/.changeset/dapp-kit-reconnecting-during-restore.md
@@ -12,13 +12,16 @@ identical to a logged-out user (`account: null`, `isConnecting: false`, `isRecon
 
 Auto-connect now eagerly enters the `reconnecting` state on mount whenever a persisted session
 exists — independent of wallet-registration timing, so the window is covered even before the saved
-wallet registers (default wallets such as Slush register asynchronously). The restore window is
-bounded by a real lifecycle signal — it stays `reconnecting` until every configured wallet
-initializer has finished registering, then settles to `disconnected` if the saved session still
-hasn't been restored — rather than a wall-clock timeout, so a slow-but-valid wallet is never cut off
-and a genuinely-absent wallet never hangs. The `reconnecting` state also now reports
+wallet registers (default wallets such as Slush register asynchronously). It stays `reconnecting`
+until both every configured wallet initializer has settled and a short grace period has elapsed (to
+absorb late-registering wallets such as browser extensions, which have no deterministic "registered"
+signal), then settles to `disconnected` if the saved session still hasn't restored — while never
+interrupting an in-flight restore, so a slow-but-valid wallet always wins, and continuing to listen
+so a very-late wallet can still restore. The `reconnecting` state also now reports
 `isReconnecting: true` while the target wallet/account is still resolving, instead of being
 suppressed to `disconnected`.
+
+Adds an `autoConnectTimeout` option (default `2000` ms) to tune that grace period.
 
 Consumers can rely on `isReconnecting` to distinguish restoring from logged-out, e.g.
 `if (!isReconnecting && !account) redirect()`.

--- a/.changeset/dapp-kit-reconnecting-during-restore.md
+++ b/.changeset/dapp-kit-reconnecting-during-restore.md
@@ -21,7 +21,7 @@ so a very-late wallet can still restore. The `reconnecting` state also now repor
 `isReconnecting: true` while the target wallet/account is still resolving, instead of being
 suppressed to `disconnected`.
 
-Adds an `autoConnectTimeout` option (default `2000` ms) to tune that grace period.
+Adds an `autoConnectTimeout` option (default `5000` ms) to tune that grace period.
 
 Consumers can rely on `isReconnecting` to distinguish restoring from logged-out, e.g.
 `if (!isReconnecting && !account) redirect()`.

--- a/.changeset/dapp-kit-reconnecting-during-restore.md
+++ b/.changeset/dapp-kit-reconnecting-during-restore.md
@@ -1,0 +1,20 @@
+---
+'@mysten/dapp-kit-core': minor
+---
+
+Report `isReconnecting` during the initial auto-connect session restore.
+
+Previously, restoring a persisted session on page load jumped the connection straight from
+`disconnected` to `connected`, so for the entire async restore window the connection looked
+identical to a logged-out user (`account: null`, `isConnecting: false`, `isReconnecting: false`,
+`status: "disconnected"`). Consumers had no way to tell "restoring a saved session" apart from
+"logged out", which caused auth gates to incorrectly redirect logged-in users on hard refresh.
+
+Auto-connect now eagerly enters the `reconnecting` state on mount whenever a persisted session
+exists — independent of wallet-registration timing, so the window is covered even before the saved
+wallet registers (e.g. async-registered zkLogin wallets) — and settles back to `disconnected` if
+the restore can't complete. The `reconnecting` state also now reports `isReconnecting: true` while
+the target wallet/account is still resolving, instead of being suppressed to `disconnected`.
+
+Consumers can rely on `isReconnecting` to distinguish restoring from logged-out, e.g.
+`if (!isReconnecting && !account) redirect()`.

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
@@ -87,11 +87,7 @@ export function createDAppKit<
 	syncRegisteredWallets(stores);
 	manageWalletConnection(stores);
 
-	if (autoConnect) {
-		autoConnectWallet({ networks, stores, storageKey, storage });
-	}
-
-	registerAdditionalWallets(
+	const walletsRegistered = registerAdditionalWallets(
 		[
 			...walletInitializers,
 			...(enableBurnerWallet ? [unsafeBurnerWalletInitializer()] : []),
@@ -99,6 +95,10 @@ export function createDAppKit<
 		],
 		{ networks, getClient },
 	);
+
+	if (autoConnect) {
+		autoConnectWallet({ networks, stores, storageKey, storage, walletsRegistered });
+	}
 
 	return {
 		networks,

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
@@ -71,7 +71,7 @@ export function createDAppKit<
 	storage = getDefaultStorage(),
 	storageKey = DEFAULT_STORAGE_KEY,
 	walletInitializers = [],
-	autoConnectTimeout = 2000,
+	autoConnectTimeout = 5000,
 }: CreateDAppKitOptions<TNetworks, Client>): DAppKit<TNetworks, Client> {
 	const networkConfig = createNetworkConfig(networks, createClient);
 	const stores = createStores<TNetworks, Client>({

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/index.ts
@@ -71,6 +71,7 @@ export function createDAppKit<
 	storage = getDefaultStorage(),
 	storageKey = DEFAULT_STORAGE_KEY,
 	walletInitializers = [],
+	autoConnectTimeout = 2000,
 }: CreateDAppKitOptions<TNetworks, Client>): DAppKit<TNetworks, Client> {
 	const networkConfig = createNetworkConfig(networks, createClient);
 	const stores = createStores<TNetworks, Client>({
@@ -97,7 +98,14 @@ export function createDAppKit<
 	);
 
 	if (autoConnect) {
-		autoConnectWallet({ networks, stores, storageKey, storage, walletsRegistered });
+		autoConnectWallet({
+			networks,
+			stores,
+			storageKey,
+			storage,
+			walletsRegistered,
+			timeout: autoConnectTimeout,
+		});
 	}
 
 	return {

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -14,7 +14,19 @@ import {
 import type { Networks } from '../../utils/networks.js';
 
 /**
+ * How long to keep advertising the `reconnecting` state while waiting for a saved
+ * wallet to register before giving up. This bounds the restore window so consumers
+ * don't wait forever when the saved wallet was uninstalled or never registers.
+ */
+export const AUTO_CONNECT_RESTORE_TIMEOUT = 5000;
+
+/**
  * Attempts to connect to a previously authorized wallet account on mount and when new wallets are registered.
+ *
+ * To let consumers distinguish "restoring a saved session" from "logged out" during
+ * the async restore window, this eagerly moves the connection into the `reconnecting`
+ * state on mount whenever a persisted session exists — even before the saved wallet
+ * has registered — and settles back to `disconnected` if the restore can't complete.
  */
 export function autoConnectWallet({
 	networks,
@@ -28,24 +40,47 @@ export function autoConnectWallet({
 	storageKey: string;
 }) {
 	onMount($compatibleWallets, () => {
-		return $compatibleWallets.subscribe(
-			async (wallets, oldWallets: readonly UiWallet[] | undefined) => {
-				// subscribe on a computed store may fire with undefined due to nanostores
-				// reading the underlying atom's uninitialized value instead of computing it.
-				if (!wallets) return;
-				if (oldWallets && oldWallets.length > wallets.length) return;
+		let done = false;
+		let unsubscribe: (() => void) | undefined;
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-				const connection = $baseConnection.get();
-				if (connection.status !== 'disconnected') return;
+		// Terminal: we've either restored the session or determined there's nothing
+		// to restore. Stop listening for further wallet registrations.
+		const stop = () => {
+			done = true;
+			if (timeoutId !== undefined) clearTimeout(timeoutId);
+			unsubscribe?.();
+		};
 
-				const savedWalletAccount = await task(() => {
-					return getSavedWalletAccount({
-						networks,
-						storage,
-						storageKey,
-						wallets,
-					});
+		// Bounded fallback: stop advertising `reconnecting` so consumers aren't stuck
+		// if the saved wallet never registers, but keep listening so a slow-registering
+		// wallet (e.g. an async-registered zkLogin wallet) can still restore later.
+		const stopReconnecting = () => {
+			if ($baseConnection.get().status === 'reconnecting') {
+				$baseConnection.set({ status: 'disconnected', currentAccount: null });
+			}
+		};
+
+		const tryRestore = (wallets: readonly UiWallet[]) =>
+			task(async () => {
+				if (done) return;
+
+				const { status } = $baseConnection.get();
+				// A manual connect takes precedence; only auto-connect while idle or
+				// while we're still mid-restore.
+				if (status !== 'disconnected' && status !== 'reconnecting') {
+					stop();
+					return;
+				}
+
+				const savedWalletAccount = await getSavedWalletAccount({
+					networks,
+					storage,
+					storageKey,
+					wallets,
 				});
+
+				if (done) return;
 
 				if (savedWalletAccount) {
 					$baseConnection.set({
@@ -53,9 +88,47 @@ export function autoConnectWallet({
 						currentAccount: savedWalletAccount.account,
 						supportedIntents: savedWalletAccount.supportedIntents,
 					});
+					stop();
 				}
+			});
+
+		unsubscribe = $compatibleWallets.subscribe(
+			(wallets, oldWallets: readonly UiWallet[] | undefined) => {
+				// subscribe on a computed store may fire with undefined due to nanostores
+				// reading the underlying atom's uninitialized value instead of computing it.
+				if (!wallets) return;
+				if (oldWallets && oldWallets.length > wallets.length) return;
+				void tryRestore(wallets);
 			},
 		);
+
+		// Eagerly enter `reconnecting` when there's a persisted session to restore,
+		// independent of wallet-registration timing, so the restore window is
+		// observable from mount. If there's nothing saved, settle immediately.
+		void task(async () => {
+			const hasSavedSession = Boolean(await storage.getItem(storageKey));
+			if (done) return;
+
+			if (!hasSavedSession) {
+				stop();
+				return;
+			}
+
+			if ($baseConnection.get().status === 'disconnected') {
+				$baseConnection.set({
+					status: 'reconnecting',
+					currentAccount: null,
+					supportedIntents: [],
+				});
+			}
+
+			timeoutId = setTimeout(stopReconnecting, AUTO_CONNECT_RESTORE_TIMEOUT);
+		});
+
+		return () => {
+			if (timeoutId !== undefined) clearTimeout(timeoutId);
+			unsubscribe?.();
+		};
 	});
 }
 

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -14,51 +14,42 @@ import {
 import type { Networks } from '../../utils/networks.js';
 
 /**
- * How long to keep advertising the `reconnecting` state while waiting for a saved
- * wallet to register before giving up. This bounds the restore window so consumers
- * don't wait forever when the saved wallet was uninstalled or never registers.
- */
-export const AUTO_CONNECT_RESTORE_TIMEOUT = 5000;
-
-/**
  * Attempts to connect to a previously authorized wallet account on mount and when new wallets are registered.
  *
  * To let consumers distinguish "restoring a saved session" from "logged out" during
  * the async restore window, this eagerly moves the connection into the `reconnecting`
  * state on mount whenever a persisted session exists — even before the saved wallet
- * has registered — and settles back to `disconnected` if the restore can't complete.
+ * has registered (default wallets like Slush register asynchronously) — and settles
+ * back to `disconnected` once every configured wallet has finished registering without
+ * the saved session being restored.
+ *
+ * The restore window is bounded by a real lifecycle signal (`walletsRegistered`
+ * resolves once all wallet initializers settle) rather than a wall-clock timeout, so a
+ * slow-but-valid wallet is never cut off and a genuinely-absent wallet never hangs.
  */
 export function autoConnectWallet({
 	networks,
 	stores: { $baseConnection, $compatibleWallets },
 	storage,
 	storageKey,
+	walletsRegistered,
 }: {
 	networks: Networks;
 	stores: DAppKitStores;
 	storage: StateStorage;
 	storageKey: string;
+	/** Resolves once all configured wallet initializers have finished registering. */
+	walletsRegistered: Promise<unknown>;
 }) {
 	onMount($compatibleWallets, () => {
 		let done = false;
 		let unsubscribe: (() => void) | undefined;
-		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
 		// Terminal: we've either restored the session or determined there's nothing
 		// to restore. Stop listening for further wallet registrations.
 		const stop = () => {
 			done = true;
-			if (timeoutId !== undefined) clearTimeout(timeoutId);
 			unsubscribe?.();
-		};
-
-		// Bounded fallback: stop advertising `reconnecting` so consumers aren't stuck
-		// if the saved wallet never registers, but keep listening so a slow-registering
-		// wallet (e.g. an async-registered zkLogin wallet) can still restore later.
-		const stopReconnecting = () => {
-			if ($baseConnection.get().status === 'reconnecting') {
-				$baseConnection.set({ status: 'disconnected', currentAccount: null });
-			}
 		};
 
 		const tryRestore = (wallets: readonly UiWallet[]) =>
@@ -122,11 +113,23 @@ export function autoConnectWallet({
 				});
 			}
 
-			timeoutId = setTimeout(stopReconnecting, AUTO_CONNECT_RESTORE_TIMEOUT);
+			// Wait for every configured wallet to finish registering, then make one
+			// final restore attempt against the complete wallet set. If the saved
+			// session still hasn't restored, it's genuinely unavailable — settle to
+			// `disconnected` so consumers aren't stuck reconnecting.
+			await walletsRegistered.catch(() => {});
+			if (done) return;
+
+			await tryRestore($compatibleWallets.get() ?? []);
+			if (done) return;
+
+			if ($baseConnection.get().status === 'reconnecting') {
+				$baseConnection.set({ status: 'disconnected', currentAccount: null });
+			}
+			stop();
 		});
 
 		return () => {
-			if (timeoutId !== undefined) clearTimeout(timeoutId);
 			unsubscribe?.();
 		};
 	});

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -120,9 +120,9 @@ export function autoConnectWallet({
 			}
 		});
 
-		return () => {
-			unsubscribe?.();
-		};
+		// `stop()` (not just `unsubscribe()`) so an in-flight eager task or restore can't
+		// mutate the shared store after teardown (e.g. a React StrictMode double-mount).
+		return stop;
 	});
 }
 

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -16,22 +16,10 @@ import type { Networks } from '../../utils/networks.js';
 /**
  * Attempts to connect to a previously authorized wallet account on mount and when new wallets are registered.
  *
- * To let consumers distinguish "restoring a saved session" from "logged out" during
- * the async restore window, this eagerly moves the connection into the `reconnecting`
- * state on mount whenever a persisted session exists — even before the saved wallet
- * has registered (default wallets like Slush register asynchronously).
- *
- * The restore window is bounded so a genuinely-absent wallet doesn't hang forever, but
- * the bound is chosen to avoid a brittle cutoff:
- * - We stay `reconnecting` until BOTH every configured wallet initializer has settled
- *   (`walletsRegistered`) AND a short grace period (`timeout`) has elapsed. The grace
- *   period absorbs wallets that register slightly after page load (e.g. browser
- *   extensions), which have no deterministic "registered" signal.
- * - An in-flight restore is never interrupted: once the bound is reached we make a final
- *   restore attempt and await it (which awaits the wallet's own connect/hydration), so a
- *   slow-but-valid wallet still wins the race.
- * - If the session still hasn't restored, we settle to `disconnected` but keep listening,
- *   so a very-late registration can still restore it.
+ * Enters `reconnecting` on mount when a persisted session exists, so consumers can tell a
+ * restore apart from a logged-out state while the saved wallet is still resolving. Settles
+ * to `disconnected` once every initializer has registered and `timeout` has elapsed without
+ * a restore, but never interrupts an in-flight restore and keeps listening afterwards.
  */
 export function autoConnectWallet({
 	networks,
@@ -54,8 +42,6 @@ export function autoConnectWallet({
 		let done = false;
 		let unsubscribe: (() => void) | undefined;
 
-		// Terminal: we've restored the session (or a manual connect took over). Stop
-		// listening for further wallet registrations.
 		const stop = () => {
 			done = true;
 			unsubscribe?.();
@@ -65,9 +51,8 @@ export function autoConnectWallet({
 			task(async () => {
 				if (done) return;
 
+				// A manual connect takes precedence over auto-connect.
 				const { status } = $baseConnection.get();
-				// A manual connect takes precedence; only auto-connect while idle or
-				// while we're still mid-restore.
 				if (status !== 'disconnected' && status !== 'reconnecting') {
 					stop();
 					return;
@@ -102,9 +87,6 @@ export function autoConnectWallet({
 			},
 		);
 
-		// Eagerly enter `reconnecting` when there's a persisted session to restore,
-		// independent of wallet-registration timing, so the restore window is
-		// observable from mount. If there's nothing saved, settle immediately.
 		void task(async () => {
 			const hasSavedSession = Boolean(await storage.getItem(storageKey));
 			if (done) return;
@@ -122,21 +104,17 @@ export function autoConnectWallet({
 				});
 			}
 
-			// Wait for the registration storm to settle: all configured initializers
-			// plus a grace period for late-registering extensions.
+			// Give every initializer, plus a grace period for late-registering wallets,
+			// a chance to register before making a final attempt and giving up.
 			const gracePeriod = new Promise((resolve) => setTimeout(resolve, timeout));
 			await Promise.all([walletsRegistered.catch(() => {}), gracePeriod]);
 			if (done) return;
 
-			// Final attempt against the now-complete wallet set. This awaits the saved
-			// wallet's connect/hydration if it's present, so an in-flight restore is
-			// never cut short.
 			await tryRestore($compatibleWallets.get() ?? []);
 			if (done) return;
 
-			// Still unresolved → the saved wallet is genuinely unavailable. Settle the
-			// signal so consumers aren't stuck, but keep listening so a very-late
-			// registration can still restore the session.
+			// Settle the signal so consumers aren't stuck, but keep listening so a
+			// very-late registration can still restore the session.
 			if ($baseConnection.get().status === 'reconnecting') {
 				$baseConnection.set({ status: 'disconnected', currentAccount: null });
 			}

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/initializers/autoconnect-wallet.ts
@@ -19,13 +19,19 @@ import type { Networks } from '../../utils/networks.js';
  * To let consumers distinguish "restoring a saved session" from "logged out" during
  * the async restore window, this eagerly moves the connection into the `reconnecting`
  * state on mount whenever a persisted session exists — even before the saved wallet
- * has registered (default wallets like Slush register asynchronously) — and settles
- * back to `disconnected` once every configured wallet has finished registering without
- * the saved session being restored.
+ * has registered (default wallets like Slush register asynchronously).
  *
- * The restore window is bounded by a real lifecycle signal (`walletsRegistered`
- * resolves once all wallet initializers settle) rather than a wall-clock timeout, so a
- * slow-but-valid wallet is never cut off and a genuinely-absent wallet never hangs.
+ * The restore window is bounded so a genuinely-absent wallet doesn't hang forever, but
+ * the bound is chosen to avoid a brittle cutoff:
+ * - We stay `reconnecting` until BOTH every configured wallet initializer has settled
+ *   (`walletsRegistered`) AND a short grace period (`timeout`) has elapsed. The grace
+ *   period absorbs wallets that register slightly after page load (e.g. browser
+ *   extensions), which have no deterministic "registered" signal.
+ * - An in-flight restore is never interrupted: once the bound is reached we make a final
+ *   restore attempt and await it (which awaits the wallet's own connect/hydration), so a
+ *   slow-but-valid wallet still wins the race.
+ * - If the session still hasn't restored, we settle to `disconnected` but keep listening,
+ *   so a very-late registration can still restore it.
  */
 export function autoConnectWallet({
 	networks,
@@ -33,6 +39,7 @@ export function autoConnectWallet({
 	storage,
 	storageKey,
 	walletsRegistered,
+	timeout,
 }: {
 	networks: Networks;
 	stores: DAppKitStores;
@@ -40,13 +47,15 @@ export function autoConnectWallet({
 	storageKey: string;
 	/** Resolves once all configured wallet initializers have finished registering. */
 	walletsRegistered: Promise<unknown>;
+	/** Grace period (ms) to keep waiting for a saved wallet to register before giving up. */
+	timeout: number;
 }) {
 	onMount($compatibleWallets, () => {
 		let done = false;
 		let unsubscribe: (() => void) | undefined;
 
-		// Terminal: we've either restored the session or determined there's nothing
-		// to restore. Stop listening for further wallet registrations.
+		// Terminal: we've restored the session (or a manual connect took over). Stop
+		// listening for further wallet registrations.
 		const stop = () => {
 			done = true;
 			unsubscribe?.();
@@ -113,20 +122,24 @@ export function autoConnectWallet({
 				});
 			}
 
-			// Wait for every configured wallet to finish registering, then make one
-			// final restore attempt against the complete wallet set. If the saved
-			// session still hasn't restored, it's genuinely unavailable — settle to
-			// `disconnected` so consumers aren't stuck reconnecting.
-			await walletsRegistered.catch(() => {});
+			// Wait for the registration storm to settle: all configured initializers
+			// plus a grace period for late-registering extensions.
+			const gracePeriod = new Promise((resolve) => setTimeout(resolve, timeout));
+			await Promise.all([walletsRegistered.catch(() => {}), gracePeriod]);
 			if (done) return;
 
+			// Final attempt against the now-complete wallet set. This awaits the saved
+			// wallet's connect/hydration if it's present, so an in-flight restore is
+			// never cut short.
 			await tryRestore($compatibleWallets.get() ?? []);
 			if (done) return;
 
+			// Still unresolved → the saved wallet is genuinely unavailable. Settle the
+			// signal so consumers aren't stuck, but keep listening so a very-late
+			// registration can still restore the session.
 			if ($baseConnection.get().status === 'reconnecting') {
 				$baseConnection.set({ status: 'disconnected', currentAccount: null });
 			}
-			stop();
 		});
 
 		return () => {

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
@@ -16,9 +16,7 @@ type InternalWalletConnection =
 			currentAccount: null;
 	  }
 	| {
-			// `reconnecting` allows a `null` account because an initial session
-			// restore enters this state before the saved wallet has registered (and
-			// therefore before its account is known).
+			// `null` account: an initial restore enters this state before the saved wallet registers.
 			status: 'reconnecting';
 			currentAccount: UiWalletAccount | null;
 			supportedIntents: string[];
@@ -127,10 +125,9 @@ export function createStores<
 						? (wallets.find((w) => uiWalletAccountBelongsToUiWallet(currentAccount, w)) ?? null)
 						: null;
 
-					// Unlike `connected`, we keep reporting `isReconnecting` even when the
-					// target wallet/account isn't resolvable yet. During an initial session
-					// restore the saved wallet often hasn't registered, and consumers need a
-					// signal that distinguishes "restoring a session" from "logged out".
+					// Unlike `connected`, keep reporting `isReconnecting` even before the
+					// target wallet/account resolves, so an initial restore is distinguishable
+					// from a logged-out state.
 					if (!currentAccount || !wallet) {
 						return {
 							wallet: null,

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
@@ -16,7 +16,15 @@ type InternalWalletConnection =
 			currentAccount: null;
 	  }
 	| {
-			status: 'reconnecting' | 'connected';
+			// `reconnecting` allows a `null` account because an initial session
+			// restore enters this state before the saved wallet has registered (and
+			// therefore before its account is known).
+			status: 'reconnecting';
+			currentAccount: UiWalletAccount | null;
+			supportedIntents: string[];
+	  }
+	| {
+			status: 'connected';
 			currentAccount: UiWalletAccount;
 			supportedIntents: string[];
 	  };
@@ -114,25 +122,32 @@ export function createStores<
 						isDisconnected: false,
 					} as const;
 				case 'reconnecting': {
-					const wallet = wallets.find((w) =>
-						uiWalletAccountBelongsToUiWallet(connection.currentAccount, w),
-					);
-					if (!wallet) {
+					const { currentAccount } = connection;
+					const wallet = currentAccount
+						? (wallets.find((w) => uiWalletAccountBelongsToUiWallet(currentAccount, w)) ?? null)
+						: null;
+
+					// Unlike `connected`, we keep reporting `isReconnecting` even when the
+					// target wallet/account isn't resolvable yet. During an initial session
+					// restore the saved wallet often hasn't registered, and consumers need a
+					// signal that distinguishes "restoring a session" from "logged out".
+					if (!currentAccount || !wallet) {
 						return {
 							wallet: null,
 							account: null,
-							status: 'disconnected',
+							status: 'reconnecting',
 							supportedIntents: [],
 							isConnected: false,
 							isConnecting: false,
-							isReconnecting: false,
-							isDisconnected: true,
+							isReconnecting: true,
+							isDisconnected: false,
 						} as const;
 					}
+
 					return {
 						wallet,
-						account: connection.currentAccount,
-						status: connection.status,
+						account: currentAccount,
+						status: 'reconnecting',
 						supportedIntents: connection.supportedIntents,
 						isConnected: false,
 						isConnecting: false,

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/store.ts
@@ -132,7 +132,7 @@ export function createStores<
 						return {
 							wallet: null,
 							account: null,
-							status: 'reconnecting',
+							status: connection.status,
 							supportedIntents: [],
 							isConnected: false,
 							isConnecting: false,
@@ -144,7 +144,7 @@ export function createStores<
 					return {
 						wallet,
 						account: currentAccount,
-						status: 'reconnecting',
+						status: connection.status,
 						supportedIntents: connection.supportedIntents,
 						isConnected: false,
 						isConnecting: false,

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
@@ -45,7 +45,7 @@ export type CreateDAppKitOptions<
 	 * browser extensions), which have no deterministic "registered" signal. An
 	 * in-progress restore is never interrupted by this — a slow-but-valid wallet still
 	 * restores. Only applies when `autoConnect` is enabled and a session is persisted.
-	 * @default `2000`
+	 * @default `5000`
 	 */
 	autoConnectTimeout?: number;
 

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
@@ -39,6 +39,17 @@ export type CreateDAppKitOptions<
 	autoConnect?: boolean;
 
 	/**
+	 * The grace period, in milliseconds, to keep attempting to restore a previously
+	 * connected session during auto-connect before treating the saved wallet as
+	 * unavailable. This absorbs wallets that register slightly after page load (e.g.
+	 * browser extensions), which have no deterministic "registered" signal. An
+	 * in-progress restore is never interrupted by this — a slow-but-valid wallet still
+	 * restores. Only applies when `autoConnect` is enabled and a session is persisted.
+	 * @default `2000`
+	 */
+	autoConnectTimeout?: number;
+
+	/**
 	 * A list of networks supported by the application.
 	 */
 	networks: TNetworks;

--- a/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/core/types.ts
@@ -39,12 +39,9 @@ export type CreateDAppKitOptions<
 	autoConnect?: boolean;
 
 	/**
-	 * The grace period, in milliseconds, to keep attempting to restore a previously
-	 * connected session during auto-connect before treating the saved wallet as
-	 * unavailable. This absorbs wallets that register slightly after page load (e.g.
-	 * browser extensions), which have no deterministic "registered" signal. An
-	 * in-progress restore is never interrupted by this — a slow-but-valid wallet still
-	 * restores. Only applies when `autoConnect` is enabled and a session is persisted.
+	 * The grace period, in milliseconds, to wait for a previously connected wallet to
+	 * register during auto-connect before treating the saved session as unavailable. An
+	 * in-progress restore is never interrupted by this.
 	 * @default `5000`
 	 */
 	autoConnectTimeout?: number;

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
@@ -34,13 +34,18 @@ describe('[Integration] autoConnectWallet initializer', () => {
 		storage,
 		autoConnect = true,
 		walletInitializers = [],
+		// Default to 0 so tests are bounded purely by initializer completion (fast and
+		// deterministic). The grace-floor tests pass an explicit value.
+		autoConnectTimeout = 0,
 	}: {
 		storage: ReturnType<typeof createInMemoryStorage>;
 		autoConnect?: boolean;
 		walletInitializers?: WalletInitializer[];
+		autoConnectTimeout?: number;
 	}): DAppKit<typeof TEST_NETWORKS> {
 		return createDAppKit({
 			autoConnect,
+			autoConnectTimeout,
 			networks: TEST_NETWORKS,
 			defaultNetwork: TEST_DEFAULT_NETWORK,
 			createClient(network) {
@@ -214,6 +219,81 @@ describe('[Integration] autoConnectWallet initializer', () => {
 		await allTasks();
 
 		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
+	});
+
+	test('Does not give up on a wallet that registers within the grace period', async () => {
+		const { wallet, account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		// No initializers, so the only thing keeping us reconnecting is the grace
+		// period — this models a late-registering browser extension.
+		const dAppKit = createKit({ storage, autoConnectTimeout: 200 });
+
+		const statusesSeen: string[] = [];
+		dAppKit.stores.$connection.subscribe((connection) => statusesSeen.push(connection.status));
+
+		await tick();
+		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
+
+		// The wallet registers within the grace window, so the session restores and we
+		// never falsely report a logged-out state.
+		registerWallets(wallet);
+		await allTasks();
+
+		const connection = dAppKit.stores.$connection.get();
+		expect(connection.status).toBe('connected');
+		expect(connection.account?.address).toBe(account.address);
+
+		// Crucially, once we start reconnecting we never flip to a (false) logged-out
+		// state before connecting — the grace period held the restore open.
+		const firstReconnecting = statusesSeen.indexOf('reconnecting');
+		expect(firstReconnecting).toBeGreaterThanOrEqual(0);
+		expect(statusesSeen.slice(firstReconnecting)).not.toContain('disconnected');
+	});
+
+	test('Settles to disconnected after the grace period when no wallet registers', async () => {
+		const { account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage, autoConnectTimeout: 50 });
+		dAppKit.stores.$connection.subscribe(() => {});
+
+		await tick();
+		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
+
+		// Once the grace period elapses with no matching wallet, we settle.
+		await new Promise((resolve) => setTimeout(resolve, 80));
+		await allTasks();
+
+		expect(dAppKit.stores.$connection.get()).toMatchObject({
+			status: 'disconnected',
+			isReconnecting: false,
+			account: null,
+		});
+	});
+
+	test('Restores a very-late wallet that registers after the grace period elapses', async () => {
+		const { wallet, account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage, autoConnectTimeout: 30 });
+		dAppKit.stores.$connection.subscribe(() => {});
+
+		// Grace period elapses with no wallet → we settle the signal to disconnected...
+		await new Promise((resolve) => setTimeout(resolve, 60));
+		await allTasks();
+		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
+
+		// ...but we keep listening, so a wallet that shows up later still restores.
+		registerWallets(wallet);
+		await allTasks();
+
+		const connection = dAppKit.stores.$connection.get();
+		expect(connection.status).toBe('connected');
+		expect(connection.account?.address).toBe(account.address);
 	});
 
 	test('Does not attempt to reconnect when autoConnect is disabled', async () => {

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
@@ -1,40 +1,43 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, test, afterEach, vi } from 'vitest';
+import { describe, expect, test, afterEach } from 'vitest';
 import { allTasks } from 'nanostores';
 import { getWallets } from '@mysten/wallet-standard';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 import { createDAppKit, DAppKit } from '../../../src/index.js';
 import { createInMemoryStorage } from '../../../src/utils/storage.js';
-import { AUTO_CONNECT_RESTORE_TIMEOUT } from '../../../src/core/initializers/autoconnect-wallet.js';
+import type { WalletInitializer } from '../../../src/wallets/index.js';
 import { GRPC_URLS, TEST_DEFAULT_NETWORK, TEST_NETWORKS } from '../../test-utils.js';
 import { createMockWallets, MockWallet } from '../../mocks/mock-wallet.js';
 import { createMockAccount } from '../../mocks/mock-account.js';
 
 describe('[Integration] autoConnectWallet initializer', () => {
 	const storageKey = 'test-storage-key';
-	let unregisterCallbacks: Array<() => void> = [];
+	let cleanups: Array<() => void> = [];
 
 	afterEach(() => {
-		unregisterCallbacks.forEach((unregister) => unregister());
-		unregisterCallbacks = [];
-		vi.useRealTimers();
+		// Release any pending initializer gates and unregister wallets so a hung
+		// initializer in one test can't leak into the next.
+		cleanups.forEach((cleanup) => cleanup());
+		cleanups = [];
 	});
 
-	function registerWallets(...wallets: MockWallet[]) {
-		const unregister = getWallets().register(...wallets);
-		unregisterCallbacks.push(unregister);
-		return unregister;
+	// Lets a macrotask elapse so queued microtasks (storage reads, restore tasks)
+	// drain, without waiting on `allTasks()` (which would block on a pending gate).
+	function tick() {
+		return new Promise((resolve) => setTimeout(resolve, 0));
 	}
 
 	function createKit({
 		storage,
 		autoConnect = true,
+		walletInitializers = [],
 	}: {
 		storage: ReturnType<typeof createInMemoryStorage>;
 		autoConnect?: boolean;
+		walletInitializers?: WalletInitializer[];
 	}): DAppKit<typeof TEST_NETWORKS> {
 		return createDAppKit({
 			autoConnect,
@@ -46,6 +49,7 @@ describe('[Integration] autoConnectWallet initializer', () => {
 			storage,
 			storageKey,
 			slushWalletConfig: null,
+			walletInitializers,
 		});
 	}
 
@@ -62,6 +66,40 @@ describe('[Integration] autoConnectWallet initializer', () => {
 			accounts: [account],
 		});
 		return { wallet, account };
+	}
+
+	function registerWallets(...wallets: MockWallet[]) {
+		const unregister = getWallets().register(...wallets);
+		cleanups.push(unregister);
+		return unregister;
+	}
+
+	/**
+	 * Builds a wallet initializer whose registration is deferred until `release()` is
+	 * called, modelling an asynchronously-registering wallet (e.g. Slush). Pass a
+	 * `wallet` to register on release, or omit it to model an initializer that
+	 * finishes without ever registering the saved wallet.
+	 */
+	function deferredInitializer({ wallet }: { wallet?: MockWallet } = {}) {
+		let release!: () => void;
+		let reject!: (error: Error) => void;
+		const gate = new Promise<void>((resolve, rejectGate) => {
+			release = resolve;
+			reject = rejectGate;
+		});
+		// Ensure the gate is always settled so `afterEach` can't leave it dangling.
+		cleanups.push(() => release());
+
+		const initializer: WalletInitializer = {
+			id: 'deferred-test-initializer',
+			async initialize() {
+				await gate;
+				const unregister = wallet ? registerWallets(wallet) : () => {};
+				return { unregister };
+			},
+		};
+
+		return { initializer, release, fail: () => reject(new Error('initializer failed')) };
 	}
 
 	test('Settles to disconnected without ever reconnecting when there is no persisted session', async () => {
@@ -81,19 +119,21 @@ describe('[Integration] autoConnectWallet initializer', () => {
 		expect(statusesSeen).not.toContain('reconnecting');
 	});
 
-	test('Advertises reconnecting before the saved wallet registers, then restores the session', async () => {
+	test('Stays reconnecting while an async wallet registers, then restores the session', async () => {
 		const { wallet, account } = createSavedWallet();
+		const { initializer, release } = deferredInitializer({ wallet });
+
 		const storage = createInMemoryStorage();
 		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
 
-		const dAppKit = createKit({ storage });
+		const dAppKit = createKit({ storage, walletInitializers: [initializer] });
 
 		const statusesSeen: string[] = [];
 		dAppKit.stores.$connection.subscribe((connection) => statusesSeen.push(connection.status));
 
-		// The saved wallet hasn't registered yet, but a persisted session exists, so
-		// the connection should immediately advertise that it is restoring.
-		await allTasks();
+		// The saved wallet's initializer hasn't registered it yet, but a persisted
+		// session exists, so the connection should advertise that it is restoring.
+		await tick();
 		expect(dAppKit.stores.$connection.get()).toMatchObject({
 			status: 'reconnecting',
 			wallet: null,
@@ -102,8 +142,8 @@ describe('[Integration] autoConnectWallet initializer', () => {
 			isDisconnected: false,
 		});
 
-		// Once the saved wallet finally registers, the session should restore.
-		registerWallets(wallet);
+		// Once the wallet finishes registering, the session restores.
+		release();
 		await allTasks();
 
 		const connection = dAppKit.stores.$connection.get();
@@ -130,22 +170,25 @@ describe('[Integration] autoConnectWallet initializer', () => {
 		expect(connection.account?.address).toBe(account.address);
 	});
 
-	test('Settles back to disconnected after a timeout if the saved wallet never registers', async () => {
-		vi.useFakeTimers();
-
+	test('Settles to disconnected once all initializers finish without the saved wallet', async () => {
 		const { account } = createSavedWallet();
+		// The initializer settles without ever registering the saved wallet, modelling
+		// a wallet that was uninstalled or is otherwise unavailable.
+		const { initializer, release } = deferredInitializer();
+
 		const storage = createInMemoryStorage();
 		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
 
-		const dAppKit = createKit({ storage });
+		const dAppKit = createKit({ storage, walletInitializers: [initializer] });
 		dAppKit.stores.$connection.subscribe(() => {});
 
-		// We have a persisted session but the wallet never registers, so we stay in
-		// the reconnecting state until the restore window elapses.
-		await allTasks();
+		// While the initializer is still pending, we keep advertising reconnecting...
+		await tick();
 		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
 
-		vi.advanceTimersByTime(AUTO_CONNECT_RESTORE_TIMEOUT);
+		// ...and settle deterministically once it finishes, with no wall-clock timeout.
+		release();
+		await allTasks();
 
 		expect(dAppKit.stores.$connection.get()).toMatchObject({
 			status: 'disconnected',
@@ -154,31 +197,23 @@ describe('[Integration] autoConnectWallet initializer', () => {
 		});
 	});
 
-	test('Restores a slow-registering wallet that appears after the restore window elapses', async () => {
-		vi.useFakeTimers();
+	test('Settles to disconnected when a wallet initializer fails', async () => {
+		const { account } = createSavedWallet();
+		const { initializer, fail } = deferredInitializer();
 
-		const { wallet, account } = createSavedWallet();
 		const storage = createInMemoryStorage();
 		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
 
-		const dAppKit = createKit({ storage });
+		const dAppKit = createKit({ storage, walletInitializers: [initializer] });
 		dAppKit.stores.$connection.subscribe(() => {});
 
-		await allTasks();
+		await tick();
 		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
 
-		// The restore window elapses before the wallet registers, so we stop
-		// advertising "reconnecting"...
-		vi.advanceTimersByTime(AUTO_CONNECT_RESTORE_TIMEOUT);
-		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
-
-		// ...but a slow-registering wallet can still restore the session afterwards.
-		registerWallets(wallet);
+		fail();
 		await allTasks();
 
-		const connection = dAppKit.stores.$connection.get();
-		expect(connection.status).toBe('connected');
-		expect(connection.account?.address).toBe(account.address);
+		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
 	});
 
 	test('Does not attempt to reconnect when autoConnect is disabled', async () => {

--- a/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/integration/initializers/autoconnect-wallet.test.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test, afterEach, vi } from 'vitest';
+import { allTasks } from 'nanostores';
+import { getWallets } from '@mysten/wallet-standard';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+import { createDAppKit, DAppKit } from '../../../src/index.js';
+import { createInMemoryStorage } from '../../../src/utils/storage.js';
+import { AUTO_CONNECT_RESTORE_TIMEOUT } from '../../../src/core/initializers/autoconnect-wallet.js';
+import { GRPC_URLS, TEST_DEFAULT_NETWORK, TEST_NETWORKS } from '../../test-utils.js';
+import { createMockWallets, MockWallet } from '../../mocks/mock-wallet.js';
+import { createMockAccount } from '../../mocks/mock-account.js';
+
+describe('[Integration] autoConnectWallet initializer', () => {
+	const storageKey = 'test-storage-key';
+	let unregisterCallbacks: Array<() => void> = [];
+
+	afterEach(() => {
+		unregisterCallbacks.forEach((unregister) => unregister());
+		unregisterCallbacks = [];
+		vi.useRealTimers();
+	});
+
+	function registerWallets(...wallets: MockWallet[]) {
+		const unregister = getWallets().register(...wallets);
+		unregisterCallbacks.push(unregister);
+		return unregister;
+	}
+
+	function createKit({
+		storage,
+		autoConnect = true,
+	}: {
+		storage: ReturnType<typeof createInMemoryStorage>;
+		autoConnect?: boolean;
+	}): DAppKit<typeof TEST_NETWORKS> {
+		return createDAppKit({
+			autoConnect,
+			networks: TEST_NETWORKS,
+			defaultNetwork: TEST_DEFAULT_NETWORK,
+			createClient(network) {
+				return new SuiGrpcClient({ network, baseUrl: GRPC_URLS[network] });
+			},
+			storage,
+			storageKey,
+			slushWalletConfig: null,
+		});
+	}
+
+	// Mirrors the format produced by `saveAccountToStorage`.
+	function savedSessionValue(walletId: string, address: string, intents: string[] = []) {
+		return [walletId.replace(':', '_'), address, intents.join(',')].join(':');
+	}
+
+	function createSavedWallet() {
+		const account = createMockAccount();
+		const [wallet] = createMockWallets({
+			id: 'saved-wallet',
+			name: 'Saved Wallet',
+			accounts: [account],
+		});
+		return { wallet, account };
+	}
+
+	test('Settles to disconnected without ever reconnecting when there is no persisted session', async () => {
+		const storage = createInMemoryStorage();
+		const dAppKit = createKit({ storage });
+
+		const statusesSeen: string[] = [];
+		dAppKit.stores.$connection.subscribe((connection) => statusesSeen.push(connection.status));
+
+		await allTasks();
+
+		expect(dAppKit.stores.$connection.get()).toMatchObject({
+			status: 'disconnected',
+			isReconnecting: false,
+			account: null,
+		});
+		expect(statusesSeen).not.toContain('reconnecting');
+	});
+
+	test('Advertises reconnecting before the saved wallet registers, then restores the session', async () => {
+		const { wallet, account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage });
+
+		const statusesSeen: string[] = [];
+		dAppKit.stores.$connection.subscribe((connection) => statusesSeen.push(connection.status));
+
+		// The saved wallet hasn't registered yet, but a persisted session exists, so
+		// the connection should immediately advertise that it is restoring.
+		await allTasks();
+		expect(dAppKit.stores.$connection.get()).toMatchObject({
+			status: 'reconnecting',
+			wallet: null,
+			account: null,
+			isReconnecting: true,
+			isDisconnected: false,
+		});
+
+		// Once the saved wallet finally registers, the session should restore.
+		registerWallets(wallet);
+		await allTasks();
+
+		const connection = dAppKit.stores.$connection.get();
+		expect(connection.status).toBe('connected');
+		expect(connection.isReconnecting).toBe(false);
+		expect(connection.account?.address).toBe(account.address);
+		expect(statusesSeen).toContain('reconnecting');
+	});
+
+	test('Restores the session when the saved wallet is already registered', async () => {
+		const { wallet, account } = createSavedWallet();
+		registerWallets(wallet);
+
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage });
+		dAppKit.stores.$connection.subscribe(() => {});
+
+		await allTasks();
+
+		const connection = dAppKit.stores.$connection.get();
+		expect(connection.status).toBe('connected');
+		expect(connection.account?.address).toBe(account.address);
+	});
+
+	test('Settles back to disconnected after a timeout if the saved wallet never registers', async () => {
+		vi.useFakeTimers();
+
+		const { account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage });
+		dAppKit.stores.$connection.subscribe(() => {});
+
+		// We have a persisted session but the wallet never registers, so we stay in
+		// the reconnecting state until the restore window elapses.
+		await allTasks();
+		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
+
+		vi.advanceTimersByTime(AUTO_CONNECT_RESTORE_TIMEOUT);
+
+		expect(dAppKit.stores.$connection.get()).toMatchObject({
+			status: 'disconnected',
+			isReconnecting: false,
+			account: null,
+		});
+	});
+
+	test('Restores a slow-registering wallet that appears after the restore window elapses', async () => {
+		vi.useFakeTimers();
+
+		const { wallet, account } = createSavedWallet();
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage });
+		dAppKit.stores.$connection.subscribe(() => {});
+
+		await allTasks();
+		expect(dAppKit.stores.$connection.get().status).toBe('reconnecting');
+
+		// The restore window elapses before the wallet registers, so we stop
+		// advertising "reconnecting"...
+		vi.advanceTimersByTime(AUTO_CONNECT_RESTORE_TIMEOUT);
+		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
+
+		// ...but a slow-registering wallet can still restore the session afterwards.
+		registerWallets(wallet);
+		await allTasks();
+
+		const connection = dAppKit.stores.$connection.get();
+		expect(connection.status).toBe('connected');
+		expect(connection.account?.address).toBe(account.address);
+	});
+
+	test('Does not attempt to reconnect when autoConnect is disabled', async () => {
+		const { wallet, account } = createSavedWallet();
+		registerWallets(wallet);
+
+		const storage = createInMemoryStorage();
+		await storage.setItem(storageKey, savedSessionValue('saved-wallet', account.address));
+
+		const dAppKit = createKit({ storage, autoConnect: false });
+
+		const statusesSeen: string[] = [];
+		dAppKit.stores.$connection.subscribe((connection) => statusesSeen.push(connection.status));
+
+		await allTasks();
+
+		expect(dAppKit.stores.$connection.get().status).toBe('disconnected');
+		expect(statusesSeen).not.toContain('reconnecting');
+	});
+});

--- a/packages/dapp-kit/packages/dapp-kit-core/test/unit/stores/connection.test.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/test/unit/stores/connection.test.ts
@@ -115,6 +115,55 @@ describe('[Unit] $connection', () => {
 		});
 	});
 
+	test('Reconnecting without a known account yet (initial restore window)', () => {
+		const { stores, uiWallets } = setDefaultUnitTestEnvWithUnmockedStores();
+		stores.$registeredWallets.set(uiWallets);
+
+		// During an initial session restore we enter `reconnecting` before the saved
+		// wallet/account is known. We must still report `isReconnecting` so consumers
+		// can tell "restoring" apart from "logged out".
+		stores.$baseConnection.set({
+			status: 'reconnecting',
+			currentAccount: null,
+			supportedIntents: [],
+		});
+
+		expect(stores.$connection.get()).toStrictEqual({
+			wallet: null,
+			account: null,
+			status: 'reconnecting',
+			supportedIntents: [],
+			isConnected: false,
+			isConnecting: false,
+			isReconnecting: true,
+			isDisconnected: false,
+		});
+	});
+
+	test('Reconnecting reports isReconnecting even when the target wallet is not registered yet', () => {
+		const { stores, uiWallets } = setDefaultUnitTestEnvWithUnmockedStores();
+		const uiWallet = uiWallets[0];
+		const uiWalletAccount = uiWallet.accounts[0];
+
+		// No wallets registered yet, but we have a saved account we're restoring to.
+		stores.$baseConnection.set({
+			status: 'reconnecting',
+			currentAccount: uiWalletAccount,
+			supportedIntents: ['testIntent'],
+		});
+
+		expect(stores.$connection.get()).toStrictEqual({
+			wallet: null,
+			account: null,
+			status: 'reconnecting',
+			supportedIntents: [],
+			isConnected: false,
+			isConnecting: false,
+			isReconnecting: true,
+			isDisconnected: false,
+		});
+	});
+
 	test('Notifies subscribers when registered wallets change', () => {
 		const { stores, uiWallets } = setDefaultUnitTestEnvWithUnmockedStores();
 


### PR DESCRIPTION
## Description

Fixes a bug where, on a fresh page load, dApp Kit's auto-connect restored a persisted session but never reported an "in-progress" state. The connection jumped straight from `disconnected` → `connected`, so throughout the async restore window a logged-in user was indistinguishable from a logged-out one:

```
{ status: "disconnected", isConnecting: false, isReconnecting: false, account: null }
```

This meant auth gates that redirect when there's no account would bounce logged-in users on every hard refresh, with no obvious code smell:

```tsx
const { isReconnecting } = useWalletConnection();
const account = useCurrentAccount();
useEffect(() => {
  if (!isReconnecting && !account) navigate('/login'); // fired during restore → false redirect
}, [isReconnecting, account]);
```

### Root cause

- `autoConnectWallet` only set `status: "connected"` *after* `await getSavedWalletAccount(...)` resolved; `status` stayed `"disconnected"` for the whole restore.
- The only writer of `"reconnecting"` was the manual `connectWallet()` path (account switch / re-auth while already connected), so initial restore never surfaced it.
- The `$connection` `reconnecting` branch suppressed `isReconnecting` to `false` (returning `disconnected`) whenever the matching wallet wasn't registered yet — which is exactly the pre-registration window during restore.

### Fix

Rather than introduce a parallel `autoConnectStatus` concept, this reuses the existing `reconnecting` state, since an initial restore *is* conceptually a reconnect:

1. **`autoConnectWallet` (initializer):** on mount, if a persisted session exists, eagerly enter `reconnecting` **before** any wallet registers (default wallets such as Slush register asynchronously). Settle to `connected` on success. **Bounding the give-up:** the wallet-standard registry is open-ended — wallets (e.g. browser extensions) can register at any time with no "registration done" signal — so the restore window can't be derived purely from a lifecycle event. We stay `reconnecting` until **both** every configured wallet initializer has settled (`createDAppKit` threads the `registerAdditionalWallets(...)` promise in) **and** a short grace period (`autoConnectTimeout`, default `5000ms`) has elapsed, to absorb late-registering extensions. Crucially this bound **never interrupts an in-flight restore** — once reached we make a final restore attempt and *await* it (which awaits the wallet's own connect/hydration), so a slow-but-valid wallet always wins — and we **keep listening after settling**, so a very-late wallet still restores. This avoids the brittle timer's two failure modes: cutting off a slow-but-valid wallet, and a `disconnected → connected` flip-flop. Settle immediately when there's nothing saved.
2. **`$connection` store:** the `reconnecting` branch now reports `isReconnecting: true` while the wallet/account is still resolving (instead of being suppressed to `disconnected`). The `reconnecting` internal type now allows a `null` account for the pre-registration window. `wallet`/`account` remain correlated (both set or both null) so existing narrowing (e.g. the connect button) still type-checks.

Consumers can now write `if (!isReconnecting && !account) redirect()` and it behaves correctly across hard refresh.

### Behavior covered

- No persisted session → settles to `disconnected` immediately, never advertises `reconnecting`.
- Persisted session, wallet registers asynchronously (via an initializer) → `reconnecting` from mount, then `connected` once it registers.
- Persisted session, wallet already registered → restores to `connected`.
- Persisted session, all initializers finish without the saved wallet → stays `reconnecting` until they settle, then `disconnected`.
- A wallet initializer fails → settles to `disconnected`.
- Persisted session, wallet registers within the grace period → restores to `connected` with **no false logged-out flip** in between.
- Persisted session, no wallet registers within the grace period → settles to `disconnected` after it elapses.
- A very-late wallet that registers *after* the grace period → still restores to `connected` (we keep listening).
- `autoConnect: false` → never reconnects.

## API

Adds `autoConnectTimeout?: number` (default `5000`) to `createDAppKit` — the grace period for absorbing late-registering wallets. Documented as never interrupting an in-progress restore.

## Test plan

- New integration tests in `test/integration/initializers/autoconnect-wallet.test.ts` covering all scenarios above, driven by gate-controlled wallet initializers and small `autoConnectTimeout` values (deterministic — no fake timers).
- New unit tests in `test/unit/stores/connection.test.ts` for the `reconnecting` branch with a `null` account and with an unregistered target wallet.
- Full package suite green (`vitest run`, 45 tests), `tsc --noEmit` clean for src + tests, oxlint + prettier clean.


---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


