### PR TITLE
feat(sponsor): thread include/execute options through signAndExecuteTransaction

### DIFF
--- a/.changeset/sponsor-sign-and-execute-include.md
+++ b/.changeset/sponsor-sign-and-execute-include.md
@@ -1,0 +1,10 @@
+---
+'@mysten-incubation/sponsor': minor
+---
+
+`Sponsor.signAndExecuteTransaction` now threads through every core `executeTransaction`
+prop (`signal`, etc.) and accepts a generic `include`, combined with the always-on
+`effects` so the result type reflects exactly what was requested. The dry-run that backs
+validation can likewise be extended: a validator declares the simulate `include` fields it
+needs (e.g. `include: { balanceChanges: true }`) and that requirement surfaces, typed, on
+`validationOptions` — `effects` stays forced on in both paths and can't be turned off.

--- a/.changeset/wallet-sdk-simulate-include.md
+++ b/.changeset/wallet-sdk-simulate-include.md
@@ -7,6 +7,9 @@ bare analyzer value) — so its result can be typed to exactly the simulate fiel
 `transactionResponse<{ balanceChanges: true }>()` returns the same shared, deduped analyzer instance
 retyped so `result.balanceChanges` is present, and makes `include` a required request-scoped option
 when it names a field that must be fetched. `effects` is always included and can't be turned off.
-This is a breaking change: update `transactionResponse` references to `transactionResponse()` (or
-`transactionResponse<Include>()`). The `balanceChanges` analyzer now requests `balanceChanges` from
-the dry-run, so its result is the real `BalanceChange[]` rather than always empty.
+An injected `transactionResponse` now skips the dry-run entirely (it previously simulated and then
+discarded the result), so `transactionResponse` and `include` are mutually exclusive in effect —
+injection takes precedence. This is a breaking change: update `transactionResponse` references to
+`transactionResponse()` (or `transactionResponse<Include>()`). The `balanceChanges` analyzer now
+requests `balanceChanges` from the dry-run, so its result is the real `BalanceChange[]` rather than
+always empty.

--- a/.changeset/wallet-sdk-simulate-include.md
+++ b/.changeset/wallet-sdk-simulate-include.md
@@ -1,0 +1,12 @@
+---
+'@mysten/wallet-sdk': minor
+---
+
+The `transactionResponse` analyzer is now a generic factory — call `transactionResponse()` (was a
+bare analyzer value) — so its result can be typed to exactly the simulate fields you request.
+`transactionResponse<{ balanceChanges: true }>()` returns the same shared, deduped analyzer instance
+retyped so `result.balanceChanges` is present, and makes `include` a required request-scoped option
+when it names a field that must be fetched. `effects` is always included and can't be turned off.
+This is a breaking change: update `transactionResponse` references to `transactionResponse()` (or
+`transactionResponse<Include>()`). The `balanceChanges` analyzer now requests `balanceChanges` from
+the dry-run, so its result is the real `BalanceChange[]` rather than always empty.

--- a/packages/sponsor/README.md
+++ b/packages/sponsor/README.md
@@ -122,9 +122,15 @@ A `Sponsor` has three members:
   request-scoped options your validators read (see
   [Request-scoped options](#request-scoped-options)) — required only when a validator declares a
   required one.
-- **`sponsor.signAndExecuteTransaction({ transaction, userSignature, validationOptions? })`** —
-  `signTransaction` + execute. Returns `{ $kind: 'Rejected', … }` (never executed) or the execution
-  result (`{ $kind: 'Transaction', … }` / `{ $kind: 'FailedTransaction', … }`).
+- **`sponsor.signAndExecuteTransaction({ transaction, userSignature, include?, validationOptions?, … })`**
+  — `signTransaction` + execute. Returns `{ $kind: 'Rejected', … }` (never executed) or the
+  execution result (`{ $kind: 'Transaction', … }` / `{ $kind: 'FailedTransaction', … }`). It
+  forwards every other prop the core `executeTransaction` takes (e.g. `signal`). `include` selects
+  the **extra** result fields to fetch — `effects` is always included and can't be turned off — and
+  the result type reflects exactly what you asked for. The dry-run that backs validation can be
+  extended too: a validator declares the simulate `include` fields it needs (e.g.
+  `include: { balanceChanges: true }`), and that requirement surfaces, typed, on `validationOptions`
+  (see [Request-scoped options](#request-scoped-options)).
 
 Validation rejection is **returned, not thrown** — `switch (result.$kind)` to handle every outcome,
 the same way you handle `Transaction` vs `FailedTransaction`. (Genuine errors — network, malformed

--- a/packages/sponsor/src/sponsor.ts
+++ b/packages/sponsor/src/sponsor.ts
@@ -148,11 +148,12 @@ export type SignTransactionResult = SponsoredTransaction | SponsorRejection;
 /**
  * `signAndExecuteTransaction`'s result: a {@link SponsorRejection} (`Rejected`,
  * never executed), or the execution result (`Transaction` / `FailedTransaction`).
- * Switch on `$kind`.
+ * Switch on `$kind`. The execution result carries exactly the data named by
+ * `Include` (defaulting to `{ effects: true }`).
  */
-export type SignAndExecuteResult =
-	| SponsorRejection
-	| SuiClientTypes.TransactionResult<{ effects: true }>;
+export type SignAndExecuteResult<
+	Include extends SuiClientTypes.TransactionInclude = { effects: true },
+> = SponsorRejection | SuiClientTypes.TransactionResult<Include>;
 
 /**
  * Anything `Transaction.from` accepts: a {@link Transaction} instance, built
@@ -184,12 +185,25 @@ export type SignOptions =
 			userSignature: string | string[];
 	  };
 
-export interface SignAndExecuteOptions {
+/**
+ * `signAndExecuteTransaction`'s options. The sponsor owns the transaction bytes
+ * and signatures it executes with, so those are omitted from the core
+ * {@link SuiClientTypes.ExecuteTransactionOptions}; every other core-execute prop
+ * (`signal`, …) is threaded straight through. `include` names the *extra* result
+ * fields to fetch — `effects` is always included (the sponsor forces it on), so
+ * it's omitted here and can't be turned off. `Include` is combined with that
+ * forced `effects` to shape the result (see {@link SignAndExecuteResult}).
+ */
+export type SignAndExecuteOptions<
+	Include extends Omit<SuiClientTypes.TransactionInclude, 'effects'> = {},
+> = Omit<SuiClientTypes.ExecuteTransactionOptions, 'transaction' | 'signatures' | 'include'> & {
 	/** The exact, already-built transaction the user signed — bytes or base64. */
 	transaction: Uint8Array | string;
 	/** The user's signature(s) — required, since execution needs every signature. */
 	userSignature: string | string[];
-}
+	/** Extra result fields to include beyond the always-present `effects`. */
+	include?: Include & { effects?: never };
+};
 
 /** Create a {@link Sponsor} bound to a signer, client, and validation policy. */
 export function createSponsor<const T extends readonly ValidateItem[] = []>(
@@ -349,19 +363,33 @@ export class Sponsor<TOptions extends object = object> {
 	 * execution result (`Transaction` / `FailedTransaction`) — switch on `$kind`.
 	 * Requires the user's signature, since execution needs both.
 	 */
-	async signAndExecuteTransaction(
-		options: SignAndExecuteOptions & ValidationOptionsArg<TOptions>,
-	): Promise<SignAndExecuteResult> {
+	async signAndExecuteTransaction<
+		Include extends Omit<SuiClientTypes.TransactionInclude, 'effects'> = {},
+	>(
+		options: SignAndExecuteOptions<Include> & ValidationOptionsArg<TOptions>,
+	): Promise<SignAndExecuteResult<Include & { effects: true }>> {
 		const signed = await this.signTransaction(
 			options as SignOptions & ValidationOptionsArg<TOptions>,
 		);
 		if (signed.$kind === 'Rejected') return signed;
 
 		await this.#runDelay(this.#delay.beforeExecute);
-		return this.#client.core.executeTransaction({
+
+		// Thread every other core-execute prop through (`signal`, …); the sponsor owns
+		// only the bytes and signatures, and forces `effects` on (merged last) so the
+		// result always carries them and a caller can't drop them.
+		const {
+			transaction: _transaction,
+			userSignature: _userSignature,
+			validationOptions: _validationOptions,
+			include,
+			...rest
+		} = options as SignAndExecuteOptions<Include> & { validationOptions?: unknown };
+		return this.#client.core.executeTransaction<Include & { effects: true }>({
+			...rest,
 			transaction: signed.bytes,
 			signatures: signed.signatures!,
-			include: { effects: true },
+			include: { ...include, effects: true } as Include & { effects: true },
 		});
 	}
 

--- a/packages/sponsor/src/validators.ts
+++ b/packages/sponsor/src/validators.ts
@@ -392,7 +392,7 @@ export function onlySenderWithdrawals(): Validator {
  */
 export function simulationSucceeds(): Validator {
 	return createAnalyzer({
-		dependencies: { transactionResponse: analyzers.transactionResponse },
+		dependencies: { transactionResponse: analyzers.transactionResponse() },
 		analyze:
 			() =>
 			({ transactionResponse }) => {

--- a/packages/sponsor/test/sponsor.test.ts
+++ b/packages/sponsor/test/sponsor.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ClientWithCoreApi } from '@mysten/sui/client';
+import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction, TransactionDataBuilder } from '@mysten/sui/transactions';
 import { normalizeSuiAddress, toBase58, toBase64 } from '@mysten/sui/utils';
@@ -301,6 +301,61 @@ describe('Sponsor.analyzer', () => {
 
 		expect(probeRuns).toBe(1);
 		expect(analysis.check.result).toBeNull();
+	});
+});
+
+describe('Sponsor.signAndExecuteTransaction', () => {
+	it('returns custom result fields (events) requested via `include`, with effects forced on', async () => {
+		const sponsorKey = new Ed25519Keypair();
+		const senderKey = new Ed25519Keypair();
+		const tx = resolvedTransaction({
+			sender: senderKey.toSuiAddress(),
+			sponsor: sponsorKey.toSuiAddress(),
+		});
+		const bytes = await tx.build();
+		const { signature: userSignature } = await senderKey.signTransaction(bytes);
+
+		const events: SuiClientTypes.Event[] = [
+			{
+				packageId: normalizeSuiAddress('0x2'),
+				module: 'foo',
+				sender: senderKey.toSuiAddress(),
+				eventType: '0x2::foo::Bar',
+				bcs: new Uint8Array([1, 2, 3]),
+				json: { value: 1 },
+			},
+		];
+
+		// Capture what the sponsor forwards to the core execute call.
+		let executeArgs: { include?: unknown; signatures?: string[] } | undefined;
+		const client = {
+			core: {
+				executeTransaction: async (options: { include?: unknown; signatures?: string[] }) => {
+					executeArgs = options;
+					return { $kind: 'Transaction', Transaction: { digest: 'digest', events } };
+				},
+			},
+		} as unknown as ClientWithCoreApi;
+
+		const sponsor = createSponsor({ signer: sponsorKey, client, validate: [validSender()] });
+		const result = await sponsor.signAndExecuteTransaction({
+			transaction: bytes,
+			userSignature,
+			include: { events: true },
+		});
+
+		expect(result.$kind).toBe('Transaction');
+		if (result.$kind === 'Transaction') {
+			// `events` is typed `Event[]` (combined with the forced `effects`) — no cast.
+			const got: SuiClientTypes.Event[] = result.Transaction.events;
+			expect(got).toEqual(events);
+		}
+		// The requested `events` is merged with the always-on `effects`, and the
+		// user + sponsor signatures are both forwarded for execution (Ed25519 signing
+		// is deterministic, so the sponsor signature is reproducible here).
+		const { signature: sponsorSignature } = await sponsorKey.signTransaction(bytes);
+		expect(executeArgs?.include).toEqual({ events: true, effects: true });
+		expect(executeArgs?.signatures).toEqual([userSignature, sponsorSignature]);
 	});
 });
 

--- a/packages/sponsor/test/types.test.ts
+++ b/packages/sponsor/test/types.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ClientWithCoreApi } from '@mysten/sui/client';
+import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import type { Signer } from '@mysten/sui/cryptography';
 import { describe, expect, it } from 'vitest';
 
-import { createAnalyzer, createSponsor } from '../src/index.js';
+import { analyzers, createAnalyzer, createSponsor } from '../src/index.js';
 
 declare const client: ClientWithCoreApi;
 declare const signer: Signer;
@@ -70,10 +70,109 @@ function _enforcement() {
 	void createSponsor({ signer, client, validate: [missingMessage] });
 }
 
+// A validator that depends on the dry-run typed for `balanceChanges`. Asking
+// `transactionResponse<{ balanceChanges: true }>()` for that field both makes the
+// requirement surface (typed) on `validationOptions` — via the same inference as
+// any other validator option — and types the result so `balanceChanges` is present.
+const needsBalanceChanges = createAnalyzer({
+	dependencies: { transactionResponse: analyzers.transactionResponse<{ balanceChanges: true }>() },
+	analyze:
+		() =>
+		({ transactionResponse }) => {
+			// Typed `BalanceChange[]` (present), not `undefined`.
+			const changes: SuiClientTypes.BalanceChange[] = transactionResponse.balanceChanges;
+			return changes.length >= 0 ? { result: null } : { result: [{ message: 'no balances' }] };
+		},
+});
+
+// A second validator depending on the dry-run typed for a *different* field, so we
+// can check the two `include` requirements merge rather than clobber each other.
+const needsEvents = createAnalyzer({
+	dependencies: { transactionResponse: analyzers.transactionResponse<{ events: true }>() },
+	analyze:
+		() =>
+		({ transactionResponse }) => {
+			// Typed `Event[]` (present), not `undefined`.
+			const events: SuiClientTypes.Event[] = transactionResponse.events;
+			return events.length >= 0 ? { result: null } : { result: [{ message: 'no events' }] };
+		},
+});
+
+// Compile-only. `signAndExecuteTransaction` threads every core-execute prop through
+// and combines the requested `include` with the always-on `effects`.
+async function _executeOptions() {
+	const sponsor = createSponsor({ signer, client });
+
+	// Extra `include` (beyond `effects`) and pass-through props like `signal` are accepted,
+	// and the result combines the requested field with the forced `effects`.
+	const res = await sponsor.signAndExecuteTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		include: { events: true },
+		signal: new AbortController().signal,
+	});
+	if (res.$kind === 'Transaction') {
+		const _effects: SuiClientTypes.TransactionEffects = res.Transaction.effects;
+		const _events: SuiClientTypes.Event[] = res.Transaction.events;
+		void _effects;
+		void _events;
+	}
+
+	// No `include` → the result still carries the forced `effects`.
+	const plain = await sponsor.signAndExecuteTransaction({ transaction: bytes, userSignature: 's' });
+	if (plain.$kind === 'Transaction') {
+		const _effects: SuiClientTypes.TransactionEffects = plain.Transaction.effects;
+		void _effects;
+	}
+
+	void sponsor.signAndExecuteTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		// @ts-expect-error `effects` is always included and can't be turned off
+		include: { effects: false },
+	});
+}
+
+// Compile-only. When several validators each need a different simulate field, the
+// required `include` on `validationOptions` is the *merge* of all of them — you must
+// pass every field, and supplying only some is a type error.
+function _simulateInclude() {
+	const sponsor = createSponsor({ signer, client, validate: [needsBalanceChanges, needsEvents] });
+
+	// Both requirements merged → must pass `balanceChanges` AND `events`.
+	void sponsor.signTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		validationOptions: { include: { balanceChanges: true, events: true } },
+	});
+	void sponsor.signAndExecuteTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		validationOptions: { include: { balanceChanges: true, events: true } },
+	});
+
+	void sponsor.signTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		// @ts-expect-error `events` is also required (merged from the second validator)
+		validationOptions: { include: { balanceChanges: true } },
+	});
+	void sponsor.signTransaction({
+		transaction: bytes,
+		userSignature: 's',
+		// @ts-expect-error `balanceChanges` is also required (merged from the first validator)
+		validationOptions: { include: { events: true } },
+	});
+	// @ts-expect-error the merged simulate `include` is missing entirely
+	void sponsor.signAndExecuteTransaction({ transaction: bytes, userSignature: 's' });
+}
+
 describe('validator typing', () => {
 	it('compiles (assertions enforced by test:typecheck)', () => {
 		void _assertions;
 		void _enforcement;
+		void _executeOptions;
+		void _simulateInclude;
 		expect(typeof requiresToken.analyze).toBe('function');
 	});
 });

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
@@ -57,15 +57,24 @@ type SimulateExtraInclude = Omit<SuiClientTypes.SimulateTransactionInclude, 'eff
 
 /**
  * {@link transactionResponse}'s request-scoped options for a given extra-`Include`.
- * `include` is required exactly when `Include` names a field that must be present
- * (so a dependent that needs, say, `balanceChanges` forces it to be passed) and is
- * optional otherwise. `effects` is always added on top.
+ * `transactionResponse` and `include` are mutually exclusive *in effect*: injecting a
+ * pre-computed response skips the dry-run, so `include` (which only shapes a
+ * simulation) is ignored — inject one or the other, not both. When simulating,
+ * `include` is required exactly when `Include` names a field that must be present (so
+ * a dependent that needs, say, `balanceChanges` forces it to be passed). `effects` is
+ * always added on top either way.
+ *
+ * The exclusivity can't be a type-level union here: the analyzer framework merges a
+ * dependency's options with `UnionToIntersection`, which would collapse the two
+ * branches to `never` and break every dependent. So both stay optional and the
+ * precedence is enforced at runtime.
  */
 type TransactionResponseOptions<Include extends SimulateExtraInclude> = {
 	client: ClientWithCoreApi;
 	/**
-	 * Inject a pre-computed response to skip the dry-run (e.g. a host that already
-	 * simulated). Must carry at least the requested fields.
+	 * Inject a pre-computed response to skip the dry-run entirely (e.g. a host that
+	 * already simulated). Must carry at least the requested fields. Takes precedence
+	 * over `include` — providing both ignores `include`.
 	 */
 	transactionResponse?: SuiClientTypes.Transaction<Include & { effects: true }>;
 } & ({} extends Include ? { include?: Include } : { include: Include });
@@ -81,6 +90,11 @@ const transactionResponseAnalyzer = createAnalyzer({
 	analyze:
 		(options: TransactionResponseOptions<SimulateExtraInclude>) =>
 		async ({ bytes }): Promise<AnalyzerOutput<SuiClientTypes.Transaction<{ effects: true }>>> => {
+			// An injected response skips the dry-run — `include` doesn't apply (it only
+			// shapes a simulation), which is why the two are mutually exclusive.
+			if (options.transactionResponse) {
+				return { result: options.transactionResponse };
+			}
 			try {
 				const result = await options.client.core.simulateTransaction({
 					transaction: bytes,
@@ -89,7 +103,7 @@ const transactionResponseAnalyzer = createAnalyzer({
 					include: { ...options.include, effects: true },
 				});
 				return {
-					result: options.transactionResponse ?? result.Transaction ?? result.FailedTransaction,
+					result: result.Transaction ?? result.FailedTransaction,
 				};
 			} catch (error) {
 				// Simulation throws for many reasons (object/version resolution, gas

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/core.ts
@@ -4,7 +4,7 @@
 import type { Transaction } from '@mysten/sui/transactions';
 import { TransactionDataBuilder } from '@mysten/sui/transactions';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
-import type { AnalyzerOutput } from '../analyzer.js';
+import type { Analyzer, AnalyzerOutput } from '../analyzer.js';
 import { createAnalyzer } from '../analyzer.js';
 
 export const bytes = createAnalyzer({
@@ -48,19 +48,45 @@ export const digest = createAnalyzer({
 		},
 });
 
-export const transactionResponse = createAnalyzer({
+/**
+ * The *extra* simulate fields {@link transactionResponse} can fetch. `effects` is
+ * always included (this analyzer and its dependents rely on it), so it's omitted
+ * here and can't be turned off — `Include` only ever widens what's fetched.
+ */
+type SimulateExtraInclude = Omit<SuiClientTypes.SimulateTransactionInclude, 'effects'>;
+
+/**
+ * {@link transactionResponse}'s request-scoped options for a given extra-`Include`.
+ * `include` is required exactly when `Include` names a field that must be present
+ * (so a dependent that needs, say, `balanceChanges` forces it to be passed) and is
+ * optional otherwise. `effects` is always added on top.
+ */
+type TransactionResponseOptions<Include extends SimulateExtraInclude> = {
+	client: ClientWithCoreApi;
+	/**
+	 * Inject a pre-computed response to skip the dry-run (e.g. a host that already
+	 * simulated). Must carry at least the requested fields.
+	 */
+	transactionResponse?: SuiClientTypes.Transaction<Include & { effects: true }>;
+} & ({} extends Include ? { include?: Include } : { include: Include });
+
+// One shared instance — the dry-run logic lives here, once. `transactionResponse()`
+// hands this exact instance back, retyped per `Include`, so every consumer keeps the
+// same identity and `cacheKey` (deduped to a single simulation per run) instead of
+// each spinning up a copy. The runtime reads `include` off the shared options, so the
+// data fetched always matches what the call actually requested.
+const transactionResponseAnalyzer = createAnalyzer({
 	cacheKey: 'transactionResponse@1.0.0',
 	dependencies: { bytes },
 	analyze:
-		(options: {
-			client: ClientWithCoreApi;
-			transactionResponse?: SuiClientTypes.Transaction<{ effects: true }>;
-		}) =>
+		(options: TransactionResponseOptions<SimulateExtraInclude>) =>
 		async ({ bytes }): Promise<AnalyzerOutput<SuiClientTypes.Transaction<{ effects: true }>>> => {
 			try {
 				const result = await options.client.core.simulateTransaction({
 					transaction: bytes,
-					include: { effects: true },
+					// `effects` is forced last so a caller-supplied `include` can only add to
+					// it, never drop the effects that `simulationSucceeds` (and others) read.
+					include: { ...options.include, effects: true },
 				});
 				return {
 					result: options.transactionResponse ?? result.Transaction ?? result.FailedTransaction,
@@ -81,11 +107,38 @@ export const transactionResponse = createAnalyzer({
 		},
 });
 
+/**
+ * The dry-run analyzer, generic over the *extra* simulate `include` fields. Calling
+ * it returns the one shared analyzer instance (above) retyped for `Include`, so its
+ * result exposes exactly the fields you asked for and `include` becomes a required
+ * option when `Include` names one — all without duplicating the analyzer or running
+ * the simulation more than once. `effects` is always included.
+ *
+ * ```ts
+ * // Reusable, deduped, and typed to what you requested:
+ * createAnalyzer({
+ *   dependencies: { tx: transactionResponse<{ balanceChanges: true }>() },
+ *   analyze: () => ({ tx }) => ({ result: tx.balanceChanges }), // typed `BalanceChange[]`
+ * });
+ * ```
+ */
+export function transactionResponse<Include extends SimulateExtraInclude = {}>(): Analyzer<
+	SuiClientTypes.Transaction<Include & { effects: true }>,
+	TransactionResponseOptions<Include>,
+	{ bytes: Uint8Array }
+> {
+	return transactionResponseAnalyzer as unknown as Analyzer<
+		SuiClientTypes.Transaction<Include & { effects: true }>,
+		TransactionResponseOptions<Include>,
+		{ bytes: Uint8Array }
+	>;
+}
+
 export const balanceChanges = createAnalyzer({
-	dependencies: { transactionResponse },
+	dependencies: { transactionResponse: transactionResponse<{ balanceChanges: true }>() },
 	analyze:
 		() =>
 		({ transactionResponse }) => {
-			return { result: transactionResponse.balanceChanges || [] };
+			return { result: transactionResponse.balanceChanges };
 		},
 });

--- a/packages/wallet-sdk/test/transaction-analyzer/core.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/core.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SuiClientTypes } from '@mysten/sui/client';
+import { Transaction } from '@mysten/sui/transactions';
+import { describe, expect, it, vi } from 'vitest';
+
+import { analyze } from '../../src/transaction-analyzer/analyzer.js';
+import { transactionResponse } from '../../src/transaction-analyzer/rules/core.js';
+import { DEFAULT_SENDER } from '../mocks/mockData.js';
+import { MockSuiClient } from '../mocks/MockSuiClient.js';
+
+/** A fully-resolved transaction so `build()` never dry-runs for gas estimation. */
+function resolvedTransaction() {
+	const tx = new Transaction();
+	tx.setSender(DEFAULT_SENDER);
+	tx.setGasBudget(2_000_000n);
+	tx.setGasPrice(1000n);
+	return tx;
+}
+
+describe('TransactionAnalyzer - transactionResponse', () => {
+	it('dry-runs with the requested include plus the forced effects', async () => {
+		const client = new MockSuiClient();
+		const spy = vi.spyOn(client, 'simulateTransaction');
+
+		const results = await analyze(
+			{ tx: transactionResponse<{ events: true }>() },
+			{ client, transaction: await resolvedTransaction().toJSON(), include: { events: true } },
+		);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+		// The requested `events` is merged with the always-on `effects`.
+		expect(spy.mock.calls[0][0].include).toEqual({ events: true, effects: true });
+		expect(results.tx.result?.effects).toBeDefined();
+	});
+
+	it('skips the dry-run when a response is injected (include is ignored)', async () => {
+		const client = new MockSuiClient();
+		const spy = vi.spyOn(client, 'simulateTransaction');
+
+		const injected = {
+			digest: 'injected-digest',
+			signatures: [],
+			epoch: '1',
+			status: { success: true, error: null },
+			effects: { status: { success: true, error: null } },
+		} as unknown as SuiClientTypes.Transaction<{ effects: true }>;
+
+		const results = await analyze(
+			{ tx: transactionResponse() },
+			{ client, transaction: await resolvedTransaction().toJSON(), transactionResponse: injected },
+		);
+
+		// Injection takes precedence — the dry-run never runs, and the injected
+		// response is returned verbatim.
+		expect(spy).not.toHaveBeenCalled();
+		expect(results.tx.result).toBe(injected);
+	});
+});


### PR DESCRIPTION
## Description

Lets sponsored transactions return exactly the result fields the caller wants, and lets validators request (and read, typed) extra dry-run fields.

**`@mysten-incubation/sponsor`**
- `Sponsor.signAndExecuteTransaction` is now generic over `Include` and forwards every other core `executeTransaction` prop (`signal`, etc.). `include` selects the **extra** result fields to fetch and is combined with the always-on `effects`, so the return type reflects exactly what was requested. `effects` can't be turned off (omitted from the option type).
- The simulate include that backs validation threads through the existing validator-options inference: a validator declares the fields it needs and they surface, typed and required, on `validationOptions`. Multiple validators' include requirements **merge** (you must pass all of them).

**`@mysten/wallet-sdk`** (breaking, see changeset)
- The `transactionResponse` analyzer becomes a generic factory — call `transactionResponse()` (or `transactionResponse<{ balanceChanges: true }>()`). It returns the **one shared, deduped** analyzer instance retyped per `Include`, so there's no duplication and still a single simulation per run. The result is typed to exactly the fields requested, and `include` becomes a required option when `Include` names a must-have field. `effects` is always included.
- `balanceChanges` now requests `balanceChanges` from the dry-run, so its result is the real `BalanceChange[]` rather than always empty.

Changesets included for both packages.

## Test plan

- `pnpm --filter @mysten-incubation/sponsor test` (typecheck + 59 unit tests) — pass
- `pnpm --filter @mysten/wallet-sdk test` (122 unit, 1 skipped) — pass
- `tsc --noEmit` clean for both packages; oxlint + prettier clean
- New coverage:
  - **Runtime** (`sponsor.test.ts`): `signAndExecuteTransaction({ include: { events: true } })` returns `events` (typed `Event[]`, no cast) and forwards `include: { events: true, effects: true }` plus both signatures to the core execute call.
  - **Type-level** (`types.test.ts`): execute `include` combines with forced `effects`; `effects` can't be set; multiple validators' simulate-`include` requirements merge on `validationOptions` (partial sets are `@ts-expect-error`).
- Not run: e2e tests (require Docker/local network).

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)