### PR TITLE
feat(zklogin): add transport-agnostic ZkLoginSigner; rebase EnokiKeypair onto it

### DIFF
--- a/.changeset/enoki-zklogin-signer.md
+++ b/.changeset/enoki-zklogin-signer.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/enoki': patch
+'@mysten/enoki': minor
 ---
 
 `EnokiKeypair` now extends the shared `ZkLoginSigner` from `@mysten/sui/zklogin`, removing duplicated

--- a/.changeset/enoki-zklogin-signer.md
+++ b/.changeset/enoki-zklogin-signer.md
@@ -1,0 +1,9 @@
+---
+'@mysten/enoki': patch
+---
+
+`EnokiKeypair` now extends the shared `ZkLoginSigner` from `@mysten/sui/zklogin`, removing duplicated
+signature-wrapping logic. `signTransaction` / `signPersonalMessage` / `getPublicKey` are unchanged.
+Two behaviors are corrected to match `ZkLoginSigner`: `getKeyScheme()` now returns `'ZkLogin'`
+(previously the ephemeral key's scheme), and `sign()` now throws instead of returning a bare
+ephemeral signature (which was never valid for the zkLogin address).

--- a/.changeset/zklogin-signer.md
+++ b/.changeset/zklogin-signer.md
@@ -6,7 +6,9 @@ Add `ZkLoginSigner`, a transport- and provider-agnostic zkLogin signer. It wraps
 `Signer` and transforms its signatures into zkLogin signatures using the supplied proof `inputs` and
 `maxEpoch`: `new ZkLoginSigner({ ephemeralSigner, maxEpoch, inputs, legacyAddress })`. The address is
 derived from the proof; `legacyAddress` is a required boolean (consistent with `jwtToAddress`,
-`toZkLoginPublicIdentifier`, and the other zkLogin address APIs). Like other composite signers (e.g.
-`MultiSigSigner`), calling `sign()` directly throws — use `signTransaction` / `signPersonalMessage`.
+`toZkLoginPublicIdentifier`, and the other zkLogin address APIs). Optionally pass `address` to
+validate the derived address (throws on mismatch) and `client` to make the derived public key able to
+verify signatures. Like other composite signers (e.g. `MultiSigSigner`), calling `sign()` directly
+throws — use `signTransaction` / `signPersonalMessage`.
 
 Also adds a read-only `legacyAddress` getter to `ZkLoginPublicIdentifier`.

--- a/.changeset/zklogin-signer.md
+++ b/.changeset/zklogin-signer.md
@@ -1,0 +1,12 @@
+---
+'@mysten/sui': minor
+---
+
+Add `ZkLoginSigner`, a transport- and provider-agnostic zkLogin signer. It wraps any ephemeral
+`Signer` and transforms its signatures into zkLogin signatures using the supplied proof `inputs` and
+`maxEpoch`: `new ZkLoginSigner({ ephemeralSigner, maxEpoch, inputs, legacyAddress })`. The address is
+derived from the proof; `legacyAddress` is a required boolean (consistent with `jwtToAddress`,
+`toZkLoginPublicIdentifier`, and the other zkLogin address APIs). Like other composite signers (e.g.
+`MultiSigSigner`), calling `sign()` directly throws — use `signTransaction` / `signPersonalMessage`.
+
+Also adds a read-only `legacyAddress` getter to `ZkLoginPublicIdentifier`.

--- a/packages/enoki/src/EnokiKeypair.ts
+++ b/packages/enoki/src/EnokiKeypair.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SignatureWithBytes } from '@mysten/sui/cryptography';
-import { Signer } from '@mysten/sui/cryptography';
+import type { Signer } from '@mysten/sui/cryptography';
 import type { ZkLoginSignatureInputs } from '@mysten/sui/zklogin';
-import { getZkLoginSignature, ZkLoginPublicIdentifier } from '@mysten/sui/zklogin';
+import { ZkLoginPublicIdentifier, ZkLoginSigner } from '@mysten/sui/zklogin';
 
 export class EnokiPublicKey extends ZkLoginPublicIdentifier {}
 
-export class EnokiKeypair extends Signer {
-	#proof: ZkLoginSignatureInputs;
-	#maxEpoch: number;
-	#ephemeralKeypair: Signer;
+export class EnokiKeypair extends ZkLoginSigner {
 	#publicKey: EnokiPublicKey;
 
 	constructor(input: {
@@ -20,54 +16,19 @@ export class EnokiKeypair extends Signer {
 		proof: ZkLoginSignatureInputs;
 		ephemeralKeypair: Signer;
 	}) {
-		super();
-		this.#proof = input.proof;
-		this.#maxEpoch = input.maxEpoch;
-		this.#ephemeralKeypair = input.ephemeralKeypair;
-		this.#publicKey = EnokiPublicKey.fromProof(input.address, input.proof);
-	}
-
-	async sign(data: Uint8Array) {
-		return this.#ephemeralKeypair.sign(data);
-	}
-
-	async signPersonalMessage(bytes: Uint8Array): Promise<SignatureWithBytes> {
-		const { bytes: signedBytes, signature: userSignature } =
-			await this.#ephemeralKeypair.signPersonalMessage(bytes);
-
-		const zkSignature = getZkLoginSignature({
-			inputs: this.#proof,
-			maxEpoch: this.#maxEpoch,
-			userSignature,
+		// Resolve the public key exactly as before — `fromProof` matches the proof against the
+		// supplied address and validates it — then bridge that to the base's `legacyAddress` flag.
+		const publicKey = EnokiPublicKey.fromProof(input.address, input.proof);
+		super({
+			ephemeralSigner: input.ephemeralKeypair,
+			maxEpoch: input.maxEpoch,
+			inputs: input.proof,
+			legacyAddress: publicKey.legacyAddress,
 		});
-
-		return {
-			bytes: signedBytes,
-			signature: zkSignature,
-		};
+		this.#publicKey = publicKey;
 	}
 
-	async signTransaction(bytes: Uint8Array): Promise<SignatureWithBytes> {
-		const { bytes: signedBytes, signature: userSignature } =
-			await this.#ephemeralKeypair.signTransaction(bytes);
-
-		const zkSignature = getZkLoginSignature({
-			inputs: this.#proof,
-			maxEpoch: this.#maxEpoch,
-			userSignature,
-		});
-
-		return {
-			bytes: signedBytes,
-			signature: zkSignature,
-		};
-	}
-
-	getKeyScheme() {
-		return this.#ephemeralKeypair.getKeyScheme();
-	}
-
-	getPublicKey() {
+	override getPublicKey(): EnokiPublicKey {
 		return this.#publicKey;
 	}
 }

--- a/packages/sui/src/zklogin/index.ts
+++ b/packages/sui/src/zklogin/index.ts
@@ -12,6 +12,8 @@ export {
 export { computeZkLoginAddressFromSeed, computeZkLoginAddress, jwtToAddress } from './address.js';
 export type { ComputeZkLoginAddressOptions } from './address.js';
 export { toZkLoginPublicIdentifier, ZkLoginPublicIdentifier } from './publickey.js';
+export { ZkLoginSigner } from './signer.js';
+export type { ZkLoginSignerOptions } from './signer.js';
 export type { ZkLoginSignatureInputs } from './bcs.js';
 export { poseidonHash } from './poseidon.js';
 export { generateNonce, generateRandomness } from './nonce.js';

--- a/packages/sui/src/zklogin/publickey.ts
+++ b/packages/sui/src/zklogin/publickey.ts
@@ -46,6 +46,13 @@ export class ZkLoginPublicIdentifier extends PublicKey {
 		}
 	}
 
+	/**
+	 * Whether this identifier resolves to the deprecated legacy address derivation.
+	 */
+	get legacyAddress(): boolean {
+		return this.#legacyAddress;
+	}
+
 	static fromBytes(
 		bytes: Uint8Array,
 		{

--- a/packages/sui/src/zklogin/signer.ts
+++ b/packages/sui/src/zklogin/signer.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ClientWithCoreApi } from '../client/core.js';
 import type { IntentScope } from '../cryptography/intent.js';
 import type { SignatureWithBytes } from '../cryptography/keypair.js';
 import { Signer } from '../cryptography/keypair.js';
@@ -21,8 +22,18 @@ export interface ZkLoginSignerOptions {
 	 * Whether this account uses the deprecated legacy address derivation. The zkLogin address is
 	 * derived from the proof inputs; this flag disambiguates legacy vs. current derivation, matching
 	 * the rest of the zkLogin address API (e.g. `jwtToAddress`, `toZkLoginPublicIdentifier`).
+	 *
+	 * A wrong flag silently yields a signer for the wrong address; pass `address` to guard against it.
 	 */
 	legacyAddress: boolean;
+	/**
+	 * The expected zkLogin address. When provided, the address derived from `inputs` + `legacyAddress`
+	 * is validated against it and the constructor throws on mismatch — guarding against a wrong
+	 * `legacyAddress` flag producing a signer for the wrong address.
+	 */
+	address?: string;
+	/** Optional client, threaded into the derived public key so it can verify signatures. */
+	client?: ClientWithCoreApi;
 }
 
 /**
@@ -37,18 +48,37 @@ export class ZkLoginSigner extends Signer {
 	#ephemeralSigner: Signer;
 	#maxEpoch: number;
 	#inputs: ZkLoginSignatureInputs;
-	#publicKey: ZkLoginPublicIdentifier;
+	#legacyAddress: boolean;
+	#client?: ClientWithCoreApi;
+	#publicKey?: ZkLoginPublicIdentifier;
 
 	constructor(options: ZkLoginSignerOptions) {
 		super();
 		this.#ephemeralSigner = options.ephemeralSigner;
 		this.#maxEpoch = options.maxEpoch;
 		this.#inputs = options.inputs;
-		this.#publicKey = toZkLoginPublicIdentifier(
-			BigInt(options.inputs.addressSeed),
-			extractClaimValue<string>(options.inputs.issBase64Details, 'iss'),
-			{ legacyAddress: options.legacyAddress },
-		);
+		this.#legacyAddress = options.legacyAddress;
+		this.#client = options.client;
+
+		if (options.address !== undefined) {
+			const derived = this.#derivePublicKey().toSuiAddress();
+			if (derived !== options.address) {
+				throw new Error(
+					`zkLogin proof does not match the provided address (derived ${derived}, expected ` +
+						`${options.address}) — check the \`legacyAddress\` flag`,
+				);
+			}
+		}
+	}
+
+	// Derived lazily and memoized so subclasses that override `getPublicKey()` (e.g. EnokiKeypair)
+	// don't pay for a derivation they never use.
+	#derivePublicKey(): ZkLoginPublicIdentifier {
+		return (this.#publicKey ??= toZkLoginPublicIdentifier(
+			BigInt(this.#inputs.addressSeed),
+			extractClaimValue<string>(this.#inputs.issBase64Details, 'iss'),
+			{ legacyAddress: this.#legacyAddress, client: this.#client },
+		));
 	}
 
 	/**
@@ -83,6 +113,6 @@ export class ZkLoginSigner extends Signer {
 	}
 
 	getPublicKey(): ZkLoginPublicIdentifier {
-		return this.#publicKey;
+		return this.#derivePublicKey();
 	}
 }

--- a/packages/sui/src/zklogin/signer.ts
+++ b/packages/sui/src/zklogin/signer.ts
@@ -71,8 +71,11 @@ export class ZkLoginSigner extends Signer {
 		}
 	}
 
-	// Derived lazily and memoized so subclasses that override `getPublicKey()` (e.g. EnokiKeypair)
-	// don't pay for a derivation they never use.
+	// Shared derive-and-memoize used by both the constructor's address validation and getPublicKey().
+	// It is `#private` (non-virtual) on purpose: the constructor must derive the *base* address even
+	// when a subclass overrides getPublicKey() — calling the overridable getPublicKey() from the
+	// constructor would dispatch to the subclass before its fields are initialized. Laziness also
+	// means subclasses that override getPublicKey() (e.g. EnokiKeypair) never pay for this derivation.
 	#derivePublicKey(): ZkLoginPublicIdentifier {
 		return (this.#publicKey ??= toZkLoginPublicIdentifier(
 			BigInt(this.#inputs.addressSeed),

--- a/packages/sui/src/zklogin/signer.ts
+++ b/packages/sui/src/zklogin/signer.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { IntentScope } from '../cryptography/intent.js';
+import type { SignatureWithBytes } from '../cryptography/keypair.js';
+import { Signer } from '../cryptography/keypair.js';
+import type { SignatureScheme } from '../cryptography/signature-scheme.js';
+import type { ZkLoginSignatureInputs } from './bcs.js';
+import { extractClaimValue } from './jwt-utils.js';
+import { toZkLoginPublicIdentifier, ZkLoginPublicIdentifier } from './publickey.js';
+import { getZkLoginSignature } from './signature.js';
+
+export interface ZkLoginSignerOptions {
+	/** The ephemeral signer whose signature is wrapped by the zkLogin proof. */
+	ephemeralSigner: Signer;
+	/** The maxEpoch the proof was generated for. */
+	maxEpoch: number;
+	/** The zkLogin proof inputs, including the `addressSeed`. */
+	inputs: ZkLoginSignatureInputs;
+	/**
+	 * Whether this account uses the deprecated legacy address derivation. The zkLogin address is
+	 * derived from the proof inputs; this flag disambiguates legacy vs. current derivation, matching
+	 * the rest of the zkLogin address API (e.g. `jwtToAddress`, `toZkLoginPublicIdentifier`).
+	 */
+	legacyAddress: boolean;
+}
+
+/**
+ * A transport- and provider-agnostic zkLogin signer.
+ *
+ * It wraps any ephemeral {@link Signer} and, for every signing operation, transforms the ephemeral
+ * signature into a zkLogin signature using the supplied proof inputs and `maxEpoch`. Because every
+ * signing method on {@link Signer} funnels through `signWithIntent`, overriding that single method is
+ * enough to cover `signTransaction`, `signPersonalMessage`, and `signAndExecuteTransaction`.
+ */
+export class ZkLoginSigner extends Signer {
+	#ephemeralSigner: Signer;
+	#maxEpoch: number;
+	#inputs: ZkLoginSignatureInputs;
+	#publicKey: ZkLoginPublicIdentifier;
+
+	constructor(options: ZkLoginSignerOptions) {
+		super();
+		this.#ephemeralSigner = options.ephemeralSigner;
+		this.#maxEpoch = options.maxEpoch;
+		this.#inputs = options.inputs;
+		this.#publicKey = toZkLoginPublicIdentifier(
+			BigInt(options.inputs.addressSeed),
+			extractClaimValue<string>(options.inputs.issBase64Details, 'iss'),
+			{ legacyAddress: options.legacyAddress },
+		);
+	}
+
+	/**
+	 * The single extension point: the ephemeral signature is produced with the requested intent and
+	 * then wrapped in a zkLogin signature.
+	 */
+	override async signWithIntent(
+		bytes: Uint8Array,
+		intent: IntentScope,
+	): Promise<SignatureWithBytes> {
+		const { bytes: signedBytes, signature: userSignature } =
+			await this.#ephemeralSigner.signWithIntent(bytes, intent);
+
+		return {
+			bytes: signedBytes,
+			signature: getZkLoginSignature({
+				inputs: this.#inputs,
+				maxEpoch: this.#maxEpoch,
+				userSignature,
+			}),
+		};
+	}
+
+	sign(_data: Uint8Array): never {
+		throw new Error(
+			'ZkLoginSigner does not support signing directly. Use signTransaction or signPersonalMessage instead',
+		);
+	}
+
+	getKeyScheme(): SignatureScheme {
+		return 'ZkLogin';
+	}
+
+	getPublicKey(): ZkLoginPublicIdentifier {
+		return this.#publicKey;
+	}
+}

--- a/packages/sui/test/unit/zklogin/signer.test.ts
+++ b/packages/sui/test/unit/zklogin/signer.test.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { toBase64 } from '@mysten/bcs';
+import { bcs, fromBase64, toBase64 } from '@mysten/bcs';
 import { describe, expect, test } from 'vitest';
 
 import type { IntentScope } from '../../../src/cryptography/intent.js';
 import type { SignatureWithBytes } from '../../../src/cryptography/keypair.js';
 import { Signer } from '../../../src/cryptography/keypair.js';
 import { Ed25519Keypair } from '../../../src/keypairs/ed25519/index.js';
-import { toZkLoginPublicIdentifier } from '../../../src/zklogin/index.js';
+import { parseZkLoginSignature, toZkLoginPublicIdentifier } from '../../../src/zklogin/index.js';
 import { extractClaimValue } from '../../../src/zklogin/jwt-utils.js';
 import { ZkLoginSigner } from '../../../src/zklogin/signer.js';
 
@@ -73,6 +73,26 @@ class FixedEphemeralSigner extends Signer {
 	}
 }
 
+// A real ephemeral signer that records the (bytes, intent) it is asked to sign, so we can assert the
+// base-class routing (byteVector wrapping for personal messages, correct intents) actually happens.
+class RecordingSigner extends Signer {
+	calls: { bytes: Uint8Array; intent: IntentScope }[] = [];
+	#inner = new Ed25519Keypair();
+	sign(data: Uint8Array) {
+		return this.#inner.sign(data);
+	}
+	override signWithIntent(bytes: Uint8Array, intent: IntentScope): Promise<SignatureWithBytes> {
+		this.calls.push({ bytes, intent });
+		return this.#inner.signWithIntent(bytes, intent);
+	}
+	getKeyScheme() {
+		return this.#inner.getKeyScheme();
+	}
+	getPublicKey() {
+		return this.#inner.getPublicKey();
+	}
+}
+
 function makeSigner(legacyAddress = false) {
 	return new ZkLoginSigner({
 		ephemeralSigner: new FixedEphemeralSigner(),
@@ -84,14 +104,19 @@ function makeSigner(legacyAddress = false) {
 
 describe('ZkLoginSigner', () => {
 	test('signTransaction wraps the ephemeral signature in a zkLogin signature', async () => {
-		const { signature } = await makeSigner().signTransaction(new Uint8Array([1, 2, 3]));
+		const tx = new Uint8Array([1, 2, 3]);
+		const { bytes, signature } = await makeSigner().signTransaction(tx);
 		expect(signature).toBe(aSignature);
+		expect(bytes).toBe(toBase64(tx));
 	});
 
 	test('signPersonalMessage also produces a zkLogin signature', async () => {
-		const { signature } = await makeSigner().signPersonalMessage(new Uint8Array([1, 2, 3]));
+		const message = new Uint8Array([1, 2, 3]);
+		const { bytes, signature } = await makeSigner().signPersonalMessage(message);
 		// Both intents wrap the same fixed ephemeral signature with the same proof inputs.
 		expect(signature).toBe(aSignature);
+		// The returned bytes are the original message, not the byteVector-wrapped form.
+		expect(bytes).toBe(toBase64(message));
 	});
 
 	test('derives the current (non-legacy) address from the proof', () => {
@@ -108,6 +133,107 @@ describe('ZkLoginSigner', () => {
 	test('derives the legacy address from the proof when legacyAddress is true', () => {
 		const signer = makeSigner(true);
 		expect(signer.getPublicKey().toSuiAddress()).toBe(anAddress);
+	});
+
+	test('propagates legacyAddress into derivation (legacy and current differ for a short seed)', () => {
+		// A small addressSeed whose big-endian form is < 32 bytes, so the legacy (trimmed) and current
+		// (zero-padded) derivations genuinely diverge — unlike the 32-byte fixture seed above, which
+		// produces the same address either way.
+		const inputs = { ...aSignatureInputs, addressSeed: '12345' };
+		const iss = extractClaimValue<string>(inputs.issBase64Details, 'iss');
+		const seed = BigInt(inputs.addressSeed);
+
+		const legacy = new ZkLoginSigner({
+			ephemeralSigner: new FixedEphemeralSigner(),
+			maxEpoch,
+			inputs,
+			legacyAddress: true,
+		});
+		const current = new ZkLoginSigner({
+			ephemeralSigner: new FixedEphemeralSigner(),
+			maxEpoch,
+			inputs,
+			legacyAddress: false,
+		});
+
+		expect(legacy.getPublicKey().toSuiAddress()).not.toBe(current.getPublicKey().toSuiAddress());
+		expect(legacy.getPublicKey().toSuiAddress()).toBe(
+			toZkLoginPublicIdentifier(seed, iss, { legacyAddress: true }).toSuiAddress(),
+		);
+		expect(current.getPublicKey().toSuiAddress()).toBe(
+			toZkLoginPublicIdentifier(seed, iss, { legacyAddress: false }).toSuiAddress(),
+		);
+	});
+
+	test('routes intents and bytes to the ephemeral signer (personal message is byteVector-wrapped)', async () => {
+		const ephemeral = new RecordingSigner();
+		const signer = new ZkLoginSigner({
+			ephemeralSigner: ephemeral,
+			maxEpoch,
+			inputs: aSignatureInputs,
+			legacyAddress: false,
+		});
+
+		const tx = new Uint8Array([1, 2, 3, 4]);
+		await signer.signTransaction(tx);
+		expect(ephemeral.calls.at(-1)).toEqual({ bytes: tx, intent: 'TransactionData' });
+
+		const message = new Uint8Array([9, 8, 7]);
+		await signer.signPersonalMessage(message);
+		expect(ephemeral.calls.at(-1)).toEqual({
+			bytes: bcs.byteVector().serialize(message).toBytes(),
+			intent: 'PersonalMessage',
+		});
+	});
+
+	test('wraps the real ephemeral signWithIntent output as the zkLogin userSignature', async () => {
+		const ephemeral = new Ed25519Keypair();
+		const signer = new ZkLoginSigner({
+			ephemeralSigner: ephemeral,
+			maxEpoch,
+			inputs: aSignatureInputs,
+			legacyAddress: false,
+		});
+
+		const tx = new Uint8Array([1, 2, 3, 4]);
+		const { signature } = await signer.signTransaction(tx);
+
+		const parsed = parseZkLoginSignature(fromBase64(signature).slice(1));
+		expect(String(parsed.maxEpoch)).toBe(String(maxEpoch));
+		expect(parsed.inputs.addressSeed).toBe(aSignatureInputs.addressSeed);
+
+		// Ed25519 is deterministic, so re-signing the same (bytes, intent) reproduces the embedded sig.
+		const direct = await ephemeral.signWithIntent(tx, 'TransactionData');
+		expect(toBase64(parsed.userSignature)).toBe(direct.signature);
+	});
+
+	test('validates a provided address and throws on mismatch', () => {
+		const iss = extractClaimValue<string>(aSignatureInputs.issBase64Details, 'iss');
+		const address = toZkLoginPublicIdentifier(BigInt(aSignatureInputs.addressSeed), iss, {
+			legacyAddress: false,
+		}).toSuiAddress();
+
+		expect(
+			() =>
+				new ZkLoginSigner({
+					ephemeralSigner: new FixedEphemeralSigner(),
+					maxEpoch,
+					inputs: aSignatureInputs,
+					legacyAddress: false,
+					address,
+				}),
+		).not.toThrow();
+
+		expect(
+			() =>
+				new ZkLoginSigner({
+					ephemeralSigner: new FixedEphemeralSigner(),
+					maxEpoch,
+					inputs: aSignatureInputs,
+					legacyAddress: false,
+					address: '0x0000000000000000000000000000000000000000000000000000000000000000',
+				}),
+		).toThrow(/does not match the provided address/);
 	});
 
 	test('reports the ZkLogin key scheme', () => {

--- a/packages/sui/test/unit/zklogin/signer.test.ts
+++ b/packages/sui/test/unit/zklogin/signer.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toBase64 } from '@mysten/bcs';
+import { describe, expect, test } from 'vitest';
+
+import type { IntentScope } from '../../../src/cryptography/intent.js';
+import type { SignatureWithBytes } from '../../../src/cryptography/keypair.js';
+import { Signer } from '../../../src/cryptography/keypair.js';
+import { Ed25519Keypair } from '../../../src/keypairs/ed25519/index.js';
+import { toZkLoginPublicIdentifier } from '../../../src/zklogin/index.js';
+import { extractClaimValue } from '../../../src/zklogin/jwt-utils.js';
+import { ZkLoginSigner } from '../../../src/zklogin/signer.js';
+
+// A real proof fixture: signing `anEphemeralSignature` with these inputs / maxEpoch produces `aSignature`.
+const aSignature =
+	'BQNNMTE3MDE4NjY4MTI3MDQ1MTcyMTM5MTQ2MTI3OTg2NzQ3NDg2NTc3NTU1NjY1ODY1OTc0MzQ4MTA5NDEyNDA0ODMzNDY3NjkzNjkyNjdNMTQxMjA0Mzg5OTgwNjM2OTIyOTczODYyNDk3NTQyMzA5NzI3MTUxNTM4NzY1Mzc1MzAxNjg4ODM5ODE1MTM1ODQ1ODYxNzIxOTU4NDEBMQMCTDE4Njc0NTQ1MDE2MDI1ODM4NDg4NTI3ODc3ODI3NjE5OTY1NjAxNzAxMTgyNDkyOTk1MDcwMTQ5OTkyMzA4ODY4NTI1NTY5OTgyNzNNMTQ0NjY0MTk2OTg2NzkxMTYzMTM0NzUyMTA2NTQ1NjI5NDkxMjgzNDk1OTcxMDE3NjkyNTY5NTkwMTAwMDMxODg4ODYwOTEwODAzMTACTTExMDcyOTU0NTYyOTI0NTg4NDk2MTQ4NjMyNDc0MDc4NDMyNDA2NjMzMjg4OTQ4MjU2NzE4ODA5NzE0ODYxOTg2MTE5MzAzNTI5NzYwTTE5NzkwNTE2MDEwNzg0OTM1MTAwMTUwNjE0OTg5MDk3OTA4MjMzODk5NzE4NjQ1NTM2MTMwNzI3NzczNzEzNDA3NjExMTYxMzY4MDQ2AgExATADTTEwNDIzMjg5MDUxODUzMDMzOTE1MzgwODEwNTE2MTMwMjA1NzQ3MTgyODY3NTk2NDU3MTM5OTk5MTc2NzE0NDc2NDE1MTQ4Mzc2MzUwTTIxNzg1NzE5Njk1ODQ4MDEzOTA4MDYxNDkyOTg5NzY1Nzc3Nzg4MTQyMjU1ODk3OTg2MzAwMjQxNTYxMjgwMTk2NzQ1MTc0OTM0NDU3ATExeUpwYzNNaU9pSm9kSFJ3Y3pvdkwyRmpZMjkxYm5SekxtZHZiMmRzWlM1amIyMGlMQwFmZXlKaGJHY2lPaUpTVXpJMU5pSXNJbXRwWkNJNkltSTVZV00yTURGa01UTXhabVEwWm1aa05UVTJabVl3TXpKaFlXSXhPRGc0T0RCalpHVXpZamtpTENKMGVYQWlPaUpLVjFRaWZRTTEzMzIyODk3OTMwMTYzMjE4NTMyMjY2NDMwNDA5NTEwMzk0MzE2OTg1Mjc0NzY5MTI1NjY3MjkwNjAwMzIxNTY0MjU5NDY2NTExNzExrgAAAAAAAABhAEp+O5GEAF/5tKNDdWBObNf/1uIrbOJmE+xpnlBD2Vikqhbd0zLrQ2NJyquYXp4KrvWUOl7Hso+OK0eiV97ffwucM8VdtG2hjf/RUGNO5JNUH+D/gHtE9sHe6ZEnxwZL7g==';
+const aSignatureInputs = {
+	addressSeed: '13322897930163218532266430409510394316985274769125667290600321564259466511711',
+	headerBase64:
+		'eyJhbGciOiJSUzI1NiIsImtpZCI6ImI5YWM2MDFkMTMxZmQ0ZmZkNTU2ZmYwMzJhYWIxODg4ODBjZGUzYjkiLCJ0eXAiOiJKV1QifQ',
+	issBase64Details: {
+		indexMod4: 1,
+		value: 'yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC',
+	},
+	proofPoints: {
+		a: [
+			'11701866812704517213914612798674748657755566586597434810941240483346769369267',
+			'14120438998063692297386249754230972715153876537530168883981513584586172195841',
+			'1',
+		],
+		b: [
+			[
+				'1867454501602583848852787782761996560170118249299507014999230886852556998273',
+				'14466419698679116313475210654562949128349597101769256959010003188886091080310',
+			],
+			[
+				'11072954562924588496148632474078432406633288948256718809714861986119303529760',
+				'19790516010784935100150614989097908233899718645536130727773713407611161368046',
+			],
+			['1', '0'],
+		],
+		c: [
+			'10423289051853033915380810516130205747182867596457139999176714476415148376350',
+			'21785719695848013908061492989765777788142255897986300241561280196745174934457',
+			'1',
+		],
+	},
+};
+const anEphemeralSignature =
+	'AEp+O5GEAF/5tKNDdWBObNf/1uIrbOJmE+xpnlBD2Vikqhbd0zLrQ2NJyquYXp4KrvWUOl7Hso+OK0eiV97ffwucM8VdtG2hjf/RUGNO5JNUH+D/gHtE9sHe6ZEnxwZL7g==';
+// The legacy zkLogin address for the fixture's addressSeed + google issuer.
+const anAddress = '0xf7badc2b245c7f74d7509a4aa357ecf80a29e7713fb4c44b0e7541ec43885ee1';
+const maxEpoch = 174;
+
+// An ephemeral signer that returns a fixed, known signature so the wrapped output is deterministic.
+class FixedEphemeralSigner extends Signer {
+	#inner = new Ed25519Keypair();
+	sign(data: Uint8Array) {
+		return this.#inner.sign(data);
+	}
+	override async signWithIntent(
+		bytes: Uint8Array,
+		_intent: IntentScope,
+	): Promise<SignatureWithBytes> {
+		return { bytes: toBase64(bytes), signature: anEphemeralSignature };
+	}
+	getKeyScheme() {
+		return this.#inner.getKeyScheme();
+	}
+	getPublicKey() {
+		return this.#inner.getPublicKey();
+	}
+}
+
+function makeSigner(legacyAddress = false) {
+	return new ZkLoginSigner({
+		ephemeralSigner: new FixedEphemeralSigner(),
+		maxEpoch,
+		inputs: aSignatureInputs,
+		legacyAddress,
+	});
+}
+
+describe('ZkLoginSigner', () => {
+	test('signTransaction wraps the ephemeral signature in a zkLogin signature', async () => {
+		const { signature } = await makeSigner().signTransaction(new Uint8Array([1, 2, 3]));
+		expect(signature).toBe(aSignature);
+	});
+
+	test('signPersonalMessage also produces a zkLogin signature', async () => {
+		const { signature } = await makeSigner().signPersonalMessage(new Uint8Array([1, 2, 3]));
+		// Both intents wrap the same fixed ephemeral signature with the same proof inputs.
+		expect(signature).toBe(aSignature);
+	});
+
+	test('derives the current (non-legacy) address from the proof', () => {
+		const iss = extractClaimValue<string>(aSignatureInputs.issBase64Details, 'iss');
+		const expected = toZkLoginPublicIdentifier(BigInt(aSignatureInputs.addressSeed), iss, {
+			legacyAddress: false,
+		}).toSuiAddress();
+
+		const signer = makeSigner(false);
+		expect(signer.getPublicKey().toSuiAddress()).toBe(expected);
+		expect(signer.toSuiAddress()).toBe(expected);
+	});
+
+	test('derives the legacy address from the proof when legacyAddress is true', () => {
+		const signer = makeSigner(true);
+		expect(signer.getPublicKey().toSuiAddress()).toBe(anAddress);
+	});
+
+	test('reports the ZkLogin key scheme', () => {
+		expect(makeSigner().getKeyScheme()).toBe('ZkLogin');
+	});
+
+	test('sign() throws — a raw signature is not a valid zkLogin signature', () => {
+		expect(() => makeSigner().sign(new Uint8Array([1, 2, 3]))).toThrow(/does not support signing/);
+	});
+});


### PR DESCRIPTION
## Description

Adds a transport- and provider-agnostic **`ZkLoginSigner`** to `@mysten/sui/zklogin`, and rebases `@mysten/enoki`'s `EnokiKeypair` onto it.

### Motivation

zkLogin signatures wrap an ephemeral ed25519 signature in a proof envelope (`getZkLoginSignature`). Today the only ready-made zkLogin signer lives in `@mysten/enoki` and is coupled to the Enoki flow — anyone obtaining a proof from another prover has to hand-roll the wrapping. The [EVE Frontier wallet-core](https://github.com/evefrontier/wallet-core) team did exactly that, using a mixin to graft zkLogin wrapping onto arbitrary signer classes. This PR fills that gap in core with a composition-based signer that works for any ephemeral `Signer` (so no mixin is needed), and folds `EnokiKeypair` into it.

### What's added

- **`ZkLoginSigner`** wraps any ephemeral `Signer`. It overrides `signWithIntent` **once** — since `signTransaction`, `signPersonalMessage`, and `signAndExecuteTransaction` all funnel through it, that single override covers every path (and removes the duplicated wrapping `EnokiKeypair` had).
- Construction: `new ZkLoginSigner({ ephemeralSigner, maxEpoch, inputs, legacyAddress })`. The address is **derived from the proof** (`addressSeed` + issuer); `legacyAddress` is a **required boolean**, consistent with the rest of the zkLogin address API (`jwtToAddress`, `computeZkLoginAddress`, `toZkLoginPublicIdentifier` — all required booleans that refuse to guess). No externally-obtained address is needed.
- Following the **`MultiSigSigner`** precedent for composite signers: `sign()` throws (a raw ephemeral signature is not valid for the zkLogin address), and `getKeyScheme()` returns `'ZkLogin'`.
- Adds a read-only `legacyAddress` getter to `ZkLoginPublicIdentifier`.
- **`EnokiKeypair`** now `extends ZkLoginSigner`. It keeps resolving its public key via `EnokiPublicKey.fromProof(address, proof)` (unchanged — same legacy auto-detection and proof/address validation) and bridges that to the base `legacyAddress` flag.

### Enoki API: verified byte-identical

The Enoki rebase was checked against a reconstruction of the previous implementation, for **both a legacy and a current address** (using a leading-zero seed so the two derivations genuinely diverge). Identical in every case:

- `getPublicKey().toSuiAddress()`, `.toRawBytes()`, `.flag()`, `.legacyAddress`
- `signTransaction()` and `signPersonalMessage()` output

The constructor signature, `getPublicKey()` (still an `EnokiPublicKey`), and `EnokiPublicKey` export are unchanged. Two previously-broken inherited behaviors are corrected (no caller in the repo depends on them): `getKeyScheme()` → `'ZkLogin'` (was the ephemeral scheme), and `sign()` now throws (was returning a bare ephemeral signature that never verified against the zkLogin address).

### Non-goals

- No mutable "attach proof after construction" mode — the signer is immutable; construct it once the proof is available.
- No mixin — composition over `Signer` covers every ephemeral scheme.

## Test plan

- New unit tests in `packages/sui/test/unit/zklogin/signer.test.ts` (real proof fixture): `signTransaction` / `signPersonalMessage` produce the expected zkLogin signature; the address derives from the proof for both `legacyAddress` values; `getKeyScheme()` is `'ZkLogin'`; `sign()` throws. 6 passing.
- Old-vs-new `EnokiKeypair` parity verified byte-for-byte (see above) for legacy and current addresses.
- `turbo build` for `@mysten/sui` and `@mysten/enoki` pass (typecheck clean); prettier + oxlint clean.

---

### AI Assistance Notice

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.