### PR TITLE
docs: add signers section and restructure cryptography docs

### DIFF
--- a/packages/docs/content/sui/cryptography/_meta.json
+++ b/packages/docs/content/sui/cryptography/_meta.json
@@ -1,6 +1,0 @@
-{
-	"keypairs": "Key pairs",
-	"multisig": "Multi-Signature Transactions",
-	"passkey": "Passkey",
-	"webcrypto-signer": "Web Crypto Signer"
-}

--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -90,6 +90,10 @@ const message = new TextEncoder().encode('hello world');
 const { signature } = await keypair.signPersonalMessage(message);
 ```
 
+Both `signPersonalMessage` and `signTransaction` resolve to `{ bytes, signature }`, where
+`signature` is the serialized signature string used for execution and verification, and `bytes` is
+the base64 payload that was signed.
+
 To sign and submit a transaction in one step, pass the signer to a client:
 
 ```typescript
@@ -100,10 +104,17 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
 
-const { digest } = await client.signAndExecuteTransaction({
+const result = await client.signAndExecuteTransaction({
 	transaction,
 	signer: keypair,
 });
+
+// signAndExecuteTransaction resolves to a discriminated union — check for failure first
+if (result.FailedTransaction) {
+	throw new Error('Transaction failed to execute');
+}
+
+console.log('Digest:', result.Transaction.digest);
 ```
 
 ## Verifying signatures

--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -1,21 +1,19 @@
 ---
 title: Cryptography
-description:
-  Sign and verify Sui transactions and personal messages with keypairs, multisig, passkeys, and
-  external signers
+description: Sign and verify Sui transactions and messages with keypairs and external signers
 keywords: [cryptography, signing, Signer, Keypair, public key, verification, multisig, passkey, Sui]
 ---
 
-Every transaction and personal message on Sui is authorized by a signature. The Sui TypeScript SDK
-exposes a single abstraction for producing those signatures — the `Signer` — and several
+A signature authorizes every transaction and personal message on Sui. The Sui TypeScript SDK exposes
+a single abstraction for producing those signatures, the `Signer`, along with several
 implementations of it, from in-process keypairs to hardware wallets and cloud key-management
 services (KMS). This page walks through the concepts shared by every signer; the subpages cover each
 implementation in detail.
 
 ## Signing schemes
 
-A signature is always produced under a signature scheme, which determines the curve and signature
-format. Sui supports three schemes, each with a corresponding `Keypair` class:
+A signer always produces a signature under a signature scheme, which determines the curve and
+signature format. Sui supports three schemes, each with a corresponding `Keypair` class:
 
 | Scheme          | Class              | Import                           |
 | --------------- | ------------------ | -------------------------------- |
@@ -25,12 +23,12 @@ format. Sui supports three schemes, each with a corresponding `Keypair` class:
 
 For background on the schemes themselves, see the
 [Signatures](https://docs.sui.io/concepts/cryptography/transaction-auth/signatures) concept topic. A
-signer's scheme determines the format of its public key and the Sui address derived from it.
+signer's scheme determines the format of its public key and the Sui address it derives.
 
 ## The Signer interface
 
-`Signer` is an abstract class exported from `@mysten/sui/cryptography`. Every signer — whether it
-holds the private key in memory, on a Ledger device, or in AWS KMS — implements the same interface,
+`Signer` is an abstract class exported from `@mysten/sui/cryptography`. Every signer, whether it
+holds the private key in memory, on a Ledger device, or in AWS KMS, implements the same interface,
 so the rest of your code doesn't need to know where the key lives.
 
 Implementations provide three primitives:
@@ -54,13 +52,13 @@ There are two broad families of signer:
 
 - **Key pairs** hold the private key in process. `Keypair` extends `Signer` and adds secret-key
   import/export (`getSecretKey`, `fromSecretKey`). This is the simplest option for scripts,
-  backends, and tests — see [Key pairs](/sui/cryptography/keypairs).
+  backends, and tests. See [Key pairs](/sui/cryptography/keypairs).
 - **External signers** keep the private key outside your application, in a KMS, on a hardware
-  wallet, or as a non-extractable browser key. They extend `Signer` directly — see
+  wallet, or as a non-extractable browser key. They extend `Signer` directly. See
   [Signers](/sui/cryptography/signers).
 
-Because both families share the `Signer` interface, any signer can be passed wherever the SDK
-accepts one — for example, as the `signer` argument to a client's `signAndExecuteTransaction`.
+Because both families share the `Signer` interface, you can pass any signer wherever the SDK accepts
+one, for example as the `signer` argument to a client's `signAndExecuteTransaction`.
 
 ## Public keys and addresses
 
@@ -82,7 +80,7 @@ const sameAddress = publicKey.toSuiAddress();
 
 ## Signing messages and transactions
 
-The signing API is identical for every signer — only construction differs. Use `signPersonalMessage`
+The signing API is identical for every signer; only construction differs. Use `signPersonalMessage`
 to sign arbitrary bytes and `signTransaction` to sign built transaction bytes:
 
 ```typescript
@@ -92,7 +90,7 @@ const { signature } = await keypair.signPersonalMessage(message);
 
 Both `signPersonalMessage` and `signTransaction` resolve to `{ bytes, signature }`, where
 `signature` is the serialized signature string used for execution and verification, and `bytes` is
-the base64 payload that was signed.
+the base64 payload that the signer signed.
 
 To sign and submit a transaction in one step, pass the signer to a client:
 
@@ -109,7 +107,7 @@ const result = await client.signAndExecuteTransaction({
 	signer: keypair,
 });
 
-// signAndExecuteTransaction resolves to a discriminated union — check for failure first
+// signAndExecuteTransaction resolves to a discriminated union, so check for failure first
 if (result.FailedTransaction) {
 	throw new Error('Transaction failed to execute');
 }
@@ -119,9 +117,9 @@ console.log('Digest:', result.Transaction.digest);
 
 ## Verifying signatures
 
-Verification ensures a signature is valid for a given message and was produced by the expected key.
-The `@mysten/sui/verify` module verifies a signature against a message and recovers the `PublicKey`
-that produced it — without needing the original signer.
+Verification confirms a signature is valid for a given message and that the expected key produced
+it. The `@mysten/sui/verify` module verifies a signature against a message and recovers the
+`PublicKey` that produced it, without needing the original signer.
 
 ```typescript
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
@@ -185,7 +183,7 @@ await verifyTransactionSignature(bytes, signature, {
 
 ### Verifying zkLogin signatures
 
-zkLogin signatures can't be verified purely on the client. When verifying a zkLogin signature, the
+You can't verify zkLogin signatures purely on the client. When verifying a zkLogin signature, the
 SDK uses the GraphQL API. This works for Mainnet signatures without any additional configuration.
 For Testnet signatures, provide a Testnet GraphQL client:
 
@@ -227,18 +225,18 @@ Both methods check the signature against the standard and
 
 ## Choosing an implementation
 
-- **[Key pairs](/sui/cryptography/keypairs)** — `Ed25519Keypair`, `Secp256k1Keypair`, and
+- **[Key pairs](/sui/cryptography/keypairs)**: `Ed25519Keypair`, `Secp256k1Keypair`, and
   `Secp256r1Keypair` hold the private key in process. The simplest option when you manage the secret
   key yourself. Covers deriving keypairs from mnemonics and secret keys.
-- **[Multi-signature](/sui/cryptography/multisig)** — combine signatures from several public keys
+- **[Multi-signature](/sui/cryptography/multisig)**: combine signatures from several public keys
   under a configurable threshold using `MultiSigPublicKey`.
-- **[Passkey](/sui/cryptography/passkey)** — sign with a WebAuthn passkey (biometric / platform
-  authenticator) via `PasskeyKeypair`.
-- **[Signers](/sui/cryptography/signers)** — external signer packages that keep the private key
-  outside your application: cloud KMS ([AWS](/sui/cryptography/signers/aws-kms),
+- **[Passkey](/sui/cryptography/passkey)**: sign with a WebAuthn passkey (biometric or platform
+  authenticator) through `PasskeyKeypair`.
+- **[Signers](/sui/cryptography/signers)**: external signer packages that keep the private key
+  outside your application, including cloud KMS ([AWS](/sui/cryptography/signers/aws-kms),
   [GCP](/sui/cryptography/signers/gcp-kms)), a [Ledger](/sui/cryptography/signers/ledger) hardware
-  wallet, or non-extractable browser keys with the [Web Crypto](/sui/cryptography/signers/webcrypto)
-  signer.
+  wallet, and non-extractable browser keys with the
+  [Web Crypto](/sui/cryptography/signers/webcrypto) signer.
 
 If you just need to sign in a script or server and are comfortable managing the secret key yourself,
 start with [Key pairs](/sui/cryptography/keypairs). If the key must never live in your application's

--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -51,8 +51,8 @@ On top of those, `Signer` provides the methods you typically call:
 There are two broad families of signer:
 
 - **Key pairs** hold the private key in process. `Keypair` extends `Signer` and adds secret-key
-  import/export (`getSecretKey`, `fromSecretKey`). This is the simplest option for scripts,
-  backends, and tests. See [Key pairs](/sui/cryptography/keypairs).
+  import/export (`getSecretKey`, `fromSecretKey`). This is the easiest option for scripts, backends,
+  and tests. See [Key pairs](/sui/cryptography/keypairs).
 - **External signers** keep the private key outside your application, in a KMS, on a hardware
   wallet, or as a non-extractable browser key. They extend `Signer` directly. See
   [Signers](/sui/cryptography/signers).
@@ -226,7 +226,7 @@ Both methods check the signature against the standard and
 ## Choosing an implementation
 
 - **[Key pairs](/sui/cryptography/keypairs)**: `Ed25519Keypair`, `Secp256k1Keypair`, and
-  `Secp256r1Keypair` hold the private key in process. The simplest option when you manage the secret
+  `Secp256r1Keypair` hold the private key in process. The easiest option when you manage the secret
   key yourself. Covers deriving keypairs from mnemonics and secret keys.
 - **[Multi-signature](/sui/cryptography/multisig)**: combine signatures from several public keys
   under a configurable threshold using `MultiSigPublicKey`.

--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -1,0 +1,234 @@
+---
+title: Cryptography
+description:
+  Sign and verify Sui transactions and personal messages with keypairs, multisig, passkeys, and
+  external signers
+keywords: [cryptography, signing, Signer, Keypair, public key, verification, multisig, passkey, Sui]
+---
+
+Every transaction and personal message on Sui is authorized by a signature. The Sui TypeScript SDK
+exposes a single abstraction for producing those signatures — the `Signer` — and several
+implementations of it, from in-process keypairs to hardware wallets and cloud key-management
+services (KMS). This page walks through the concepts shared by every signer; the subpages cover each
+implementation in detail.
+
+## Signing schemes
+
+A signature is always produced under a signature scheme, which determines the curve and signature
+format. Sui supports three schemes, each with a corresponding `Keypair` class:
+
+| Scheme          | Class              | Import                           |
+| --------------- | ------------------ | -------------------------------- |
+| Ed25519         | `Ed25519Keypair`   | `@mysten/sui/keypairs/ed25519`   |
+| ECDSA Secp256k1 | `Secp256k1Keypair` | `@mysten/sui/keypairs/secp256k1` |
+| ECDSA Secp256r1 | `Secp256r1Keypair` | `@mysten/sui/keypairs/secp256r1` |
+
+For background on the schemes themselves, see the
+[Signatures](https://docs.sui.io/concepts/cryptography/transaction-auth/signatures) concept topic. A
+signer's scheme determines the format of its public key and the Sui address derived from it.
+
+## The Signer interface
+
+`Signer` is an abstract class exported from `@mysten/sui/cryptography`. Every signer — whether it
+holds the private key in memory, on a Ledger device, or in AWS KMS — implements the same interface,
+so the rest of your code doesn't need to know where the key lives.
+
+Implementations provide three primitives:
+
+| Method           | Description                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `getPublicKey()` | Returns the `PublicKey` for deriving the address and verifying     |
+| `getKeyScheme()` | Returns the signature scheme (`ED25519`, `Secp256k1`, `Secp256r1`) |
+| `sign(bytes)`    | Signs raw bytes and returns the signature                          |
+
+On top of those, `Signer` provides the methods you typically call:
+
+| Method                        | Description                                      |
+| ----------------------------- | ------------------------------------------------ |
+| `toSuiAddress()`              | The Sui address derived from the public key      |
+| `signTransaction(bytes)`      | Signs transaction bytes with the correct intent  |
+| `signPersonalMessage(bytes)`  | Signs a personal message                         |
+| `signAndExecuteTransaction()` | Signs and submits a transaction through a client |
+
+There are two broad families of signer:
+
+- **Key pairs** hold the private key in process. `Keypair` extends `Signer` and adds secret-key
+  import/export (`getSecretKey`, `fromSecretKey`). This is the simplest option for scripts,
+  backends, and tests — see [Key pairs](/sui/cryptography/keypairs).
+- **External signers** keep the private key outside your application, in a KMS, on a hardware
+  wallet, or as a non-extractable browser key. They extend `Signer` directly — see
+  [Signers](/sui/cryptography/signers).
+
+Because both families share the `Signer` interface, any signer can be passed wherever the SDK
+accepts one — for example, as the `signer` argument to a client's `signAndExecuteTransaction`.
+
+## Public keys and addresses
+
+Every signer exposes a `PublicKey` through `getPublicKey()`. You use the public key to derive the
+signer's Sui address and to verify signatures:
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+
+const keypair = new Ed25519Keypair();
+
+// Derive the address directly from the signer...
+const address = keypair.toSuiAddress();
+
+// ...or from its public key
+const publicKey = keypair.getPublicKey();
+const sameAddress = publicKey.toSuiAddress();
+```
+
+## Signing messages and transactions
+
+The signing API is identical for every signer — only construction differs. Use `signPersonalMessage`
+to sign arbitrary bytes and `signTransaction` to sign built transaction bytes:
+
+```typescript
+const message = new TextEncoder().encode('hello world');
+const { signature } = await keypair.signPersonalMessage(message);
+```
+
+To sign and submit a transaction in one step, pass the signer to a client:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+
+const { digest } = await client.signAndExecuteTransaction({
+	transaction,
+	signer: keypair,
+});
+```
+
+## Verifying signatures
+
+Verification ensures a signature is valid for a given message and was produced by the expected key.
+The `@mysten/sui/verify` module verifies a signature against a message and recovers the `PublicKey`
+that produced it — without needing the original signer.
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
+
+const keypair = new Ed25519Keypair();
+const message = new TextEncoder().encode('hello world');
+const { signature } = await keypair.signPersonalMessage(message);
+
+const publicKey = await verifyPersonalMessageSignature(message, signature);
+
+if (!publicKey.verifyAddress(keypair.toSuiAddress())) {
+	throw new Error('Signature was valid, but was signed by a different key pair');
+}
+```
+
+### Verifying that a signature is valid for a specific address
+
+`verifyPersonalMessageSignature` and `verifyTransactionSignature` accept an optional `address` and
+throw if the signature is not valid for it:
+
+```typescript
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
+
+const keypair = new Ed25519Keypair();
+const message = new TextEncoder().encode('hello world');
+const { signature } = await keypair.signPersonalMessage(message);
+
+await verifyPersonalMessageSignature(message, signature, {
+	address: keypair.toSuiAddress(),
+});
+```
+
+### Verifying transaction signatures
+
+Verifying transaction signatures works the same way, using `verifyTransactionSignature`:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { Transaction } from '@mysten/sui/transactions';
+import { verifyTransactionSignature } from '@mysten/sui/verify';
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+const tx = new Transaction();
+// ... add some transactions...
+const bytes = await tx.build({ client });
+
+const keypair = new Ed25519Keypair();
+const { signature } = await keypair.signTransaction(bytes);
+
+await verifyTransactionSignature(bytes, signature, {
+	// optionally verify that the signature is valid for a specific address
+	address: keypair.toSuiAddress(),
+});
+```
+
+### Verifying zkLogin signatures
+
+zkLogin signatures can't be verified purely on the client. When verifying a zkLogin signature, the
+SDK uses the GraphQL API. This works for Mainnet signatures without any additional configuration.
+For Testnet signatures, provide a Testnet GraphQL client:
+
+```typescript
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
+
+const publicKey = await verifyPersonalMessageSignature(message, zkSignature, {
+	client: new SuiGraphQLClient({
+		url: 'https://graphql.testnet.sui.io/graphql',
+	}),
+});
+```
+
+For some zkLogin accounts, there are two valid addresses for a given set of inputs, so comparing the
+address from `publicKey.toSuiAddress()` directly against an expected address can fail. Instead, pass
+the expected address during verification, or use `publicKey.verifyAddress(address)`:
+
+```typescript
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
+
+const publicKey = await verifyPersonalMessageSignature(message, zkSignature, {
+	client: new SuiGraphQLClient({
+		url: 'https://graphql.testnet.sui.io/graphql',
+	}),
+	// Throws if the signature is not valid for the provided address
+	address: '0x...expectedAddress',
+});
+// or
+
+if (!publicKey.verifyAddress('0x...expectedAddress')) {
+	throw new Error('Signature was valid, but was signed by a different key pair');
+}
+```
+
+Both methods check the signature against the standard and
+[legacy versions of the zkLogin address](https://sdk.mystenlabs.com/sui/zklogin#legacy-addresses).
+
+## Choosing an implementation
+
+- **[Key pairs](/sui/cryptography/keypairs)** — `Ed25519Keypair`, `Secp256k1Keypair`, and
+  `Secp256r1Keypair` hold the private key in process. The simplest option when you manage the secret
+  key yourself. Covers deriving keypairs from mnemonics and secret keys.
+- **[Multi-signature](/sui/cryptography/multisig)** — combine signatures from several public keys
+  under a configurable threshold using `MultiSigPublicKey`.
+- **[Passkey](/sui/cryptography/passkey)** — sign with a WebAuthn passkey (biometric / platform
+  authenticator) via `PasskeyKeypair`.
+- **[Signers](/sui/cryptography/signers)** — external signer packages that keep the private key
+  outside your application: cloud KMS ([AWS](/sui/cryptography/signers/aws-kms),
+  [GCP](/sui/cryptography/signers/gcp-kms)), a [Ledger](/sui/cryptography/signers/ledger) hardware
+  wallet, or non-extractable browser keys with the [Web Crypto](/sui/cryptography/signers/webcrypto)
+  signer.
+
+If you just need to sign in a script or server and are comfortable managing the secret key yourself,
+start with [Key pairs](/sui/cryptography/keypairs). If the key must never live in your application's
+memory, use one of the external [signers](/sui/cryptography/signers).

--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -51,8 +51,8 @@ On top of those, `Signer` provides the methods you typically call:
 There are two broad families of signer:
 
 - **Key pairs** hold the private key in process. `Keypair` extends `Signer` and adds secret-key
-  import/export (`getSecretKey`, `fromSecretKey`). This is the easiest option for scripts, backends,
-  and tests. See [Key pairs](/sui/cryptography/keypairs).
+  import and export (`getSecretKey`, `fromSecretKey`). This is the easiest option for scripts,
+  backends, and tests. See [Key pairs](/sui/cryptography/keypairs).
 - **External signers** keep the private key outside your application, in a KMS, on a hardware
   wallet, or as a non-extractable browser key. They extend `Signer` directly. See
   [Signers](/sui/cryptography/signers).

--- a/packages/docs/content/sui/cryptography/keypairs.mdx
+++ b/packages/docs/content/sui/cryptography/keypairs.mdx
@@ -6,7 +6,7 @@ keywords:
   [keypairs, Ed25519, Secp256k1, Secp256r1, mnemonic, secret key, signing, Sui, TypeScript SDK]
 ---
 
-A `Keypair` holds a Sui private key in process and signs with it. It is the simplest
+A `Keypair` holds a Sui private key in process and signs with it. It is the easiest
 [`Signer`](/sui/cryptography) to use. It is ideal for scripts, backends, and tests where you manage
 the secret key yourself. For the signing and verification API shared by all signers, see
 [Cryptography](/sui/cryptography); this page focuses on creating keypairs and deriving them from

--- a/packages/docs/content/sui/cryptography/keypairs.mdx
+++ b/packages/docs/content/sui/cryptography/keypairs.mdx
@@ -1,23 +1,24 @@
 ---
 title: Key pairs
 description:
-  'Create and manage Ed25519, Secp256k1, and Secp256r1 keypairs for Sui transaction signing.'
-keywords: [keypairs, Ed25519, Secp256k1, Secp256r1, cryptography, signing, Sui, TypeScript SDK]
+  'Create Ed25519, Secp256k1, and Secp256r1 keypairs and derive them from mnemonics and secret keys.'
+keywords:
+  [keypairs, Ed25519, Secp256k1, Secp256r1, mnemonic, secret key, signing, Sui, TypeScript SDK]
 ---
 
-The Sui TypeScript SDK provides `Keypair` classes that handle logic for signing and verification
-using the cryptographic key pairs associated with a Sui address.
+A `Keypair` holds a Sui private key in process and signs with it. It is the simplest
+[`Signer`](/sui/cryptography) to use — ideal for scripts, backends, and tests where you manage the
+secret key yourself. For the signing and verification API shared by all signers, see
+[Cryptography](/sui/cryptography); this page focuses on creating keypairs and deriving them from
+mnemonics and secret keys.
 
-The Sui TypeScript SDK supports three signing schemes:
+Each signing scheme has a corresponding `Keypair` class:
 
 | Sign scheme     | Class name         | Import folder                    |
 | --------------- | ------------------ | -------------------------------- |
 | Ed25519         | `Ed25519Keypair`   | `@mysten/sui/keypairs/ed25519`   |
 | ECDSA Secp256k1 | `Secp256k1Keypair` | `@mysten/sui/keypairs/secp256k1` |
 | ECDSA Secp256r1 | `Secp256r1Keypair` | `@mysten/sui/keypairs/secp256r1` |
-
-For information on these schemes, see the
-[Signatures](https://docs.sui.io/concepts/cryptography/transaction-auth/signatures) topic.
 
 To use, import the key pair class your project uses from the `@mysten/sui/keypairs` folder. For
 example, to use the Ed25519 scheme, import the `Ed25519Keypair` class from
@@ -26,6 +27,8 @@ example, to use the Ed25519 scheme, import the `Ed25519Keypair` class from
 ```typescript
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 ```
+
+## Creating a key pair
 
 To create a random key pair (which identifies a Sui address), instantiate a new `Keypair` class. To
 reference a key pair from an existing secret key, pass the secret to the `fromSecretKey` function.
@@ -37,157 +40,43 @@ const keypair = new Ed25519Keypair();
 const keypair = Ed25519Keypair.fromSecretKey(secretKey);
 ```
 
-With your key pair created, you can reference it when performing actions on the network. For
-example, you can use it to sign transactions, like the following code that creates and signs a
-personal message using the public key from the key pair created in the previous code:
+With your key pair created, you can derive its address and sign with it. The following signs a
+personal message and verifies it with the public key:
 
 ```typescript
 const publicKey = keypair.getPublicKey();
-const message = new TextEncoder().encode('hello world');
+const address = keypair.toSuiAddress();
 
+const message = new TextEncoder().encode('hello world');
 const { signature } = await keypair.signPersonalMessage(message);
 const isValid = await publicKey.verifyPersonalMessage(message, signature);
 ```
 
+See [Cryptography](/sui/cryptography) for the full signing and verification API, including
+[verifying signatures](/sui/cryptography#verifying-signatures) without the original key pair.
+
 ## Public keys
 
-Each `Keypair` has an associated `PublicKey` class. You use the public key to verify signatures or
-to retrieve its associated Sui address. You can access a `Keypair` from its `PublicKey` or construct
-it from the bytes (as a `Uint8Array`) of the `PublicKey`, as in the following code:
+Each `Keypair` has an associated `PublicKey`, which you use to verify signatures or to retrieve its
+Sui address. Access it from a `Keypair` with `getPublicKey()`. To recreate a keypair — and therefore
+its public key — from saved key material, reconstruct it from the secret key:
 
 ```typescript
-import { Ed25519Keypair, Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 
-const keypair = new Ed25519Keypair();
+// Recreate the keypair from its secret key (Uint8Array)
+const keypair = Ed25519Keypair.fromSecretKey(secretKey);
 
-// method 1
-const bytes = keypair.getPublicKey().toRawBytes();
-const publicKey = new Ed25519PublicKey(bytes);
+// Access the public key and derive the address
+const publicKey = keypair.getPublicKey();
 const address = publicKey.toSuiAddress();
-
-// method 2
-const address = keypair.getPublicKey().toSuiAddress();
-// or use `toSuiAddress()` directly
-const address = keypair.toSuiAddress();
+// or derive the address directly from the keypair
+const sameAddress = keypair.toSuiAddress();
 ```
 
-## Verifying signatures without a key pair
-
-When you have an existing public key, you can use it to verify a signature. Verification ensures the
-signature is valid for the provided message and is signed with the appropriate secret key.
-
-The following code creates a key pair in the Ed25519 scheme, creates and signs a message with it,
-then verifies the message to retrieve the public key. The code then uses `toSuiAddress()` to check
-if the address associated with the public key matches the address that the key pair defines.
-
-```typescript
-import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
-
-const keypair = new Ed25519Keypair();
-const message = new TextEncoder().encode('hello world');
-const { signature } = await keypair.signPersonalMessage(message);
-
-const publicKey = await verifyPersonalMessageSignature(message, signature);
-
-if (!publicKey.verifyAddress(keypair.toSuiAddress())) {
-	throw new Error('Signature was valid, but was signed by a different key pair');
-}
-```
-
-## Verifying that a signature is valid for a specific address
-
-`verifyPersonalMessageSignature` and `verifyTransactionSignature` accept an optional `address`, and
-will throw an error if the signature is not valid for the provided address.
-
-```typescript
-import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
-
-const keypair = new Ed25519Keypair();
-const message = new TextEncoder().encode('hello world');
-const { signature } = await keypair.signPersonalMessage(message);
-
-await verifyPersonalMessageSignature(message, signature, {
-	address: keypair.toSuiAddress(),
-});
-```
-
-## Verifying transaction signatures
-
-Verifying transaction signatures is similar to personal message signature verification, except you
-use `verifyTransactionSignature`:
-
-```typescript
-// import SuiGrpcClient to create a network client
-import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import { verifyTransactionSignature } from '@mysten/sui/verify';
-
-// create a client connected to testnet
-const client = new SuiGrpcClient({
-	network: 'testnet',
-	baseUrl: 'https://fullnode.testnet.sui.io:443',
-});
-const tx = new Transaction();
-// ... add some transactions...
-const bytes = await tx.build({ client });
-
-const keypair = new Ed25519Keypair();
-const { signature } = await keypair.signTransaction(bytes);
-
-await verifyTransactionSignature(bytes, signature, {
-	// optionally verify that the signature is valid for a specific address
-	address: keypair.toSuiAddress(),
-});
-```
-
-## Verifying zkLogin signatures
-
-ZkLogin signatures can't be verified purely on the client. When verifying a zkLogin signature, the
-SDK uses the GraphQL API to verify the signature. This works for Mainnet signatures without any
-additional configuration.
-
-For Testnet signatures, you need to provide a Testnet GraphQL Client:
-
-```typescript
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
-import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
-
-const publicKey = await verifyPersonalMessageSignature(message, zkSignature, {
-	client: new SuiGraphQLClient({
-		url: 'https://graphql.testnet.sui.io/graphql',
-	}),
-});
-```
-
-For some zklogin accounts, there are two valid addresses for a given set of inputs. This means you
-might run into issues if you try to compare the address returned by `publicKey.toSuiAddress()`
-directly with an expected address.
-
-Instead, you can either pass in the expected address during verification, or use the
-`publicKey.verifyAddress(address)` method:
-
-```typescript
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
-import { verifyPersonalMessageSignature } from '@mysten/sui/verify';
-
-const publicKey = await verifyPersonalMessageSignature(message, zkSignature, {
-	client: new SuiGraphQLClient({
-		url: 'https://graphql.testnet.sui.io/graphql',
-	}),
-	// Pass in the expected address, and the verification method will throw an error if the signature is not valid for the provided address
-	address: '0x...expectedAddress',
-});
-// or
-
-if (!publicKey.verifyAddress('0x...expectedAddress')) {
-	throw new Error('Signature was valid, but was signed by a different key pair');
-}
-```
-
-Both of these methods will check the signature against both the standard and
-[legacy versions of the zklogin address](https://sdk.mystenlabs.com/sui/zklogin#legacy-addresses).
+See
+[Deriving a `Keypair` from a Bech32 encoded secret key](#deriving-a-keypair-from-a-bech32-encoded-secret-key)
+for working with encoded secret-key formats.
 
 ## Deriving a key pair from a mnemonic
 
@@ -245,16 +134,7 @@ switch (scheme) {
 See [SIP-15](https://github.com/sui-foundation/sips/blob/main/sips/sip-15.md) for additional context
 and motivation.
 
-If you know your keypair scheme, you can use the `fromSecretKey` method of the appropriate keypair
-to directly derive the keypair from the secret key.
-
-```typescript
-const secretKey = 'suiprivkey1qzse89atw7d3zum8ujep76d2cxmgduyuast0y9fu23xcl0mpafgkktllhyc';
-
-const keypair = Ed25519Keypair.fromSecretKey(secretKey);
-```
-
-You can also export a keypair to a Bech32 encoded secret key using the `getSecretKey` method.
+You can export a keypair to a Bech32 encoded secret key using the `getSecretKey` method.
 
 ```typescript
 const secretKey = keypair.getSecretKey();

--- a/packages/docs/content/sui/cryptography/keypairs.mdx
+++ b/packages/docs/content/sui/cryptography/keypairs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Key pairs
 description:
-  'Create Ed25519, Secp256k1, and Secp256r1 keypairs and derive them from mnemonics and secret keys.'
+  Create Ed25519, Secp256k1, and Secp256r1 keypairs and derive them from mnemonics and secret keys
 keywords:
   [keypairs, Ed25519, Secp256k1, Secp256r1, mnemonic, secret key, signing, Sui, TypeScript SDK]
 ---
@@ -36,8 +36,9 @@ reference a key pair from an existing secret key, pass the secret to the `fromSe
 ```typescript
 // random Keypair
 const keypair = new Ed25519Keypair();
-// Keypair from an existing secret key (Uint8Array)
-const keypair = Ed25519Keypair.fromSecretKey(secretKey);
+
+// or, a Keypair from an existing secret key (Uint8Array)
+const fromSecret = Ed25519Keypair.fromSecretKey(secretKey);
 ```
 
 With your key pair created, you can derive its address and sign with it. The following signs a
@@ -104,8 +105,8 @@ const keypair = Ed25519Keypair.fromSecretKey(secretKey);
 ```
 
 You can also use the `decodeSuiPrivateKey` function to decode the secret key and determine the
-keyScheme, and get the keypairs private key bytes, which can be used to instantiate the appropriate
-`Keypair` class.
+keyScheme, and get the key pair's private key bytes, which can be used to instantiate the
+appropriate `Keypair` class.
 
 ```typescript
 import { decodeSuiPrivateKey } from '@mysten/sui/cryptography';
@@ -113,9 +114,11 @@ import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Secp256r1Keypair } from '@mysten/sui/keypairs/secp256r1';
 import { Secp256k1Keypair } from '@mysten/sui/keypairs/secp256k1';
 
+const encoded = 'suiprivkey1qzse89atw7d3zum8ujep76d2cxmgduyuast0y9fu23xcl0mpafgkktllhyc';
 const { scheme, secretKey } = decodeSuiPrivateKey(encoded);
 
 // use scheme to choose the correct key pair
+let keypair;
 switch (scheme) {
 	case 'ED25519':
 		keypair = Ed25519Keypair.fromSecretKey(secretKey);

--- a/packages/docs/content/sui/cryptography/keypairs.mdx
+++ b/packages/docs/content/sui/cryptography/keypairs.mdx
@@ -7,8 +7,8 @@ keywords:
 ---
 
 A `Keypair` holds a Sui private key in process and signs with it. It is the simplest
-[`Signer`](/sui/cryptography) to use — ideal for scripts, backends, and tests where you manage the
-secret key yourself. For the signing and verification API shared by all signers, see
+[`Signer`](/sui/cryptography) to use. It is ideal for scripts, backends, and tests where you manage
+the secret key yourself. For the signing and verification API shared by all signers, see
 [Cryptography](/sui/cryptography); this page focuses on creating keypairs and deriving them from
 mnemonics and secret keys.
 
@@ -59,8 +59,8 @@ See [Cryptography](/sui/cryptography) for the full signing and verification API,
 ## Public keys
 
 Each `Keypair` has an associated `PublicKey`, which you use to verify signatures or to retrieve its
-Sui address. Access it from a `Keypair` with `getPublicKey()`. To recreate a keypair — and therefore
-its public key — from saved key material, reconstruct it from the secret key:
+Sui address. Access it from a `Keypair` with `getPublicKey()`. To recreate a keypair, and therefore
+its public key, from saved key material, reconstruct it from the secret key:
 
 ```typescript
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
@@ -105,7 +105,7 @@ const keypair = Ed25519Keypair.fromSecretKey(secretKey);
 ```
 
 You can also use the `decodeSuiPrivateKey` function to decode the secret key and determine the
-keyScheme, and get the key pair's private key bytes, which can be used to instantiate the
+keyScheme, and get the key pair's private key bytes, which you can use to instantiate the
 appropriate `Keypair` class.
 
 ```typescript

--- a/packages/docs/content/sui/cryptography/meta.json
+++ b/packages/docs/content/sui/cryptography/meta.json
@@ -1,0 +1,4 @@
+{
+	"title": "Cryptography",
+	"pages": ["index", "keypairs", "multisig", "passkey", "signers"]
+}

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -5,7 +5,7 @@ keywords: [AWS KMS, signer, AwsKmsSigner, KMS, Secp256k1, Secp256r1, Sui, TypeSc
 ---
 
 The `AwsKmsSigner` signs Sui transactions using a key held in
-[AWS Key Management Service](https://aws.amazon.com/kms/). The private key never leaves AWS — the
+[AWS Key Management Service](https://aws.amazon.com/kms/). The private key never leaves AWS; the
 signer sends the message digest to KMS and receives the signature back.
 
 AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
@@ -53,8 +53,8 @@ const signer = await AwsKmsSigner.fromKeyId(AWS_KMS_KEY_ID, {
 
 ## Usage
 
-Once created, the signer behaves like any other [`Signer`](../index) — derive the address, sign
-messages, and sign or execute transactions.
+Once created, the signer behaves like any other [`Signer`](/sui/cryptography): derive the address,
+sign messages, and sign or execute transactions.
 
 ```typescript
 // Derive the Sui address

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -12,7 +12,8 @@ AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme i
 curve of the KMS key (`ECC_SECG_P256K1` → `Secp256k1`, `ECC_NIST_P256` → `Secp256r1`).
 
 <Callout type="warn">
-	The AWS KMS Signer requires Node.js >= 20, because it relies on the global Web Crypto API.
+	The AWS KMS Signer requires Node.js >= 22 (the package's `engines.node` constraint) and relies on
+	the global Web Crypto API.
 </Callout>
 
 ## Installation
@@ -78,10 +79,11 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
 
-const { digest } = await client.core.signAndExecuteTransaction({
-	transaction,
-	signer,
-});
+const result = await client.signAndExecuteTransaction({ transaction, signer });
+if (result.FailedTransaction) {
+	throw new Error('Transaction failed to execute');
+}
+console.log(result.Transaction.digest);
 ```
 
 See [Cryptography](/sui/cryptography) for the full signing and verification API shared by all

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -1,0 +1,88 @@
+---
+title: AWS KMS Signer
+description: Sign Sui transactions with a key stored in AWS Key Management Service
+keywords: [AWS KMS, signer, AwsKmsSigner, KMS, Secp256k1, Secp256r1, Sui, TypeScript SDK]
+---
+
+The `AwsKmsSigner` signs Sui transactions using a key held in
+[AWS Key Management Service](https://aws.amazon.com/kms/). The private key never leaves AWS — the
+signer sends the message digest to KMS and receives the signature back.
+
+AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
+curve of the KMS key (`ECC_SECG_P256K1` → `Secp256k1`, `ECC_NIST_P256` → `Secp256r1`).
+
+<Callout type="warn">
+	The AWS KMS Signer requires Node.js >= 20, because it relies on the global Web Crypto API.
+</Callout>
+
+## Installation
+
+```sh npm2yarn
+npm i @mysten/aws-kms-signer
+```
+
+## Creating a signer
+
+Construct the signer with `AwsKmsSigner.fromKeyId`, passing the KMS key ID and the AWS credentials
+and region. This is async: it fetches the public key from KMS so the signer can derive the Sui
+address.
+
+```typescript
+import { AwsKmsSigner } from '@mysten/aws-kms-signer';
+
+const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_KMS_KEY_ID } = process.env;
+
+const signer = await AwsKmsSigner.fromKeyId(AWS_KMS_KEY_ID, {
+	region: AWS_REGION,
+	accessKeyId: AWS_ACCESS_KEY_ID,
+	secretAccessKey: AWS_SECRET_ACCESS_KEY,
+});
+```
+
+### Parameters
+
+`fromKeyId(keyId, options)`
+
+| Parameter                 | Type     | Description                     |
+| ------------------------- | -------- | ------------------------------- |
+| `keyId`                   | `string` | The AWS KMS key ID              |
+| `options.region`          | `string` | The AWS region the key lives in |
+| `options.accessKeyId`     | `string` | The AWS access key ID           |
+| `options.secretAccessKey` | `string` | The AWS secret access key       |
+
+## Usage
+
+Once created, the signer behaves like any other [`Signer`](../index) — derive the address, sign
+messages, and sign or execute transactions.
+
+```typescript
+// Derive the Sui address
+const address = signer.getPublicKey().toSuiAddress();
+
+// Sign a personal message
+const message = new TextEncoder().encode('Hello, AWS KMS Signer!');
+const { signature } = await signer.signPersonalMessage(message);
+
+// Verify the signature
+const isValid = await signer.getPublicKey().verifyPersonalMessage(message, signature);
+console.log(isValid); // true
+```
+
+To sign and submit a transaction, pass the signer to a client:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+
+const { digest } = await client.core.signAndExecuteTransaction({
+	transaction,
+	signer,
+});
+```
+
+See [Cryptography](/sui/cryptography) for the full signing and verification API shared by all
+signers.

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -8,8 +8,8 @@ The `AwsKmsSigner` signs Sui transactions using a key held in
 [AWS Key Management Service](https://aws.amazon.com/kms/). The private key never leaves AWS; the
 signer sends the message digest to KMS and receives the signature back.
 
-AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
-curve of the KMS key (`ECC_SECG_P256K1` → `Secp256k1`, `ECC_NIST_P256` → `Secp256r1`).
+AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The curve of the KMS key determines the
+signature scheme (`ECC_SECG_P256K1` → `Secp256k1`, `ECC_NIST_P256` → `Secp256r1`).
 
 <Callout type="warn">
 	The AWS KMS Signer requires Node.js >= 22 (the package's `engines.node` constraint) and relies on

--- a/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
@@ -86,10 +86,11 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
 
-const { digest } = await client.core.signAndExecuteTransaction({
-	transaction,
-	signer,
-});
+const result = await client.signAndExecuteTransaction({ transaction, signer });
+if (result.FailedTransaction) {
+	throw new Error('Transaction failed to execute');
+}
+console.log(result.Transaction.digest);
 ```
 
 See [Cryptography](/sui/cryptography) for the full signing and verification API shared by all

--- a/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
@@ -1,0 +1,96 @@
+---
+title: GCP KMS Signer
+description: Sign Sui transactions with a key stored in Google Cloud Key Management Service
+keywords:
+  [GCP KMS, signer, GcpKmsSigner, KMS, Secp256k1, Secp256r1, Google Cloud, Sui, TypeScript SDK]
+---
+
+The `GcpKmsSigner` signs Sui transactions using a key held in
+[Google Cloud KMS](https://cloud.google.com/kms). The private key never leaves GCP — the signer
+sends the message digest to KMS and receives the signature back.
+
+GCP KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
+curve of the KMS key (`EC_SIGN_SECP256K1_SHA256` → `Secp256k1`, `EC_SIGN_P256_SHA256` →
+`Secp256r1`).
+
+## Installation
+
+```sh npm2yarn
+npm i @mysten/gcp-kms-signer
+```
+
+## Creating a signer
+
+Construct the signer with `GcpKmsSigner.fromOptions`, identifying the key by its project, location,
+key ring, key, and version. This is async: it fetches the public key from KMS so the signer can
+derive the Sui address.
+
+```typescript
+import { GcpKmsSigner } from '@mysten/gcp-kms-signer';
+
+const signer = await GcpKmsSigner.fromOptions({
+	projectId: 'your-google-project-id',
+	location: 'your-google-location',
+	keyRing: 'your-google-keyring',
+	cryptoKey: 'your-google-key-name',
+	cryptoKeyVersion: 'your-google-key-version',
+});
+```
+
+### Parameters
+
+`fromOptions(options)`
+
+| Parameter          | Type     | Description           |
+| ------------------ | -------- | --------------------- |
+| `projectId`        | `string` | The GCP project ID    |
+| `location`         | `string` | The GCP location      |
+| `keyRing`          | `string` | The GCP key ring name |
+| `cryptoKey`        | `string` | The GCP key name      |
+| `cryptoKeyVersion` | `string` | The GCP key version   |
+
+If you already have a fully-qualified KMS version name, construct the signer directly with
+`GcpKmsSigner.fromVersionName`:
+
+```typescript
+const signer = await GcpKmsSigner.fromVersionName(
+	'projects/p/locations/l/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1',
+);
+```
+
+## Usage
+
+Once created, the signer behaves like any other [`Signer`](../index) — derive the address, sign
+messages, and sign or execute transactions.
+
+```typescript
+// Derive the Sui address
+const address = signer.getPublicKey().toSuiAddress();
+
+// Sign a personal message
+const message = new TextEncoder().encode('Hello, GCP KMS Signer!');
+const { signature } = await signer.signPersonalMessage(message);
+
+// Verify the signature
+const isValid = await signer.getPublicKey().verifyPersonalMessage(message, signature);
+console.log(isValid); // true
+```
+
+To sign and submit a transaction, pass the signer to a client:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+
+const { digest } = await client.core.signAndExecuteTransaction({
+	transaction,
+	signer,
+});
+```
+
+See [Cryptography](/sui/cryptography) for the full signing and verification API shared by all
+signers.

--- a/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
@@ -6,8 +6,8 @@ keywords:
 ---
 
 The `GcpKmsSigner` signs Sui transactions using a key held in
-[Google Cloud KMS](https://cloud.google.com/kms). The private key never leaves GCP — the signer
-sends the message digest to KMS and receives the signature back.
+[Google Cloud KMS](https://cloud.google.com/kms). The private key never leaves GCP; the signer sends
+the message digest to KMS and receives the signature back.
 
 GCP KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
 curve of the KMS key (`EC_SIGN_SECP256K1_SHA256` → `Secp256k1`, `EC_SIGN_P256_SHA256` →
@@ -60,8 +60,8 @@ const signer = await GcpKmsSigner.fromVersionName(
 
 ## Usage
 
-Once created, the signer behaves like any other [`Signer`](../index) — derive the address, sign
-messages, and sign or execute transactions.
+Once created, the signer behaves like any other [`Signer`](/sui/cryptography): derive the address,
+sign messages, and sign or execute transactions.
 
 ```typescript
 // Derive the Sui address

--- a/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/gcp-kms.mdx
@@ -9,9 +9,8 @@ The `GcpKmsSigner` signs Sui transactions using a key held in
 [Google Cloud KMS](https://cloud.google.com/kms). The private key never leaves GCP; the signer sends
 the message digest to KMS and receives the signature back.
 
-GCP KMS supports the `Secp256k1` and `Secp256r1` schemes. The signature scheme is determined by the
-curve of the KMS key (`EC_SIGN_SECP256K1_SHA256` → `Secp256k1`, `EC_SIGN_P256_SHA256` →
-`Secp256r1`).
+GCP KMS supports the `Secp256k1` and `Secp256r1` schemes. The curve of the KMS key determines the
+signature scheme (`EC_SIGN_SECP256K1_SHA256` → `Secp256k1`, `EC_SIGN_P256_SHA256` → `Secp256r1`).
 
 ## Installation
 

--- a/packages/docs/content/sui/cryptography/signers/index.mdx
+++ b/packages/docs/content/sui/cryptography/signers/index.mdx
@@ -1,16 +1,15 @@
 ---
 title: Signers
-description:
-  External signer packages for AWS KMS, GCP KMS, Ledger hardware wallets, and the Web Crypto API
+description: External signer packages for AWS KMS, GCP KMS, Ledger, and the Web Crypto API
 keywords:
   [signers, Signer, AWS KMS, GCP KMS, Ledger, Web Crypto, KMS, hardware wallet, Sui, TypeScript SDK]
 ---
 
 In addition to the in-process [keypairs](/sui/cryptography/keypairs) built into `@mysten/sui`, the
 SDK ecosystem publishes standalone signer packages that keep the private key outside your
-application — in a cloud key-management service (KMS), on a hardware wallet, or as a non-extractable
-browser key. Each one extends the same [`Signer`](/sui/cryptography) base class, so it can be used
-anywhere a keypair can.
+application, in a cloud key-management service (KMS), on a hardware wallet, or as a non-extractable
+browser key. Each one extends the same [`Signer`](/sui/cryptography) base class, so it works
+anywhere a keypair does.
 
 ## Available signers
 
@@ -27,7 +26,7 @@ key (`ECC_NIST_P256` → `Secp256r1`, `ECC_SECG_P256K1` → `Secp256k1`).
 ## Shared interface
 
 Because every signer extends `Signer`, the signing API is identical regardless of where the key is
-held — only the way you construct the signer differs:
+held; only the way you construct the signer differs:
 
 ```typescript
 // Derive the address
@@ -53,9 +52,9 @@ share.
 Each signer exposes a static factory rather than a public constructor, because preparing the signer
 requires an async round-trip to fetch the public key from the KMS or device:
 
-- `AwsKmsSigner.fromKeyId(keyId, options)` — see [AWS KMS Signer](/sui/cryptography/signers/aws-kms)
-- `GcpKmsSigner.fromOptions(options)` — see [GCP KMS Signer](/sui/cryptography/signers/gcp-kms)
-- `LedgerSigner.fromDerivationPath(path, ledgerClient, suiClient)` — see
-  [Ledger Signer](/sui/cryptography/signers/ledger)
-- `WebCryptoSigner.generate()` / `WebCryptoSigner.import(exported)` — see
-  [Web Crypto Signer](/sui/cryptography/signers/webcrypto)
+- `AwsKmsSigner.fromKeyId(keyId, options)`. See [AWS KMS Signer](/sui/cryptography/signers/aws-kms).
+- `GcpKmsSigner.fromOptions(options)`. See [GCP KMS Signer](/sui/cryptography/signers/gcp-kms).
+- `LedgerSigner.fromDerivationPath(path, ledgerClient, suiClient)`. See
+  [Ledger Signer](/sui/cryptography/signers/ledger).
+- `WebCryptoSigner.generate()` and `WebCryptoSigner.import(exported)`. See
+  [Web Crypto Signer](/sui/cryptography/signers/webcrypto).

--- a/packages/docs/content/sui/cryptography/signers/index.mdx
+++ b/packages/docs/content/sui/cryptography/signers/index.mdx
@@ -1,0 +1,60 @@
+---
+title: Signers
+description:
+  External signer packages for AWS KMS, GCP KMS, Ledger hardware wallets, and the Web Crypto API
+keywords:
+  [signers, Signer, AWS KMS, GCP KMS, Ledger, Web Crypto, KMS, hardware wallet, Sui, TypeScript SDK]
+---
+
+In addition to the in-process [keypairs](/sui/cryptography/keypairs) built into `@mysten/sui`, the
+SDK ecosystem publishes standalone signer packages that keep the private key outside your
+application — in a cloud key-management service (KMS), on a hardware wallet, or as a non-extractable
+browser key. Each one extends the same [`Signer`](/sui/cryptography) base class, so it can be used
+anywhere a keypair can.
+
+## Available signers
+
+| Signer            | Package                    | Scheme                 | Key lives in                                                    |
+| ----------------- | -------------------------- | ---------------------- | --------------------------------------------------------------- |
+| `AwsKmsSigner`    | `@mysten/aws-kms-signer`   | Secp256k1 or Secp256r1 | [AWS KMS](/sui/cryptography/signers/aws-kms)                    |
+| `GcpKmsSigner`    | `@mysten/gcp-kms-signer`   | Secp256k1 or Secp256r1 | [GCP KMS](/sui/cryptography/signers/gcp-kms)                    |
+| `LedgerSigner`    | `@mysten/ledger-signer`    | Ed25519                | [Ledger hardware wallet](/sui/cryptography/signers/ledger)      |
+| `WebCryptoSigner` | `@mysten/webcrypto-signer` | Secp256r1              | [Browser Web Crypto store](/sui/cryptography/signers/webcrypto) |
+
+For the AWS and GCP signers, the signature scheme is determined by the curve of the underlying KMS
+key (`ECC_NIST_P256` → `Secp256r1`, `ECC_SECG_P256K1` → `Secp256k1`).
+
+## Shared interface
+
+Because every signer extends `Signer`, the signing API is identical regardless of where the key is
+held — only the way you construct the signer differs:
+
+```typescript
+// Derive the address
+const address = signer.getPublicKey().toSuiAddress();
+
+// Sign a personal message
+const message = new TextEncoder().encode('hello world');
+const { signature } = await signer.signPersonalMessage(message);
+
+// Sign and execute a transaction
+const { digest } = await client.core.signAndExecuteTransaction({
+	transaction,
+	signer,
+});
+```
+
+See [Cryptography](/sui/cryptography) for the full signing and verification API that all signers
+share.
+
+## Construction
+
+Each signer exposes a static factory rather than a public constructor, because preparing the signer
+requires an async round-trip to fetch the public key from the KMS or device:
+
+- `AwsKmsSigner.fromKeyId(keyId, options)` — see [AWS KMS Signer](/sui/cryptography/signers/aws-kms)
+- `GcpKmsSigner.fromOptions(options)` — see [GCP KMS Signer](/sui/cryptography/signers/gcp-kms)
+- `LedgerSigner.fromDerivationPath(path, ledgerClient, suiClient)` — see
+  [Ledger Signer](/sui/cryptography/signers/ledger)
+- `WebCryptoSigner.generate()` / `WebCryptoSigner.import(exported)` — see
+  [Web Crypto Signer](/sui/cryptography/signers/webcrypto)

--- a/packages/docs/content/sui/cryptography/signers/index.mdx
+++ b/packages/docs/content/sui/cryptography/signers/index.mdx
@@ -20,8 +20,8 @@ anywhere a keypair does.
 | `LedgerSigner`    | `@mysten/ledger-signer`    | Ed25519                | [Ledger hardware wallet](/sui/cryptography/signers/ledger)      |
 | `WebCryptoSigner` | `@mysten/webcrypto-signer` | Secp256r1              | [Browser Web Crypto store](/sui/cryptography/signers/webcrypto) |
 
-For the AWS and GCP signers, the signature scheme is determined by the curve of the underlying KMS
-key (`ECC_NIST_P256` → `Secp256r1`, `ECC_SECG_P256K1` → `Secp256k1`).
+For the AWS and GCP signers, the curve of the underlying KMS key determines the signature scheme
+(`ECC_NIST_P256` → `Secp256r1`, `ECC_SECG_P256K1` → `Secp256k1`).
 
 ## Shared interface
 

--- a/packages/docs/content/sui/cryptography/signers/index.mdx
+++ b/packages/docs/content/sui/cryptography/signers/index.mdx
@@ -37,11 +37,12 @@ const address = signer.getPublicKey().toSuiAddress();
 const message = new TextEncoder().encode('hello world');
 const { signature } = await signer.signPersonalMessage(message);
 
-// Sign and execute a transaction
-const { digest } = await client.core.signAndExecuteTransaction({
-	transaction,
-	signer,
-});
+// Sign and execute a transaction (resolves to a discriminated union)
+const result = await client.signAndExecuteTransaction({ transaction, signer });
+if (result.FailedTransaction) {
+	throw new Error('Transaction failed to execute');
+}
+console.log(result.Transaction.digest);
 ```
 
 See [Cryptography](/sui/cryptography) for the full signing and verification API that all signers

--- a/packages/docs/content/sui/cryptography/signers/ledger.mdx
+++ b/packages/docs/content/sui/cryptography/signers/ledger.mdx
@@ -1,0 +1,86 @@
+---
+title: Ledger Signer
+description: Sign Sui transactions with a Ledger hardware wallet
+keywords:
+  [Ledger, signer, LedgerSigner, hardware wallet, Ed25519, derivation path, Sui, TypeScript SDK]
+---
+
+The `LedgerSigner` signs Sui transactions and personal messages with a
+[Ledger](https://www.ledger.com/) hardware wallet. The private key never leaves the device — each
+signature must be confirmed on the Ledger. The Ledger signer uses the `Ed25519` scheme.
+
+## Installation
+
+```sh npm2yarn
+npm i @mysten/ledger-signer @mysten/ledgerjs-hw-app-sui
+```
+
+You also need a
+[Ledger transport](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) for your
+environment — for example `@ledgerhq/hw-transport-node-hid` in Node.js or
+`@ledgerhq/hw-transport-webhid` in the browser.
+
+## Creating a signer
+
+Open a transport, wrap it in a `SuiLedgerClient`, then construct the signer with
+`LedgerSigner.fromDerivationPath`. This is async: it fetches the public key from the device so the
+signer can derive the Sui address.
+
+```typescript
+import Transport from '@ledgerhq/hw-transport-node-hid';
+import SuiLedgerClient from '@mysten/ledgerjs-hw-app-sui';
+import { LedgerSigner } from '@mysten/ledger-signer';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const transport = await Transport.open(undefined);
+const ledgerClient = new SuiLedgerClient(transport);
+const suiClient = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+
+const signer = await LedgerSigner.fromDerivationPath(
+	"m/44'/784'/0'/0'/0'",
+	ledgerClient,
+	suiClient,
+);
+```
+
+### Parameters
+
+`fromDerivationPath(derivationPath, ledgerClient, suiClient)`
+
+| Parameter        | Type                | Description                                           |
+| ---------------- | ------------------- | ----------------------------------------------------- |
+| `derivationPath` | `string`            | BIP-32 derivation path (Sui uses coin type `784`)     |
+| `ledgerClient`   | `SuiLedgerClient`   | A `SuiLedgerClient` wrapping an open Ledger transport |
+| `suiClient`      | `ClientWithCoreApi` | A Sui client used to resolve transaction data         |
+
+## Usage
+
+Derive the address, then sign a transaction or personal message. The user confirms each signature on
+the device.
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+
+// Derive the Sui address
+const address = signer.toSuiAddress();
+
+// Build and sign a transaction
+const transaction = new Transaction();
+const transactionBytes = await transaction.build({ client: suiClient });
+const { signature } = await signer.signTransaction(transactionBytes);
+
+// Or sign a personal message
+const message = new TextEncoder().encode('Hello, Ledger Signer!');
+await signer.signPersonalMessage(message);
+```
+
+<Callout type="warn">
+	The Ledger signer only supports `signTransaction` and `signPersonalMessage`. The generic `sign`
+	and `signWithIntent` methods are not supported and throw an error, because the device only signs
+	recognized transaction and message payloads.
+</Callout>
+
+See [Cryptography](/sui/cryptography) for the signing and verification API shared by all signers.

--- a/packages/docs/content/sui/cryptography/signers/ledger.mdx
+++ b/packages/docs/content/sui/cryptography/signers/ledger.mdx
@@ -78,9 +78,9 @@ await signer.signPersonalMessage(message);
 ```
 
 <Callout type="warn">
-	The Ledger signer only supports `signTransaction` and `signPersonalMessage`. The generic `sign`
-	and `signWithIntent` methods are not supported and throw an error, because the device only signs
-	recognized transaction and message payloads.
+	The Ledger signer supports only `signTransaction` and `signPersonalMessage`. It does not support
+	the generic `sign` and `signWithIntent` methods, which throw an error because the device only
+	signs recognized transaction and message payloads.
 </Callout>
 
 See [Cryptography](/sui/cryptography) for the signing and verification API shared by all signers.

--- a/packages/docs/content/sui/cryptography/signers/ledger.mdx
+++ b/packages/docs/content/sui/cryptography/signers/ledger.mdx
@@ -6,8 +6,8 @@ keywords:
 ---
 
 The `LedgerSigner` signs Sui transactions and personal messages with a
-[Ledger](https://www.ledger.com/) hardware wallet. The private key never leaves the device — each
-signature must be confirmed on the Ledger. The Ledger signer uses the `Ed25519` scheme.
+[Ledger](https://www.ledger.com/) hardware wallet. The private key never leaves the device; you
+confirm each signature on the Ledger. The Ledger signer uses the `Ed25519` scheme.
 
 ## Installation
 
@@ -17,7 +17,7 @@ npm i @mysten/ledger-signer @mysten/ledgerjs-hw-app-sui
 
 You also need a
 [Ledger transport](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs) for your
-environment — for example `@ledgerhq/hw-transport-node-hid` in Node.js or
+environment, for example `@ledgerhq/hw-transport-node-hid` in Node.js or
 `@ledgerhq/hw-transport-webhid` in the browser.
 
 ## Creating a signer

--- a/packages/docs/content/sui/cryptography/signers/meta.json
+++ b/packages/docs/content/sui/cryptography/signers/meta.json
@@ -1,0 +1,4 @@
+{
+	"title": "Signers",
+	"pages": ["index", "aws-kms", "gcp-kms", "ledger", "webcrypto"]
+}

--- a/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
+++ b/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Crypto Signer
-description: Sign transactions using the Web Crypto API for secure browser-based key management.
+description: Sign transactions using the Web Crypto API for secure browser-based key management
 keywords:
   [
     Web Crypto API,

--- a/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
+++ b/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
@@ -17,9 +17,9 @@ keywords:
 For cases where you need to create keypairs directly within client apps, you can use the Web Crypto
 Signer. This signer leverages the
 [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) to provide a
-secure and efficient way to generate and manage cryptographic keys in the browser. The generated
-keys are `Secp256r1` keys which can be persisted between sessions, and are not extractable by
-client-side code (including extensions).
+secure and efficient way to generate and manage cryptographic keys in the browser. It generates
+`Secp256r1` keys that you can persist between sessions, and that client-side code (including
+extensions) cannot extract.
 
 Common use cases for the Web Crypto Signer include:
 

--- a/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
+++ b/packages/docs/content/sui/cryptography/signers/webcrypto.mdx
@@ -82,8 +82,8 @@ const keypair = await WebCryptoSigner.import(exported);
 ## Usage
 
 The usage for a Web Crypto signer is the same as any other keypair. You can derive the public key,
-derive the address, sign personal messages, sign transactions, and verify signatures. See the
-[Key pairs](./keypairs) documentation for more details.
+derive the address, sign personal messages, sign transactions, and verify signatures. See
+[Cryptography](/sui/cryptography) for more details.
 
 ```typescript
 const publicKey = keypair.getPublicKey();

--- a/packages/docs/content/sui/index.mdx
+++ b/packages/docs/content/sui/index.mdx
@@ -36,10 +36,9 @@ what you need to keep your code light and compact.
   with transactions.
 - [`@mysten/sui/keypairs/*`](/sui/cryptography/keypairs): Modular exports for specific KeyPair
   implementations.
-- [`@mysten/sui/verify`](/sui/cryptography/keypairs#verifying-signatures-without-a-key-pair):
-  Methods for verifying transactions and messages.
-- [`@mysten/sui/cryptography`](/sui/cryptography/keypairs): Shared types and classes for
-  cryptography.
+- [`@mysten/sui/verify`](/sui/cryptography#verifying-signatures): Methods for verifying transactions
+  and messages.
+- [`@mysten/sui/cryptography`](/sui/cryptography): Shared types and classes for cryptography.
 - [`@mysten/sui/multisig`](/sui/cryptography/multisig): Utilities for working with multisig
   signatures.
 - [`@mysten/sui/utils`](/sui/utils): Utilities for formatting and parsing various Sui types.

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -55,6 +55,11 @@ const config = {
 				destination: '/dapp-kit/slush',
 				statusCode: 302,
 			},
+			{
+				source: '/sui/cryptography/webcrypto-signer',
+				destination: '/sui/cryptography/signers/webcrypto',
+				statusCode: 302,
+			},
 		];
 	},
 };


### PR DESCRIPTION
## Description

Adds documentation coverage for the external signer packages and restructures the cryptography section so it flows through the key concepts.

**New `signers/` subsection** (`sui/cryptography/signers/`) covering the standalone signer packages, each of which implements the shared `Signer` interface:

- `aws-kms.mdx` — `@mysten/aws-kms-signer`
- `gcp-kms.mdx` — `@mysten/gcp-kms-signer`
- `ledger.mdx` — `@mysten/ledger-signer`
- `webcrypto.mdx` — `@mysten/webcrypto-signer` (moved from `cryptography/webcrypto-signer.mdx`)
- `index.mdx` — overview + comparison table of all four

> Note: these use the real published package names (`@mysten/aws-kms-signer`, etc.). The old `packages/signers/README.md` still references the pre-split `@mysten/signers/*` import paths and is stale — not touched here, but worth a follow-up.

**Cryptography section restructure:**

- New `cryptography/index.mdx` is now the conceptual hub: signing schemes → the `Signer` interface → public keys & addresses → signing → verifying signatures → choosing an implementation.
- `keypairs.mdx` trimmed to keypair-specific concerns (creation, mnemonics, Bech32/hex secret keys); shared signing/verification material hoisted up to the index.
- Converted `_meta.json` to the standard `meta.json` `{title, pages}` format used everywhere else in the repo.
- Updated inbound links to the relocated content (`sui/index.mdx` `@mysten/sui/verify` anchor, signer pages → cryptography hub).

**URL change:** `/sui/cryptography/webcrypto-signer` → `/sui/cryptography/signers/webcrypto` (tracked as a git rename).

## Test plan

- `pnpm --filter @mysten/docs build:docs` regenerates the LLM index — new signer pages and the `signers/` group appear in order.
- `pnpm --filter @mysten/docs validate-docs` passes: frontmatter completeness, orphan detection, and internal-link/anchor resolution (confirms the new `#verifying-signatures` anchors resolve).
- `prettier --check` clean on all changed files.
- No changeset — docs-only content change, consistent with prior docs-only PRs (e.g. #1085).

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)