### PR TITLE
docs: link Ledger signer from low-level hw package; reorganize signers section

### DIFF
--- a/packages/docs/content/sui/cryptography/index.mdx
+++ b/packages/docs/content/sui/cryptography/index.mdx
@@ -228,15 +228,13 @@ Both methods check the signature against the standard and
 - **[Key pairs](/sui/cryptography/keypairs)**: `Ed25519Keypair`, `Secp256k1Keypair`, and
   `Secp256r1Keypair` hold the private key in process. The easiest option when you manage the secret
   key yourself. Covers deriving keypairs from mnemonics and secret keys.
-- **[Multi-signature](/sui/cryptography/multisig)**: combine signatures from several public keys
-  under a configurable threshold using `MultiSigPublicKey`.
-- **[Passkey](/sui/cryptography/passkey)**: sign with a WebAuthn passkey (biometric or platform
-  authenticator) through `PasskeyKeypair`.
-- **[Signers](/sui/cryptography/signers)**: external signer packages that keep the private key
-  outside your application, including cloud KMS ([AWS](/sui/cryptography/signers/aws-kms),
-  [GCP](/sui/cryptography/signers/gcp-kms)), a [Ledger](/sui/cryptography/signers/ledger) hardware
-  wallet, and non-extractable browser keys with the
-  [Web Crypto](/sui/cryptography/signers/webcrypto) signer.
+- **[Signers](/sui/cryptography/signers)**: other implementations of the `Signer` interface,
+  including signer packages that keep the private key outside your application — cloud KMS
+  ([AWS](/sui/cryptography/signers/aws-kms), [GCP](/sui/cryptography/signers/gcp-kms)), a
+  [Ledger](/sui/cryptography/signers/ledger) hardware wallet, and non-extractable browser keys with
+  the [Web Crypto](/sui/cryptography/signers/webcrypto) signer — as well as
+  [passkeys](/sui/cryptography/signers/passkey) and
+  [multi-signature](/sui/cryptography/signers/multisig).
 
 If you just need to sign in a script or server and are comfortable managing the secret key yourself,
 start with [Key pairs](/sui/cryptography/keypairs). If the key must never live in your application's

--- a/packages/docs/content/sui/cryptography/meta.json
+++ b/packages/docs/content/sui/cryptography/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Cryptography",
-	"pages": ["index", "keypairs", "multisig", "passkey", "signers"]
+	"pages": ["index", "keypairs", "signers"]
 }

--- a/packages/docs/content/sui/cryptography/signers/index.mdx
+++ b/packages/docs/content/sui/cryptography/signers/index.mdx
@@ -1,17 +1,35 @@
 ---
 title: Signers
-description: External signer packages for AWS KMS, GCP KMS, Ledger, and the Web Crypto API
+description:
+  Signer implementations beyond keypairs — cloud KMS, Ledger, Web Crypto, passkeys, and multisig
 keywords:
-  [signers, Signer, AWS KMS, GCP KMS, Ledger, Web Crypto, KMS, hardware wallet, Sui, TypeScript SDK]
+  [
+    signers,
+    Signer,
+    AWS KMS,
+    GCP KMS,
+    Ledger,
+    Web Crypto,
+    passkey,
+    multisig,
+    KMS,
+    hardware wallet,
+    Sui,
+    TypeScript SDK,
+  ]
 ---
 
 In addition to the in-process [keypairs](/sui/cryptography/keypairs) built into `@mysten/sui`, the
-SDK ecosystem publishes standalone signer packages that keep the private key outside your
-application, in a cloud key-management service (KMS), on a hardware wallet, or as a non-extractable
-browser key. Each one extends the same [`Signer`](/sui/cryptography) base class, so it works
-anywhere a keypair does.
+SDK ecosystem ships more implementations of the [`Signer`](/sui/cryptography) interface. Some keep
+the private key outside your application — in a cloud key-management service (KMS), on a hardware
+wallet, or as a non-extractable browser key — while others, like
+[multisig](/sui/cryptography/signers/multisig), combine several signers together. Because each one
+extends the same `Signer` base class, it works anywhere a keypair does.
 
-## Available signers
+## External signers
+
+These signers hold the key material outside your process. Each is published as its **own package**,
+so you install only the one you need:
 
 | Signer            | Package                    | Scheme                 | Key lives in                                                    |
 | ----------------- | -------------------------- | ---------------------- | --------------------------------------------------------------- |
@@ -22,6 +40,25 @@ anywhere a keypair does.
 
 For the AWS and GCP signers, the curve of the underlying KMS key determines the signature scheme
 (`ECC_NIST_P256` → `Secp256r1`, `ECC_SECG_P256K1` → `Secp256k1`).
+
+<Callout>
+	Each signer above is its own npm package — import directly from `@mysten/aws-kms-signer`,
+	`@mysten/ledger-signer`, and so on, and depend only on the ones you use. The `@mysten/signers`
+	package is a convenience umbrella that re-exports all four under subpaths (`@mysten/signers/aws`,
+	`@mysten/signers/gcp`, `@mysten/signers/ledger`, `@mysten/signers/webcrypto`) if you would rather
+	depend on a single package. The individual pages below use the standalone packages.
+</Callout>
+
+## Other Signer implementations
+
+Two more `Signer` implementations live in `@mysten/sui` itself rather than in a standalone package:
+
+- **[Passkey](/sui/cryptography/signers/passkey)**: sign with a WebAuthn passkey (biometric or
+  platform authenticator) through `PasskeyKeypair`.
+- **[Multi-signature](/sui/cryptography/signers/multisig)**: combine signatures from several public
+  keys under a configurable threshold with `MultiSigPublicKey`. Its `getSigner` method returns a
+  `MultiSigSigner` you can use anywhere a keypair works. The underlying keys can be keypairs, KMS
+  signers, passkeys, or zkLogin identifiers.
 
 ## Shared interface
 
@@ -49,8 +86,8 @@ share.
 
 ## Construction
 
-Each signer exposes a static factory rather than a public constructor, because preparing the signer
-requires an async round-trip to fetch the public key from the KMS or device:
+Each external signer exposes a static factory rather than a public constructor, because preparing
+the signer requires an async round-trip to fetch the public key from the KMS or device:
 
 - `AwsKmsSigner.fromKeyId(keyId, options)`. See [AWS KMS Signer](/sui/cryptography/signers/aws-kms).
 - `GcpKmsSigner.fromOptions(options)`. See [GCP KMS Signer](/sui/cryptography/signers/gcp-kms).

--- a/packages/docs/content/sui/cryptography/signers/meta.json
+++ b/packages/docs/content/sui/cryptography/signers/meta.json
@@ -1,4 +1,4 @@
 {
 	"title": "Signers",
-	"pages": ["index", "aws-kms", "gcp-kms", "ledger", "webcrypto"]
+	"pages": ["index", "aws-kms", "gcp-kms", "ledger", "webcrypto", "passkey", "multisig"]
 }

--- a/packages/docs/content/sui/cryptography/signers/multisig.mdx
+++ b/packages/docs/content/sui/cryptography/signers/multisig.mdx
@@ -18,8 +18,8 @@ The Sui TypeScript SDK provides a `MultiSigPublicKey` class to support
 [Multi-Signature](https://docs.sui.io/concepts/cryptography/transaction-auth/multisig) (MultiSig)
 transaction and personal message signing.
 
-This class implements the same interface as the `PublicKey` classes that [Keypairs](./keypairs) uses
-and you call the same methods to verify signatures for `PersonalMessages` and `Transactions`.
+This class implements the same interface as the `PublicKey` classes that [Keypairs](../keypairs)
+uses and you call the same methods to verify signatures for `PersonalMessages` and `Transactions`.
 
 ## Creating a MultiSigPublicKey
 

--- a/packages/docs/content/sui/cryptography/signers/passkey.mdx
+++ b/packages/docs/content/sui/cryptography/signers/passkey.mdx
@@ -92,7 +92,7 @@ work.
 
 The usage for a passkey keypair is the same as any other keypair. You can derive the public key,
 derive the address, sign personal messages, sign transactions, and verify signatures. See the
-[Key pairs](./keypairs) documentation for more details.
+[Key pairs](../keypairs) documentation for more details.
 
 ```typescript
 const publicKey = keypair.getPublicKey();

--- a/packages/docs/content/sui/index.mdx
+++ b/packages/docs/content/sui/index.mdx
@@ -39,7 +39,7 @@ what you need to keep your code light and compact.
 - [`@mysten/sui/verify`](/sui/cryptography#verifying-signatures): Methods for verifying transactions
   and messages.
 - [`@mysten/sui/cryptography`](/sui/cryptography): Shared types and classes for cryptography.
-- [`@mysten/sui/multisig`](/sui/cryptography/multisig): Utilities for working with multisig
+- [`@mysten/sui/multisig`](/sui/cryptography/signers/multisig): Utilities for working with multisig
   signatures.
 - [`@mysten/sui/utils`](/sui/utils): Utilities for formatting and parsing various Sui types.
 - [`@mysten/sui/faucet`](#faucet): Methods for requesting SUI from a faucet.

--- a/packages/docs/content/sui/zklogin.mdx
+++ b/packages/docs/content/sui/zklogin.mdx
@@ -53,8 +53,8 @@ const address = computeZkLoginAddress({
 });
 ```
 
-To use zkLogin inside a multisig, see the [Multisig Guide](../sui/cryptography/multisig) for more
-details.
+To use zkLogin inside a multisig, see the [Multisig Guide](../sui/cryptography/signers/multisig) for
+more details.
 
 ## Legacy addresses
 

--- a/packages/docs/next.config.mjs
+++ b/packages/docs/next.config.mjs
@@ -60,6 +60,16 @@ const config = {
 				destination: '/sui/cryptography/signers/webcrypto',
 				statusCode: 302,
 			},
+			{
+				source: '/sui/cryptography/multisig',
+				destination: '/sui/cryptography/signers/multisig',
+				statusCode: 302,
+			},
+			{
+				source: '/sui/cryptography/passkey',
+				destination: '/sui/cryptography/signers/passkey',
+				statusCode: 302,
+			},
 		];
 	},
 };

--- a/packages/ledgerjs-hw-app-sui/README.md
+++ b/packages/ledgerjs-hw-app-sui/README.md
@@ -7,6 +7,16 @@
 [Ledger Hardware Wallet](https://www.ledger.com/) JavaScript bindings for [Sui](https://sui.io/),
 based on [LedgerJS](https://github.com/LedgerHQ/ledgerjs).
 
+> **Most applications should use the
+> [`@mysten/ledger-signer`](https://www.npmjs.com/package/@mysten/ledger-signer) package instead.**
+> This package is a low-level binding to the Ledger Sui app. `@mysten/ledger-signer` wraps it in a
+> `LedgerSigner` that implements the standard Sui `Signer` interface, so it works anywhere the SDK
+> accepts a signer (deriving addresses, signing transactions and personal messages,
+> `signAndExecuteTransaction`, and so on). See the
+> [Ledger Signer documentation](https://sdk.mystenlabs.com/sui/cryptography/signers/ledger) for
+> setup and usage. Reach for this package directly only when you need lower-level control over the
+> device protocol.
+
 ## Using LedgerJS for Sui
 
 Here is a sample app for Node:


### PR DESCRIPTION
## Description

Two related docs improvements around signers:

**1. Link the low-level Ledger package to the signer docs.** `@mysten/ledgerjs-hw-app-sui` is a low-level binding to the Ledger Sui app, but most developers should use the higher-level `@mysten/ledger-signer` (`LedgerSigner`) which implements the standard `Signer` interface. Added a prominent note at the top of the hw-app README pointing to `@mysten/ledger-signer` and the [Ledger Signer docs](https://sdk.mystenlabs.com/sui/cryptography/signers/ledger).

**2. Document the standalone signer packages and broaden the signers section.** The signers index now makes clear that each external signer is its own npm package (`@mysten/aws-kms-signer`, `@mysten/gcp-kms-signer`, `@mysten/ledger-signer`, `@mysten/webcrypto-signer`), with `@mysten/signers` as a convenience re-export umbrella — the standalone packages are the documented path.

**3. Reorganize so the signers section isn't specific to the `@mysten/signers` package.** Moved `passkey` and `multisig` under `cryptography/signers/`, and reworked the index into a general overview of `Signer` implementations (external/KMS, hardware, Web Crypto, passkey, multisig). Cryptography now has just `index`, `keypairs`, and `signers`.

Inbound links updated and redirects added for the two relocated URLs (`/sui/cryptography/multisig`, `/sui/cryptography/passkey`).

## Test plan

- `pnpm --filter @mysten/docs build:docs` — generates cleanly
- `pnpm --filter @mysten/docs validate-docs` — frontmatter, orphan, and internal-link checks all pass
- `pnpm prettier` — all changed files formatted

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)