### PR TITLE
[sponsor] Adds a runnable example

### DIFF
--- a/packages/sponsor/examples/sponsor-server/README.md
+++ b/packages/sponsor/examples/sponsor-server/README.md
@@ -1,0 +1,56 @@
+# Sponsor server example
+
+This example runs a small Hono server that sponsors and executes user-signed transactions only when
+they call a configured Move function.
+
+The server keeps the default sponsor validators, verifies the user signature, caps the gas budget,
+and requires the transaction to contain exactly one command: a `MoveCall` to `ALLOWED_TARGET`.
+
+## Run
+
+```sh
+SPONSOR_KEY=<sponsor-secret-key> \
+ALLOWED_TARGET=0x...::module::function \
+pnpm --filter @mysten-incubation/sponsor dev:sponsor-server
+```
+
+Optional environment variables:
+
+- `FULLNODE_URL`: Sui gRPC fullnode URL. Defaults to Testnet.
+- `MAX_GAS_BUDGET`: Maximum sponsored gas budget in MIST. Defaults to `50000000`.
+- `PORT`: Server port. Defaults to `3000`.
+
+## Request
+
+The client fetches the sponsor address from `/config`, builds a transaction with that address as gas
+owner and address-balance gas, signs those bytes, then sends the base64 transaction, signature, and
+optional execution `include` fields to the server. `effects` are always included in the response,
+even if omitted from `include`.
+
+```ts
+import { toBase64 } from '@mysten/sui/utils';
+
+const config = await fetch('http://127.0.0.1:3000/config').then(
+	(response) => response.json() as Promise<{ sponsor: string }>,
+);
+
+transaction.setSender(userAddress);
+transaction.setGasOwner(config.sponsor);
+transaction.setGasPayment([]);
+
+const bytes = await transaction.build({ client });
+const { signature } = await userSigner.signTransaction(bytes);
+
+const response = await fetch('http://127.0.0.1:3000/v1/sponsor', {
+	method: 'POST',
+	headers: { 'content-type': 'application/json' },
+	body: JSON.stringify({
+		transaction: toBase64(bytes),
+		userSignature: signature,
+		include: {
+			events: true,
+			balanceChanges: true,
+		},
+	}),
+});
+```

--- a/packages/sponsor/examples/sponsor-server/index.ts
+++ b/packages/sponsor/examples/sponsor-server/index.ts
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { serve } from '@hono/node-server';
+import type { SuiClientTypes } from '@mysten/sui/client';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
+import { Hono } from 'hono';
+
+import {
+	analyzers,
+	createAnalyzer,
+	createSponsor,
+	defaults,
+	gasBudget,
+	userSignatureMatchesSender,
+} from '../../src/index.js';
+
+const FULLNODE_URL = process.env.FULLNODE_URL ?? 'https://fullnode.testnet.sui.io:443';
+const SPONSOR_KEY = requiredEnv('SPONSOR_KEY');
+const ALLOWED_TARGET = parseMoveTarget(requiredEnv('ALLOWED_TARGET'));
+const MAX_GAS_BUDGET = BigInt(process.env.MAX_GAS_BUDGET ?? 50_000_000);
+const PORT = Number.parseInt(process.env.PORT ?? '3000', 10);
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: FULLNODE_URL,
+});
+
+const onlyAllowedTargetCall = createAnalyzer({
+	dependencies: { data: analyzers.data },
+	analyze:
+		() =>
+		({ data }) => {
+			if (data.commands.length !== 1) {
+				return {
+					result: [
+						{
+							code: 'EXPECTED_ONE_COMMAND',
+							message: 'Transaction must contain exactly one command.',
+						},
+					],
+				};
+			}
+
+			const [command] = data.commands;
+			if (
+				command.$kind !== 'MoveCall' ||
+				normalizeSuiAddress(command.MoveCall.package) !== ALLOWED_TARGET.packageId ||
+				command.MoveCall.module !== ALLOWED_TARGET.module ||
+				command.MoveCall.function !== ALLOWED_TARGET.function
+			) {
+				return {
+					result: [
+						{
+							code: 'TARGET_CALL_REQUIRED',
+							message: `The only command must be a MoveCall to ${ALLOWED_TARGET.target}.`,
+						},
+					],
+				};
+			}
+
+			return { result: null };
+		},
+});
+
+const sponsor = createSponsor({
+	signer: Ed25519Keypair.fromSecretKey(SPONSOR_KEY),
+	client,
+	validate: [
+		defaults(),
+		userSignatureMatchesSender(),
+		gasBudget({ max: MAX_GAS_BUDGET }),
+		onlyAllowedTargetCall,
+	],
+});
+
+type SponsorExecutionInclude = Omit<SuiClientTypes.TransactionInclude, 'effects'> & {
+	effects?: never;
+};
+
+type SponsorRequest = {
+	transaction: string;
+	userSignature: string | string[];
+	include?: SponsorExecutionInclude;
+};
+
+const app = new Hono();
+
+// Expose the sponsor address the client sets as gas owner before building / signing bytes.
+app.get('/config', (c) =>
+	c.json({
+		ok: true,
+		sponsor: sponsor.address,
+		allowedTarget: ALLOWED_TARGET.target,
+		maxGasBudget: MAX_GAS_BUDGET.toString(),
+	}),
+);
+
+// Accept already-built, user-signed transaction bytes; validate policy, co-sign, and execute.
+app.post('/v1/sponsor', async (c) => {
+	const body = await c.req.json<SponsorRequest>();
+
+	const result = await sponsor.signAndExecuteTransaction({
+		transaction: body.transaction,
+		userSignature: body.userSignature,
+		include: body.include,
+	});
+
+	switch (result.$kind) {
+		case 'Rejected':
+			return c.json({ ok: false, reason: result.reason, issues: result.issues }, 403);
+		case 'FailedTransaction':
+			return c.json(
+				{
+					ok: false,
+					error: 'Transaction executed but failed on-chain.',
+					digest: result.FailedTransaction.digest,
+					transaction: result.FailedTransaction,
+				},
+				502,
+			);
+		case 'Transaction':
+			return c.json({
+				ok: true,
+				digest: result.Transaction.digest,
+				transaction: result.Transaction,
+			});
+	}
+});
+
+serve({ fetch: app.fetch, port: PORT }, (info) => {
+	console.log(`Sponsor server listening on http://127.0.0.1:${info.port}`);
+	console.log(`Sponsor address: ${sponsor.address}`);
+	console.log(`Allowed target: ${ALLOWED_TARGET.target}`);
+});
+
+function parseMoveTarget(target: string) {
+	const [packageId, module, fn] = target.split('::');
+	if (!packageId || !module || !fn) {
+		throw new Error('ALLOWED_TARGET must use the format packageId::module::function.');
+	}
+	return {
+		target: `${normalizeSuiAddress(packageId)}::${module}::${fn}`,
+		packageId: normalizeSuiAddress(packageId),
+		module,
+		function: fn,
+	};
+}
+
+function requiredEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+	return value;
+}

--- a/packages/sponsor/examples/tsconfig.json
+++ b/packages/sponsor/examples/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../tsconfig.json",
+	"include": ["**/*.ts", "../src/**/*.ts"],
+	"compilerOptions": {
+		"noEmit": true,
+		"rootDir": "..",
+		"types": ["node"],
+		"module": "preserve",
+		"moduleResolution": "bundler"
+	}
+}

--- a/packages/sponsor/package.json
+++ b/packages/sponsor/package.json
@@ -34,20 +34,24 @@
 	"scripts": {
 		"clean": "rm -rf tsconfig.tsbuildinfo ./dist",
 		"build": "rm -rf dist && tsc --noEmit && tsdown",
+		"dev:sponsor-server": "tsx examples/sponsor-server/index.ts",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"oxlint:check": "oxlint  .",
 		"oxlint:fix": "oxlint --fix",
 		"lint": "pnpm run oxlint:check && pnpm run prettier:check",
 		"lint:fix": "pnpm run oxlint:fix && pnpm run prettier:fix",
-		"test": "pnpm run test:typecheck && pnpm run test:unit",
+		"test": "pnpm run test:typecheck && pnpm run test:examples && pnpm run test:unit",
+		"test:examples": "tsc -p ./examples",
 		"test:typecheck": "tsc -p ./test",
 		"test:unit": "vitest run",
 		"test:e2e": "vitest run --config test/e2e/vitest.config.ts",
 		"vitest": "vitest"
 	},
 	"devDependencies": {
+		"@hono/node-server": "^2.0.4",
 		"@types/node": "^25.9.3",
+		"hono": "^4.12.25",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.8"
 	},

--- a/packages/sponsor/package.json
+++ b/packages/sponsor/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@hono/node-server": "^2.0.4",
 		"@types/node": "^25.9.3",
-		"hono": "^4.12.25",
+		"hono": ">=4.12.18",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.8"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1232,9 +1232,15 @@ importers:
         specifier: workspace:^
         version: link:../wallet-sdk
     devDependencies:
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.25)
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.25
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,7 +1239,7 @@ importers:
         specifier: ^25.9.3
         version: 25.9.3
       hono:
-        specifier: ^4.12.25
+        specifier: '>=4.12.18'
         version: 4.12.25
       typescript:
         specifier: ^6.0.3


### PR DESCRIPTION
## Description

Add a runnable example for running sponsorship through an API, that validates that a PTB only has 1 move call, calling a specific package.

## Test plan

Tried locally against the e2e counter example & also verified failure modes. Not including these as this is an example.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
