### PR TITLE
feat(aws-kms-signer): Ed25519 support + pluggable credential provider

### DIFF
--- a/.changeset/aws-kms-credential-provider.md
+++ b/.changeset/aws-kms-credential-provider.md
@@ -1,0 +1,16 @@
+---
+'@mysten/aws-kms-signer': minor
+---
+
+Support a pluggable credential provider in `AwsKmsClient` / `AwsKmsSigner`.
+
+`AwsClientOptions` now accepts an optional async `credentials` provider (compatible with the
+providers from `@aws-sdk/credential-providers`, e.g. `fromNodeProviderChain()`). When supplied,
+credentials are resolved before each request instead of being captured statically at
+construction. This enables the standard AWS credential provider chain (SSO, IAM roles,
+container/instance metadata) and lets temporary credentials refresh automatically — previously
+the only option was static `accessKeyId`/`secretAccessKey`, which cannot refresh and break when
+the underlying session expires.
+
+Static credentials continue to work unchanged, so this is fully backwards compatible. New
+`AwsCredentialIdentity` and `AwsCredentialProvider` types are exported.

--- a/.changeset/aws-kms-ed25519.md
+++ b/.changeset/aws-kms-ed25519.md
@@ -1,0 +1,13 @@
+---
+'@mysten/aws-kms-signer': minor
+---
+
+Add Ed25519 support to `AwsKmsSigner`.
+
+`AwsKmsClient.getPublicKey` now recognizes the `ECC_NIST_EDWARDS25519` key spec and
+returns an `Ed25519PublicKey`, and `AwsKmsSigner.sign` signs with the `ED25519_SHA_512`
+algorithm for Ed25519 keys. Ed25519 signatures are returned as raw 64-byte values, so the
+DER parsing and low-S normalization used for the ECDSA curves is skipped.
+
+This lets AWS KMS sign for Sui's native Ed25519 scheme — previously only `Secp256k1`
+(`ECC_SECG_P256K1`) and `Secp256r1` (`ECC_NIST_P256`) keys were supported.

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -61,8 +61,8 @@ Instead of static keys, pass an async `credentials` provider (any function retur
 `{ accessKeyId, secretAccessKey, sessionToken? }`). This is structurally compatible with the
 providers from
 [`@aws-sdk/credential-providers`](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html),
-so the standard AWS credential chain (SSO, IAM roles, and container/instance metadata) works out
-of the box. Credentials are resolved before each request, so temporary credentials refresh
+so the standard AWS credential chain (SSO, IAM roles, and container/instance metadata) works out of
+the box. Credentials are resolved before each request, so temporary credentials refresh
 automatically once their session nears expiry.
 
 ```typescript
@@ -76,8 +76,8 @@ const signer = await AwsKmsSigner.fromKeyId(process.env.AWS_KMS_KEY_ID, {
 });
 ```
 
-`@aws-sdk/credential-providers` is **not** a dependency of this package, so install it yourself if you
-want the AWS-provided resolvers. This keeps the signer lightweight for edge, browser, and Worker
+`@aws-sdk/credential-providers` is **not** a dependency of this package, so install it yourself if
+you want the AWS-provided resolvers. This keeps the signer lightweight for edge, browser, and Worker
 runtimes, where you can instead pass static credentials or a custom resolver.
 
 ## Usage

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -57,11 +57,11 @@ You must supply either static `accessKeyId`/`secretAccessKey` **or** a `credenti
 
 ### Using a credential provider
 
-Instead of static keys, pass an async `credentials` provider — any function returning
-`{ accessKeyId, secretAccessKey, sessionToken? }`. This is structurally compatible with the
+Instead of static keys, pass an async `credentials` provider (any function returning
+`{ accessKeyId, secretAccessKey, sessionToken? }`). This is structurally compatible with the
 providers from
 [`@aws-sdk/credential-providers`](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html),
-so the standard AWS credential chain — SSO, IAM roles, and container/instance metadata — works out
+so the standard AWS credential chain (SSO, IAM roles, and container/instance metadata) works out
 of the box. Credentials are resolved before each request, so temporary credentials refresh
 automatically once their session nears expiry.
 
@@ -76,7 +76,7 @@ const signer = await AwsKmsSigner.fromKeyId(process.env.AWS_KMS_KEY_ID, {
 });
 ```
 
-`@aws-sdk/credential-providers` is **not** a dependency of this package — install it yourself if you
+`@aws-sdk/credential-providers` is **not** a dependency of this package, so install it yourself if you
 want the AWS-provided resolvers. This keeps the signer lightweight for edge, browser, and Worker
 runtimes, where you can instead pass static credentials or a custom resolver.
 

--- a/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
+++ b/packages/docs/content/sui/cryptography/signers/aws-kms.mdx
@@ -1,15 +1,16 @@
 ---
 title: AWS KMS Signer
 description: Sign Sui transactions with a key stored in AWS Key Management Service
-keywords: [AWS KMS, signer, AwsKmsSigner, KMS, Secp256k1, Secp256r1, Sui, TypeScript SDK]
+keywords: [AWS KMS, signer, AwsKmsSigner, KMS, Ed25519, Secp256k1, Secp256r1, Sui, TypeScript SDK]
 ---
 
 The `AwsKmsSigner` signs Sui transactions using a key held in
 [AWS Key Management Service](https://aws.amazon.com/kms/). The private key never leaves AWS; the
-signer sends the message digest to KMS and receives the signature back.
+signer sends the message to KMS and receives the signature back.
 
-AWS KMS supports the `Secp256k1` and `Secp256r1` schemes. The curve of the KMS key determines the
-signature scheme (`ECC_SECG_P256K1` → `Secp256k1`, `ECC_NIST_P256` → `Secp256r1`).
+AWS KMS supports the `Ed25519`, `Secp256k1`, and `Secp256r1` schemes. The curve of the KMS key
+determines the signature scheme (`ECC_NIST_EDWARDS25519` → `Ed25519`, `ECC_SECG_P256K1` →
+`Secp256k1`, `ECC_NIST_P256` → `Secp256r1`). `Ed25519` is Sui's native scheme.
 
 <Callout type="warn">
 	The AWS KMS Signer requires Node.js >= 22 (the package's `engines.node` constraint) and relies on
@@ -44,12 +45,40 @@ const signer = await AwsKmsSigner.fromKeyId(AWS_KMS_KEY_ID, {
 
 `fromKeyId(keyId, options)`
 
-| Parameter                 | Type     | Description                     |
-| ------------------------- | -------- | ------------------------------- |
-| `keyId`                   | `string` | The AWS KMS key ID              |
-| `options.region`          | `string` | The AWS region the key lives in |
-| `options.accessKeyId`     | `string` | The AWS access key ID           |
-| `options.secretAccessKey` | `string` | The AWS secret access key       |
+| Parameter                 | Type                    | Description                                                      |
+| ------------------------- | ----------------------- | ---------------------------------------------------------------- |
+| `keyId`                   | `string`                | The AWS KMS key ID                                               |
+| `options.region`          | `string`                | The AWS region the key lives in                                  |
+| `options.accessKeyId`     | `string`                | The AWS access key ID (omit when using `credentials`)            |
+| `options.secretAccessKey` | `string`                | The AWS secret access key (omit when using `credentials`)        |
+| `options.credentials`     | `AwsCredentialProvider` | Optional async provider resolved before each request (see below) |
+
+You must supply either static `accessKeyId`/`secretAccessKey` **or** a `credentials` provider.
+
+### Using a credential provider
+
+Instead of static keys, pass an async `credentials` provider — any function returning
+`{ accessKeyId, secretAccessKey, sessionToken? }`. This is structurally compatible with the
+providers from
+[`@aws-sdk/credential-providers`](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html),
+so the standard AWS credential chain — SSO, IAM roles, and container/instance metadata — works out
+of the box. Credentials are resolved before each request, so temporary credentials refresh
+automatically once their session nears expiry.
+
+```typescript
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
+import { AwsKmsSigner } from '@mysten/aws-kms-signer';
+
+const signer = await AwsKmsSigner.fromKeyId(process.env.AWS_KMS_KEY_ID, {
+	region: process.env.AWS_REGION,
+	credentials: fromNodeProviderChain(),
+});
+```
+
+`@aws-sdk/credential-providers` is **not** a dependency of this package — install it yourself if you
+want the AWS-provided resolvers. This keeps the signer lightweight for edge, browser, and Worker
+runtimes, where you can instead pass static credentials or a custom resolver.
 
 ## Usage
 

--- a/packages/signers/aws/src/aws-client.ts
+++ b/packages/signers/aws/src/aws-client.ts
@@ -88,32 +88,13 @@ export class AwsKmsClient extends AwsClient {
 			...options,
 			service: 'kms',
 			// aws4fetch requires non-null credentials at construction. When a provider is used,
-			// pass placeholders here — `runCommand` resolves the real credentials before each
-			// request via `#resolveCredentials`.
+			// pass placeholders here — `runCommand` resolves the real credentials per request and
+			// passes them through aws4fetch's `aws` override.
 			accessKeyId: options.accessKeyId ?? '',
 			secretAccessKey: options.secretAccessKey ?? '',
 		});
 
 		this.#credentialsProvider = options.credentials;
-	}
-
-	/**
-	 * Resolves fresh credentials from the configured provider and applies them before signing
-	 * the next request. No-op when static credentials were supplied instead.
-	 *
-	 * This is what lets temporary credentials (SSO, IAM roles, STS) refresh: provider chains
-	 * memoize internally and only hit the network when the cached credentials are near expiry,
-	 * so calling this before every request is cheap and correct.
-	 */
-	async #resolveCredentials() {
-		if (!this.#credentialsProvider) {
-			return;
-		}
-
-		const credentials = await this.#credentialsProvider();
-		this.accessKeyId = credentials.accessKeyId;
-		this.secretAccessKey = credentials.secretAccessKey;
-		this.sessionToken = credentials.sessionToken;
 	}
 
 	async getPublicKey(keyId: string) {
@@ -150,8 +131,12 @@ export class AwsKmsClient extends AwsClient {
 			throw new Error('Region is required');
 		}
 
-		// Resolve fresh credentials before signing (no-op unless a provider was configured).
-		await this.#resolveCredentials();
+		// Resolve fresh credentials for this request when a provider is configured. They're handed
+		// to aws4fetch per-request via its `aws` override rather than mutating shared instance
+		// state, so concurrent requests can't race on each other's credentials. Provider chains
+		// memoize internally and only hit the network near expiry, so this is cheap and is what
+		// lets temporary credentials (SSO, IAM roles, STS) refresh.
+		const credentials = await this.#credentialsProvider?.();
 
 		const res = await this.fetch(`https://kms.${region}.amazonaws.com/`, {
 			headers: {
@@ -159,6 +144,7 @@ export class AwsKmsClient extends AwsClient {
 				'X-Amz-Target': `TrentService.${command}`,
 			},
 			body: JSON.stringify(body),
+			...(credentials && { aws: credentials }),
 		});
 
 		if (!res.ok) {

--- a/packages/signers/aws/src/aws-client.ts
+++ b/packages/signers/aws/src/aws-client.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519';
 import { Secp256k1PublicKey } from '@mysten/sui/keypairs/secp256k1';
 import { Secp256r1PublicKey } from '@mysten/sui/keypairs/secp256r1';
 import { fromBase64 } from '@mysten/sui/utils';
 
 import { AwsClient } from './aws4fetch.js';
-import { publicKeyFromDER } from './utils.js';
+import { publicKeyFromDER, publicKeyFromEd25519DER } from './utils.js';
 
 interface KmsCommands {
 	Sign: {
@@ -14,7 +15,7 @@ interface KmsCommands {
 			KeyId: string;
 			Message: string;
 			MessageType: 'RAW' | 'DIGEST';
-			SigningAlgorithm: 'ECDSA_SHA_256';
+			SigningAlgorithm: 'ECDSA_SHA_256' | 'ED25519_SHA_512';
 		};
 		response: {
 			KeyId: string;
@@ -65,13 +66,15 @@ export class AwsKmsClient extends AwsClient {
 			throw new Error('Public Key not found for the supplied `keyId`');
 		}
 
-		const compressedKey = publicKeyFromDER(fromBase64(publicKeyResponse.PublicKey));
+		const derBytes = fromBase64(publicKeyResponse.PublicKey);
 
 		switch (publicKeyResponse.KeySpec) {
 			case 'ECC_NIST_P256':
-				return new Secp256r1PublicKey(compressedKey);
+				return new Secp256r1PublicKey(publicKeyFromDER(derBytes));
 			case 'ECC_SECG_P256K1':
-				return new Secp256k1PublicKey(compressedKey);
+				return new Secp256k1PublicKey(publicKeyFromDER(derBytes));
+			case 'ECC_NIST_EDWARDS25519':
+				return new Ed25519PublicKey(publicKeyFromEd25519DER(derBytes));
 			default:
 				throw new Error('Unsupported key spec: ' + publicKeyResponse.KeySpec);
 		}

--- a/packages/signers/aws/src/aws-client.ts
+++ b/packages/signers/aws/src/aws-client.ts
@@ -38,12 +38,46 @@ interface KmsCommands {
 	};
 }
 
-export interface AwsClientOptions extends Partial<ConstructorParameters<typeof AwsClient>[0]> {}
+/**
+ * A resolved set of AWS credentials. Structurally compatible with the AWS SDK's
+ * `AwsCredentialIdentity`, so providers from `@aws-sdk/credential-providers` can be passed directly.
+ */
+export interface AwsCredentialIdentity {
+	accessKeyId: string;
+	secretAccessKey: string;
+	sessionToken?: string;
+}
+
+/**
+ * An async function that resolves AWS credentials. Compatible with the AWS SDK's
+ * `AwsCredentialIdentityProvider` (e.g. the providers from `@aws-sdk/credential-providers`
+ * such as `fromNodeProviderChain()`), enabling SSO, IAM roles, and automatic refresh of
+ * temporary credentials.
+ */
+export type AwsCredentialProvider = () => Promise<AwsCredentialIdentity>;
+
+export interface AwsClientOptions extends Partial<ConstructorParameters<typeof AwsClient>[0]> {
+	/**
+	 * An optional async credential provider. When supplied, credentials are resolved before
+	 * each request instead of being captured statically at construction — enabling the standard
+	 * AWS credential provider chain (SSO, IAM roles, container/instance metadata) and letting
+	 * temporary credentials refresh automatically. Compatible with the providers exported by
+	 * `@aws-sdk/credential-providers`.
+	 */
+	credentials?: AwsCredentialProvider;
+}
 
 export class AwsKmsClient extends AwsClient {
+	/** Optional async credential provider, resolved before each request. */
+	readonly #credentialsProvider?: AwsCredentialProvider;
+
 	constructor(options: AwsClientOptions = {}) {
-		if (!options.accessKeyId || !options.secretAccessKey) {
-			throw new Error('AWS Access Key ID and Secret Access Key are required');
+		const hasStaticCredentials = Boolean(options.accessKeyId && options.secretAccessKey);
+
+		if (!hasStaticCredentials && !options.credentials) {
+			throw new Error(
+				'Either static credentials (`accessKeyId` and `secretAccessKey`) or a `credentials` provider is required',
+			);
 		}
 
 		if (!options.region) {
@@ -51,12 +85,35 @@ export class AwsKmsClient extends AwsClient {
 		}
 
 		super({
-			region: options.region,
-			accessKeyId: options.accessKeyId,
-			secretAccessKey: options.secretAccessKey,
-			service: 'kms',
 			...options,
+			service: 'kms',
+			// aws4fetch requires non-null credentials at construction. When a provider is used,
+			// pass placeholders here — `runCommand` resolves the real credentials before each
+			// request via `#resolveCredentials`.
+			accessKeyId: options.accessKeyId ?? '',
+			secretAccessKey: options.secretAccessKey ?? '',
 		});
+
+		this.#credentialsProvider = options.credentials;
+	}
+
+	/**
+	 * Resolves fresh credentials from the configured provider and applies them before signing
+	 * the next request. No-op when static credentials were supplied instead.
+	 *
+	 * This is what lets temporary credentials (SSO, IAM roles, STS) refresh: provider chains
+	 * memoize internally and only hit the network when the cached credentials are near expiry,
+	 * so calling this before every request is cheap and correct.
+	 */
+	async #resolveCredentials() {
+		if (!this.#credentialsProvider) {
+			return;
+		}
+
+		const credentials = await this.#credentialsProvider();
+		this.accessKeyId = credentials.accessKeyId;
+		this.secretAccessKey = credentials.secretAccessKey;
+		this.sessionToken = credentials.sessionToken;
 	}
 
 	async getPublicKey(keyId: string) {
@@ -92,6 +149,9 @@ export class AwsKmsClient extends AwsClient {
 		if (!region) {
 			throw new Error('Region is required');
 		}
+
+		// Resolve fresh credentials before signing (no-op unless a provider was configured).
+		await this.#resolveCredentials();
 
 		const res = await this.fetch(`https://kms.${region}.amazonaws.com/`, {
 			headers: {

--- a/packages/signers/aws/src/aws-kms-signer.ts
+++ b/packages/signers/aws/src/aws-kms-signer.ts
@@ -50,7 +50,7 @@ export class AwsKmsSigner extends Signer {
 
 	/**
 	 * Retrieves the key scheme used by this signer.
-	 * @returns AWS supports only Secp256k1 and Secp256r1 schemes.
+	 * @returns The scheme derived from the public key — `Ed25519`, `Secp256k1`, or `Secp256r1`.
 	 */
 	getKeyScheme() {
 		return SIGNATURE_FLAG_TO_SCHEME[this.#publicKey.flag() as SignatureFlag];
@@ -58,7 +58,7 @@ export class AwsKmsSigner extends Signer {
 
 	/**
 	 * Retrieves the public key associated with this signer.
-	 * @returns The Secp256k1PublicKey instance.
+	 * @returns The public key instance (`Ed25519PublicKey`, `Secp256k1PublicKey`, or `Secp256r1PublicKey`).
 	 * @throws Will throw an error if the public key has not been initialized.
 	 */
 	getPublicKey() {
@@ -72,6 +72,21 @@ export class AwsKmsSigner extends Signer {
 	 * @throws Will throw an error if the public key is not initialized or if signing fails.
 	 */
 	async sign(bytes: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
+		const keyScheme = this.getKeyScheme();
+
+		// Ed25519 keys use the EdDSA signing algorithm and return a raw 64-byte signature,
+		// so no DER parsing or low-S normalization (required for the ECDSA curves) is needed.
+		if (keyScheme === 'ED25519') {
+			const signResponse = await this.#client.runCommand('Sign', {
+				KeyId: this.#kmsKeyId,
+				Message: toBase64(bytes),
+				MessageType: 'RAW',
+				SigningAlgorithm: 'ED25519_SHA_512',
+			});
+
+			return fromBase64(signResponse.Signature) as Uint8Array<ArrayBuffer>;
+		}
+
 		const signResponse = await this.#client.runCommand('Sign', {
 			KeyId: this.#kmsKeyId,
 			Message: toBase64(bytes),
@@ -80,7 +95,7 @@ export class AwsKmsSigner extends Signer {
 		});
 
 		// Concatenate the signature components into a compact form
-		return getConcatenatedSignature(fromBase64(signResponse.Signature), this.getKeyScheme());
+		return getConcatenatedSignature(fromBase64(signResponse.Signature), keyScheme);
 	}
 
 	/**

--- a/packages/signers/aws/src/aws-kms-signer.ts
+++ b/packages/signers/aws/src/aws-kms-signer.ts
@@ -9,6 +9,36 @@ import { AwsKmsClient } from './aws-client.js';
 import { getConcatenatedSignature } from './utils.js';
 
 /**
+ * Maps each supported key scheme to its AWS KMS signing algorithm and the function that
+ * converts the raw KMS response into the compact signature Sui expects.
+ *
+ * - Ed25519 keys use EdDSA and return a raw 64-byte signature, so no DER parsing or low-S
+ *   normalization is needed.
+ * - The ECDSA curves return a DER-encoded signature that is parsed, low-S normalized, and
+ *   concatenated into compact form by `getConcatenatedSignature`.
+ */
+const SIGNING_ALGORITHMS: Record<
+	string,
+	{
+		algorithm: 'ED25519_SHA_512' | 'ECDSA_SHA_256';
+		format: (signature: Uint8Array) => Uint8Array<ArrayBuffer>;
+	}
+> = {
+	ED25519: {
+		algorithm: 'ED25519_SHA_512',
+		format: (signature) => signature as Uint8Array<ArrayBuffer>,
+	},
+	Secp256k1: {
+		algorithm: 'ECDSA_SHA_256',
+		format: (signature) => getConcatenatedSignature(signature, 'Secp256k1'),
+	},
+	Secp256r1: {
+		algorithm: 'ECDSA_SHA_256',
+		format: (signature) => getConcatenatedSignature(signature, 'Secp256r1'),
+	},
+};
+
+/**
  * Configuration options for initializing the AwsKmsSigner.
  */
 export interface AwsKmsSignerOptions {
@@ -72,30 +102,20 @@ export class AwsKmsSigner extends Signer {
 	 * @throws Will throw an error if the public key is not initialized or if signing fails.
 	 */
 	async sign(bytes: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
-		const keyScheme = this.getKeyScheme();
+		const signing = SIGNING_ALGORITHMS[this.getKeyScheme()];
 
-		// Ed25519 keys use the EdDSA signing algorithm and return a raw 64-byte signature,
-		// so no DER parsing or low-S normalization (required for the ECDSA curves) is needed.
-		if (keyScheme === 'ED25519') {
-			const signResponse = await this.#client.runCommand('Sign', {
-				KeyId: this.#kmsKeyId,
-				Message: toBase64(bytes),
-				MessageType: 'RAW',
-				SigningAlgorithm: 'ED25519_SHA_512',
-			});
-
-			return fromBase64(signResponse.Signature) as Uint8Array<ArrayBuffer>;
+		if (!signing) {
+			throw new Error('Unsupported key scheme');
 		}
 
 		const signResponse = await this.#client.runCommand('Sign', {
 			KeyId: this.#kmsKeyId,
 			Message: toBase64(bytes),
 			MessageType: 'RAW',
-			SigningAlgorithm: 'ECDSA_SHA_256',
+			SigningAlgorithm: signing.algorithm,
 		});
 
-		// Concatenate the signature components into a compact form
-		return getConcatenatedSignature(fromBase64(signResponse.Signature), keyScheme);
+		return signing.format(fromBase64(signResponse.Signature));
 	}
 
 	/**

--- a/packages/signers/aws/src/index.ts
+++ b/packages/signers/aws/src/index.ts
@@ -1,9 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-import type { AwsClientOptions } from './aws-client.js';
+import type {
+	AwsClientOptions,
+	AwsCredentialIdentity,
+	AwsCredentialProvider,
+} from './aws-client.js';
 import type { AwsKmsSignerOptions } from './aws-kms-signer.js';
 import { AwsKmsSigner } from './aws-kms-signer.js';
 
 export { AwsKmsSigner };
 
-export type { AwsKmsSignerOptions, AwsClientOptions };
+export type { AwsKmsSignerOptions, AwsClientOptions, AwsCredentialIdentity, AwsCredentialProvider };

--- a/packages/signers/aws/src/utils.ts
+++ b/packages/signers/aws/src/utils.ts
@@ -33,6 +33,41 @@ function bitsToBytes(bitsArray: Uint8ClampedArray): Uint8Array {
 	return bytes;
 }
 
+/**
+ * The fixed ASN.1/DER (SPKI) prefix for an Ed25519 public key, as returned by AWS KMS
+ * `GetPublicKey` for an `ECC_NIST_EDWARDS25519` key. The raw 32-byte key follows the prefix.
+ *
+ * Structure: SEQUENCE { SEQUENCE { OID 1.3.101.112 } BIT STRING { 0x00 || <32 raw bytes> } }
+ */
+const ED25519_SPKI_PREFIX = new Uint8Array([
+	0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+/**
+ * Extracts the raw 32-byte Ed25519 public key from its DER/SPKI encoding.
+ *
+ * Unlike the ECDSA curves, Ed25519 keys need no point decompression — the raw key is the
+ * final 32 bytes of the SPKI structure, so we validate the fixed prefix and slice it off.
+ *
+ * @param derBytes - The DER-encoded SPKI public key bytes.
+ * @returns A `Uint8Array` containing the raw 32-byte Ed25519 public key.
+ *
+ * @throws {Error} If the input does not match the expected Ed25519 SPKI structure.
+ */
+export function publicKeyFromEd25519DER(derBytes: Uint8Array): Uint8Array {
+	if (derBytes.length !== ED25519_SPKI_PREFIX.length + 32) {
+		throw new Error('Unexpected length for an Ed25519 SPKI public key');
+	}
+
+	for (let i = 0; i < ED25519_SPKI_PREFIX.length; i++) {
+		if (derBytes[i] !== ED25519_SPKI_PREFIX[i]) {
+			throw new Error('Unexpected ASN.1 structure for an Ed25519 public key');
+		}
+	}
+
+	return derBytes.slice(ED25519_SPKI_PREFIX.length);
+}
+
 export function publicKeyFromDER(derBytes: Uint8Array) {
 	const encodedData: Uint8Array = derBytes;
 	const derElement = new DERElement();

--- a/packages/signers/aws/tests/credential-provider.test.ts
+++ b/packages/signers/aws/tests/credential-provider.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AwsKmsClient } from '../src/aws-client.js';
+
+describe('AwsKmsClient credential handling', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('throws when neither static credentials nor a provider are supplied', () => {
+		expect(() => new AwsKmsClient({ region: 'us-east-1' })).toThrow(/credentials/i);
+	});
+
+	it('accepts a credential provider without static credentials', () => {
+		expect(
+			() =>
+				new AwsKmsClient({
+					region: 'us-east-1',
+					credentials: async () => ({ accessKeyId: 'AKID', secretAccessKey: 'SECRET' }),
+				}),
+		).not.toThrow();
+	});
+
+	it('remains backwards compatible with static credentials', () => {
+		expect(
+			() =>
+				new AwsKmsClient({
+					region: 'us-east-1',
+					accessKeyId: 'AKID',
+					secretAccessKey: 'SECRET',
+				}),
+		).not.toThrow();
+	});
+
+	it('resolves the credential provider before every request (enables refresh)', async () => {
+		const provider = vi.fn(async () => ({
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+			sessionToken: 'TOKEN',
+		}));
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify({ KeyId: 'k' }), { status: 200 }),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const client = new AwsKmsClient({ region: 'us-east-1', credentials: provider });
+
+		await client.runCommand('GetPublicKey', { KeyId: 'k' });
+		await client.runCommand('GetPublicKey', { KeyId: 'k' });
+
+		// Re-resolved on each request — this is precisely what lets temporary credentials refresh.
+		expect(provider).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not invoke a provider when static credentials are used', async () => {
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify({ KeyId: 'k' }), { status: 200 }),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const client = new AwsKmsClient({
+			region: 'us-east-1',
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+		});
+
+		await client.runCommand('GetPublicKey', { KeyId: 'k' });
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/signers/aws/tests/credential-provider.test.ts
+++ b/packages/signers/aws/tests/credential-provider.test.ts
@@ -56,6 +56,35 @@ describe('AwsKmsClient credential handling', () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 
+	it('signs each concurrent request with its own resolved credentials (no shared-state race)', async () => {
+		let counter = 0;
+		const provider = vi.fn(async () => {
+			const n = ++counter;
+			// Yield so the other in-flight request can interleave between resolve and sign.
+			await Promise.resolve();
+			return { accessKeyId: `AKID${n}`, secretAccessKey: `SECRET${n}` };
+		});
+
+		const signedAccessKeyIds: string[] = [];
+		const fetchMock = vi.fn(async (req: Request) => {
+			const credential = (req.headers.get('authorization') ?? '').match(/Credential=([^/]+)\//);
+			if (credential) signedAccessKeyIds.push(credential[1]);
+			return new Response(JSON.stringify({ KeyId: 'k' }), { status: 200 });
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		const client = new AwsKmsClient({ region: 'us-east-1', credentials: provider });
+
+		await Promise.all([
+			client.runCommand('GetPublicKey', { KeyId: 'k' }),
+			client.runCommand('GetPublicKey', { KeyId: 'k' }),
+		]);
+
+		// Each request must be signed with the distinct credentials resolved for it — not whichever
+		// value the other concurrent request happened to resolve last into shared state.
+		expect(signedAccessKeyIds.sort()).toEqual(['AKID1', 'AKID2']);
+	});
+
 	it('does not invoke a provider when static credentials are used', async () => {
 		const fetchMock = vi.fn(
 			async () => new Response(JSON.stringify({ KeyId: 'k' }), { status: 200 }),

--- a/packages/signers/aws/tests/sign.test.ts
+++ b/packages/signers/aws/tests/sign.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
+import { Secp256k1Keypair } from '@mysten/sui/keypairs/secp256k1';
+import { Secp256r1Keypair } from '@mysten/sui/keypairs/secp256r1';
+import { fromBase64, toBase64 } from '@mysten/sui/utils';
+import { p256 as secp256r1 } from '@noble/curves/nist.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AwsKmsClient } from '../src/aws-client.js';
+import { AwsKmsSigner } from '../src/aws-kms-signer.js';
+
+/**
+ * SHA-256 a message the way AWS KMS does internally for `MessageType: 'RAW'` + `ECDSA_SHA_256`.
+ */
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+	return new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as BufferSource));
+}
+
+describe('AwsKmsSigner signing', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Stand in for AWS KMS `Sign` with a local keypair so signing is verified end-to-end without
+	// live AWS: each scheme produces the same response shape KMS returns (raw 64 bytes for Ed25519,
+	// DER-encoded for the ECDSA curves), and the resulting signature is checked against the public key.
+
+	it('signs with Ed25519 and produces a signature that verifies (raw 64-byte signature)', async () => {
+		const keypair = new Ed25519Keypair();
+		const publicKey = keypair.getPublicKey();
+
+		const client = new AwsKmsClient({
+			region: 'us-east-1',
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+		});
+		const runCommand = vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
+			// KMS signs the raw message with EdDSA and returns the raw 64-byte signature.
+			const signature = await keypair.sign(fromBase64((body as { Message: string }).Message));
+			return { Signature: toBase64(signature) } as never;
+		});
+
+		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
+		const message = new TextEncoder().encode('Hello, Ed25519!');
+		const { signature } = await signer.signPersonalMessage(message);
+
+		expect(await publicKey.verifyPersonalMessage(message, signature)).toBe(true);
+		expect(runCommand).toHaveBeenCalledWith(
+			'Sign',
+			expect.objectContaining({ SigningAlgorithm: 'ED25519_SHA_512', MessageType: 'RAW' }),
+		);
+	});
+
+	it('signs with Secp256k1 and produces a signature that verifies (DER -> compact, low-S)', async () => {
+		const secretKey = secp256k1.utils.randomSecretKey();
+		const publicKey = Secp256k1Keypair.fromSecretKey(secretKey).getPublicKey();
+
+		const client = new AwsKmsClient({
+			region: 'us-east-1',
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+		});
+		const runCommand = vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
+			// KMS hashes the raw message with SHA-256, signs with ECDSA, and returns DER.
+			const digest = await sha256(fromBase64((body as { Message: string }).Message));
+			const der = secp256k1.sign(digest, secretKey, { prehash: false, format: 'der' });
+			return { Signature: toBase64(der) } as never;
+		});
+
+		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
+		const message = new TextEncoder().encode('Hello, Secp256k1!');
+		const { signature } = await signer.signPersonalMessage(message);
+
+		expect(await publicKey.verifyPersonalMessage(message, signature)).toBe(true);
+		expect(runCommand).toHaveBeenCalledWith(
+			'Sign',
+			expect.objectContaining({ SigningAlgorithm: 'ECDSA_SHA_256', MessageType: 'RAW' }),
+		);
+	});
+
+	it('signs with Secp256r1 and produces a signature that verifies (DER -> compact, low-S)', async () => {
+		const secretKey = secp256r1.utils.randomSecretKey();
+		const publicKey = Secp256r1Keypair.fromSecretKey(secretKey).getPublicKey();
+
+		const client = new AwsKmsClient({
+			region: 'us-east-1',
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+		});
+		const runCommand = vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
+			const digest = await sha256(fromBase64((body as { Message: string }).Message));
+			const der = secp256r1.sign(digest, secretKey, { prehash: false, format: 'der' });
+			return { Signature: toBase64(der) } as never;
+		});
+
+		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
+		const message = new TextEncoder().encode('Hello, Secp256r1!');
+		const { signature } = await signer.signPersonalMessage(message);
+
+		expect(await publicKey.verifyPersonalMessage(message, signature)).toBe(true);
+		expect(runCommand).toHaveBeenCalledWith(
+			'Sign',
+			expect.objectContaining({ SigningAlgorithm: 'ECDSA_SHA_256', MessageType: 'RAW' }),
+		);
+	});
+});

--- a/packages/signers/aws/tests/sign.test.ts
+++ b/packages/signers/aws/tests/sign.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+import type { PublicKey } from '@mysten/sui/cryptography';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Secp256k1Keypair } from '@mysten/sui/keypairs/secp256k1';
 import { Secp256r1Keypair } from '@mysten/sui/keypairs/secp256r1';
@@ -18,6 +19,34 @@ async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
 	return new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as BufferSource));
 }
 
+type EcdsaCurve = typeof secp256k1 | typeof secp256r1;
+
+/**
+ * Produce a DER-encoded ECDSA signature exactly as AWS KMS would for a `MessageType: 'RAW'` +
+ * `ECDSA_SHA_256` request: SHA-256 the message, sign, and DER-encode. Crucially KMS does **not**
+ * low-S normalize — it returns the raw ECDSA output, which is high-S roughly half the time — so we
+ * pass `lowS: false` to faithfully emulate that. The signer's `getConcatenatedSignature` is what
+ * performs the low-S normalization Sui requires; if the mock normalized for it, that code path
+ * would never be exercised.
+ */
+async function kmsEcdsaSignDER(
+	curve: EcdsaCurve,
+	secretKey: Uint8Array,
+	message: Uint8Array,
+): Promise<Uint8Array> {
+	const digest = await sha256(message);
+	return curve.sign(digest, secretKey, { prehash: false, lowS: false, format: 'der' });
+}
+
+/**
+ * Extract the 64-byte compact signature from a serialized Sui signature
+ * (1 flag byte + 64 signature bytes + 33 public-key bytes).
+ */
+function extractCompactSignature(signature: Uint8Array | string): Uint8Array {
+	const bytes = signature instanceof Uint8Array ? signature : fromBase64(signature);
+	return bytes.slice(1, 65);
+}
+
 describe('AwsKmsSigner signing', () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
@@ -25,7 +54,8 @@ describe('AwsKmsSigner signing', () => {
 
 	// Stand in for AWS KMS `Sign` with a local keypair so signing is verified end-to-end without
 	// live AWS: each scheme produces the same response shape KMS returns (raw 64 bytes for Ed25519,
-	// DER-encoded for the ECDSA curves), and the resulting signature is checked against the public key.
+	// DER-encoded and NOT low-S normalized for the ECDSA curves), and the resulting signature is
+	// checked against the public key.
 
 	it('signs with Ed25519 and produces a signature that verifies (raw 64-byte signature)', async () => {
 		const keypair = new Ed25519Keypair();
@@ -63,10 +93,8 @@ describe('AwsKmsSigner signing', () => {
 			secretAccessKey: 'SECRET',
 		});
 		const runCommand = vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
-			// KMS hashes the raw message with SHA-256, signs with ECDSA, and returns DER.
-			const digest = await sha256(fromBase64((body as { Message: string }).Message));
-			const der = secp256k1.sign(digest, secretKey, { prehash: false, format: 'der' });
-			return { Signature: toBase64(der) } as never;
+			const message = fromBase64((body as { Message: string }).Message);
+			return { Signature: toBase64(await kmsEcdsaSignDER(secp256k1, secretKey, message)) } as never;
 		});
 
 		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
@@ -90,9 +118,8 @@ describe('AwsKmsSigner signing', () => {
 			secretAccessKey: 'SECRET',
 		});
 		const runCommand = vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
-			const digest = await sha256(fromBase64((body as { Message: string }).Message));
-			const der = secp256r1.sign(digest, secretKey, { prehash: false, format: 'der' });
-			return { Signature: toBase64(der) } as never;
+			const message = fromBase64((body as { Message: string }).Message);
+			return { Signature: toBase64(await kmsEcdsaSignDER(secp256r1, secretKey, message)) } as never;
 		});
 
 		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
@@ -104,5 +131,55 @@ describe('AwsKmsSigner signing', () => {
 			'Sign',
 			expect.objectContaining({ SigningAlgorithm: 'ECDSA_SHA_256', MessageType: 'RAW' }),
 		);
+	});
+
+	// AWS KMS returns high-S ECDSA signatures (it does not normalize), and Sui rejects high-S, so
+	// the signer MUST low-S normalize. The mock here emulates KMS faithfully (lowS: false), then we
+	// drive `signPersonalMessage` with different messages until the KMS-side signature is high-S
+	// (~50% per attempt) and assert the signer's output is low-S and verifies — the normalization
+	// path the happy-path tests above can't guarantee they exercise.
+	async function expectHighSNormalized(
+		curve: EcdsaCurve,
+		publicKey: PublicKey,
+		secretKey: Uint8Array,
+	) {
+		const client = new AwsKmsClient({
+			region: 'us-east-1',
+			accessKeyId: 'AKID',
+			secretAccessKey: 'SECRET',
+		});
+		let lastWasHighS = false;
+		vi.spyOn(client, 'runCommand').mockImplementation(async (_command, body) => {
+			const signedBytes = fromBase64((body as { Message: string }).Message);
+			const der = curve.sign(signedBytes, secretKey, { prehash: true, lowS: false, format: 'der' });
+			lastWasHighS = curve.Signature.fromBytes(der, 'der').hasHighS();
+			return { Signature: toBase64(der) } as never;
+		});
+
+		const signer = new AwsKmsSigner({ kmsKeyId: 'k', client, publicKey });
+		for (let i = 0; i < 100; i++) {
+			const message = new TextEncoder().encode(`high-s probe ${i}`);
+			const { signature } = await signer.signPersonalMessage(message);
+			if (!lastWasHighS) continue;
+
+			// KMS returned a high-S signature; the signer must have normalized it to low-S.
+			const sigBytes = extractCompactSignature(signature);
+			expect(curve.Signature.fromBytes(sigBytes, 'compact').hasHighS()).toBe(false);
+			expect(await publicKey.verifyPersonalMessage(message, signature)).toBe(true);
+			return;
+		}
+		throw new Error('KMS mock never produced a high-S signature to normalize');
+	}
+
+	it('normalizes a high-S Secp256k1 signature from KMS to low-S', async () => {
+		const secretKey = secp256k1.utils.randomSecretKey();
+		const publicKey = Secp256k1Keypair.fromSecretKey(secretKey).getPublicKey();
+		await expectHighSNormalized(secp256k1, publicKey, secretKey);
+	});
+
+	it('normalizes a high-S Secp256r1 signature from KMS to low-S', async () => {
+		const secretKey = secp256r1.utils.randomSecretKey();
+		const publicKey = Secp256r1Keypair.fromSecretKey(secretKey).getPublicKey();
+		await expectHighSNormalized(secp256r1, publicKey, secretKey);
 	});
 });

--- a/packages/signers/aws/tests/utils.test.ts
+++ b/packages/signers/aws/tests/utils.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { Ed25519PublicKey } from '@mysten/sui/keypairs/ed25519';
+import { fromBase64, fromHex } from '@mysten/sui/utils';
+import { describe, expect, it } from 'vitest';
+
+import { publicKeyFromEd25519DER } from '../src/utils.js';
+
+// A real Ed25519 SPKI public key as returned by AWS KMS `GetPublicKey` for an
+// `ECC_NIST_EDWARDS25519` key, alongside its raw 32-byte form.
+const ED25519_SPKI_BASE64 = 'MCowBQYDK2VwAyEAGtrlMq+wg/Im5WXF88lJcXT31S0gHy85XhUKpTXuW3c=';
+const ED25519_RAW_HEX = '1adae532afb083f226e565c5f3c9497174f7d52d201f2f395e150aa535ee5b77';
+
+describe('publicKeyFromEd25519DER', () => {
+	it('extracts the raw 32-byte key from a valid SPKI structure', () => {
+		const raw = publicKeyFromEd25519DER(fromBase64(ED25519_SPKI_BASE64));
+		expect(raw).toEqual(fromHex(ED25519_RAW_HEX));
+	});
+
+	it('produces a public key that round-trips through Ed25519PublicKey', () => {
+		const raw = publicKeyFromEd25519DER(fromBase64(ED25519_SPKI_BASE64));
+		const publicKey = new Ed25519PublicKey(raw);
+		expect(publicKey.toRawBytes()).toEqual(fromHex(ED25519_RAW_HEX));
+	});
+
+	it('rejects a key with an unexpected length', () => {
+		const tooShort = fromBase64(ED25519_SPKI_BASE64).slice(0, 40);
+		expect(() => publicKeyFromEd25519DER(tooShort)).toThrow(/length/);
+	});
+
+	it('rejects a key with an unexpected ASN.1 prefix', () => {
+		const der = fromBase64(ED25519_SPKI_BASE64);
+		der[1] = 0x2b; // corrupt a prefix byte
+		expect(() => publicKeyFromEd25519DER(der)).toThrow(/ASN\.1/);
+	});
+});


### PR DESCRIPTION
## Description

Adds two additive, non-breaking features to `@mysten/aws-kms-signer`, both originally
implemented and verified end-to-end by **@0xkurious (Antonio Jiménez)** and filed as issues
(the repo restricts PRs to collaborators, so the work is pulled in here on their behalf).

Closes #1111 — **Ed25519 support**
- `AwsKmsClient.getPublicKey` now recognizes the `ECC_NIST_EDWARDS25519` key spec and returns an
  `Ed25519PublicKey` (raw 32 bytes parsed from the SPKI DER via a new `publicKeyFromEd25519DER`).
- `AwsKmsSigner.sign` signs Ed25519 keys with `ED25519_SHA_512` (`MessageType: RAW`) and returns
  the raw 64-byte signature, skipping the DER parsing / low-S normalization used for the ECDSA
  curves. This unblocks Sui's native Ed25519 scheme, previously unsupported.
- Grounded in a real AWS capability — KMS added EdDSA / `ECC_NIST_EDWARDS25519` support in Nov 2025.

Closes #1112 — **Pluggable credential provider**
- `AwsClientOptions` accepts an optional async `credentials` provider (structurally compatible
  with `@aws-sdk/credential-providers`, e.g. `fromNodeProviderChain()`). When supplied,
  credentials are resolved per request, enabling the standard AWS provider chain (SSO, IAM roles,
  container/instance metadata) and automatic refresh of temporary credentials.
- Static `accessKeyId`/`secretAccessKey` continue to work unchanged (fully backwards compatible).
- New `AwsCredentialIdentity` / `AwsCredentialProvider` types are exported.
- The `@aws-sdk/credential-providers` dependency is intentionally **not** added, to preserve the
  package's edge/browser-light footprint — consumers bring their own provider.

### Review notes / changes from the original branches

I reviewed every byte of both contributed commits for correctness and safety (no exfiltration,
no out-of-scope changes, DER constants and test vectors verified). One fix was added on top:

- **`fix: resolve credentials per-request`** — the original provider implementation stored
  resolved credentials on mutable `AwsClient` instance fields before each request. Concurrent
  `sign()` calls sharing one client could interleave between resolving and signing, so a request
  could be signed with another in-flight request's credentials. Credentials are now passed to
  `aws4fetch` per-request via its `aws` override, keeping each request isolated. A regression test
  asserts concurrent requests are each signed with their own credentials.

## Test plan

- `pnpm --filter @mysten/aws-kms-signer test` — 10 unit tests pass (Ed25519 SPKI parser + round-trip,
  credential provider resolution/back-compat/per-request isolation).
- `pnpm --filter @mysten/aws-kms-signer build` (tsc `--noEmit` + tsdown), oxlint, and prettier all clean.
- **Original author verification** (per the issues): both features were tested end-to-end against
  real AWS KMS keys, with `signPersonalMessage` signatures verifying and real testnet transactions
  accepted on-chain.
- Not covered here: an automated e2e run against a real `ECC_NIST_EDWARDS25519` KMS key (requires
  live AWS credentials). Worth a manual confirmation before/at release.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

> Note: the two feature commits were authored by the external contributor **@0xkurious**; AI
> (Claude Code) reviewed every byte, bundled them into this branch, and added the per-request
> credential fix and its regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
