### PR TITLE
docs(walrus): note serverExternalPackages applies to Turbopack

### DIFF
--- a/packages/docs/content/walrus/index.mdx
+++ b/packages/docs/content/walrus/index.mdx
@@ -565,6 +565,12 @@ const nextConfig: NextConfig = {
 };
 ```
 
+This is the same setting for both the webpack and Turbopack (`next dev --turbo`) bundlers. Without
+it, bundling the WASM loader into a server route can break how it locates the binary at runtime;
+Turbopack in particular surfaces this as a virtualized path such as `/ROOT/...`. If you cannot use
+`serverExternalPackages`, point `wasmUrl` at the web build as shown in the Vite example above, which
+resolves the binary through `import.meta.url` instead of the filesystem.
+
 ## Known fetch limitations
 
 - Some nodes can be slow to respond. When running in Node.js, the default `connectTimeout` is 10


### PR DESCRIPTION
## Description

Follow-up to three reported Walrus SDK issues (#1114, #1115, #1116). After reproducing each, only **#1115 (Turbopack)** needed a doc change, and even that was mostly covered by the existing `serverExternalPackages` guidance.

This PR adds one paragraph to the Walrus docs clarifying that:
- The existing `serverExternalPackages` Next.js config applies to **both** webpack and Turbopack (`next dev --turbo`) — it is the same setting, not a Turbopack-specific one.
- The `/ROOT/...` virtualized-path error a user sees under Turbopack is this same bundling problem (named so searches for that error land on the fix).
- If a build must bundle the package, `wasmUrl` can point at the web build (which resolves the binary via `import.meta.url` instead of the filesystem), as already shown in the Vite example.

The other two issues were investigated and found not to need changes:

- **#1114 (snake_case vs camelCase on `writeBlob().blobObject.storage`)** — not a bug. The returned object is `Blob.parse(content)` over BCS-encoded bytes; both the runtime keys and the TS type derive from the same generated Move struct schema (`snake_case`), so they always match. No doc or example anywhere showed camelCase. Likely confusion came from the camelCase `writeBlob` return wrapper (`blobId`) and the separate camelCase `getBlobStatus()` DTO.
- **#1116 (IPv6-first connection stalls in Node)** — handled by default on Node ≥20. `globalThis.fetch` (undici) inherits Node's `net` Happy Eyeballs (`autoSelectFamily`), which races IPv4/IPv6 and falls back. Verified empirically across Node 18/20/22/24: the failure reproduces only on Node 18 (EOL April 2025), where the default is `false`; Node 20+ succeeds out of the box. No SDK change warranted.

## Test plan

- `pnpm --filter @mysten/docs build:docs` (regenerated the LLM index)
- `pnpm --filter @mysten/docs validate-docs` — all checks pass (frontmatter, orphans, internal links)
- `prettier --check` on the changed file — clean
- Docs-content-only change; no changeset needed (consistent with prior docs PRs).

For #1116, reproduced the IPv6-first stall across Node 18/20/22/24 with a controlled DNS-lookup A/B harness, confirming the issue is default-on only for Node ≤18 and that Node 20+ recovers via Happy Eyeballs.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)