### PR TITLE
Add optional transaction analyzer dependencies

### DIFF
--- a/.changeset/calm-rivers-analyze.md
+++ b/.changeset/calm-rivers-analyze.md
@@ -3,10 +3,15 @@
 '@mysten-incubation/sponsor': minor
 ---
 
-Add explicit transaction analyzer result statuses and support optional analyzer dependencies.
+Add explicit transaction analyzer result statuses and a uniform dependency shape.
 
-Analyzer results now include `status`, top-level analysis includes an overall status, and
-`optional(analyzer)` lets aggregate analyzers inspect another analyzer's full result without being
-skipped when that optional dependency cannot run. Sponsor validation now uses this to preserve
-policy rejections from validators that ran while separately reporting analysis failures from
-validators that could not run.
+Analyzer results now include `status`, and top-level analysis includes an overall status.
+Dependencies are now declared with a uniform shape: a bare analyzer is a required edge whose value
+is the unwrapped result, while the explicit `{ analyzer, required?, transform? }` form lets a
+dependency opt out of short-circuiting (`required: false`) and/or map the dependency's full
+`AnalyzerResult` to a custom value via `transform` (the default transform unwraps `result`).
+`optional(analyzer)` is sugar for `{ analyzer, required: false, transform: (r) => r }`, so an
+aggregate analyzer can inspect another analyzer's full result without being skipped when that
+dependency cannot run. Sponsor validation uses this to preserve policy rejections from validators
+that ran while separately reporting analysis failures from validators that could not run, and now
+fails closed when a validator could not run even if it surfaced no message.

--- a/.changeset/calm-rivers-analyze.md
+++ b/.changeset/calm-rivers-analyze.md
@@ -15,3 +15,8 @@ aggregate analyzer can inspect another analyzer's full result without being skip
 dependency cannot run. Sponsor validation uses this to preserve policy rejections from validators
 that ran while separately reporting analysis failures from validators that could not run, and now
 fails closed when a validator could not run even if it surfaced no message.
+
+These packages are still pre-1.0, but note that the type changes are not purely additive for code
+that constructs these result objects or exhaustively matches the old unions: `status` is now required
+on analyzer results, `partial`/`skipped` statuses are part of the result model, and sponsor
+rejections now include required `policyIssues` and `analysisIssues` fields.

--- a/.changeset/calm-rivers-analyze.md
+++ b/.changeset/calm-rivers-analyze.md
@@ -3,20 +3,21 @@
 '@mysten-incubation/sponsor': minor
 ---
 
-Add explicit transaction analyzer result statuses and a uniform dependency shape.
+Add transaction analyzer status metadata and optional dependency edges.
 
-Analyzer results now include `status`, and top-level analysis includes an overall status.
-Dependencies are now declared with a uniform shape: a bare analyzer is a required edge whose value
-is the unwrapped result, while the explicit `{ analyzer, required?, transform? }` form lets a
-dependency opt out of short-circuiting (`required: false`) and/or map the dependency's full
-`AnalyzerResult` to a custom value via `transform` (the default transform unwraps `result`).
-`optional(analyzer)` is sugar for `{ analyzer, required: false, transform: (r) => r }`, so an
-aggregate analyzer can inspect another analyzer's full result without being skipped when that
-dependency cannot run. Sponsor validation uses this to preserve policy rejections from validators
-that ran while separately reporting analysis failures from validators that could not run, and now
-fails closed when a validator could not run even if it surfaced no message.
+Analyzer results now include `status`, and top-level analysis returns an overall status. Dependency
+objects can use `{ analyzer, required?, transform? }`; bare analyzer dependencies remain required
+and unwrap `result`, while `optional(analyzer)` and `{ analyzer, required: false }` pass the full
+dependency `AnalyzerResult` unless a custom transform is provided. The top-level analyzer key
+`status` is now reserved.
 
-These packages are still pre-1.0, but note that the type changes are not purely additive for code
-that constructs these result objects or exhaustively matches the old unions: `status` is now required
-on analyzer results, `partial`/`skipped` statuses are part of the result model, and sponsor
-rejections now include required `policyIssues` and `analysisIssues` fields.
+Sponsor validation now preserves policy findings from validators that ran while separately reporting
+validators that failed or were skipped. Sponsor rejections include `policyIssues` and
+`analysisIssues`, and failed or skipped validators reject even when they surface no issue message.
+
+Auto-approval state mutation methods now require a `success` analysis result before mutating budgets
+or pending digests.
+
+Compatibility note: code that constructs analyzer results, constructs sponsor rejections, or
+exhaustively matches the old analyzer result union may need updates for the required `status` field,
+the `partial` and `skipped` statuses, and the required `policyIssues` and `analysisIssues` fields.

--- a/.changeset/calm-rivers-analyze.md
+++ b/.changeset/calm-rivers-analyze.md
@@ -1,0 +1,12 @@
+---
+'@mysten/wallet-sdk': minor
+'@mysten-incubation/sponsor': minor
+---
+
+Add explicit transaction analyzer result statuses and support optional analyzer dependencies.
+
+Analyzer results now include `status`, top-level analysis includes an overall status, and
+`optional(analyzer)` lets aggregate analyzers inspect another analyzer's full result without being
+skipped when that optional dependency cannot run. Sponsor validation now uses this to preserve
+policy rejections from validators that ran while separately reporting analysis failures from
+validators that could not run.

--- a/packages/docs/content/sponsor/validators.mdx
+++ b/packages/docs/content/sponsor/validators.mdx
@@ -13,7 +13,9 @@ through `dependencies` and reports one of three outcomes:
   (`POLICY_REJECTED`);
 - **couldn't analyze**: `{ issues: [{ message }] }` or `throw`: the analyzer itself couldn't decide
   (a failed lookup, an unreachable service), producing `ANALYSIS_FAILED`. This is the analyzer
-  framework's own channel, so it propagates, and dependents don't run.
+  framework's own channel, so it propagates through strict dependencies. Sponsor validation treats
+  each configured validator independently, so one validator's analysis failure doesn't suppress
+  policy rejections from other validators.
 
 Reporting findings as the `result` (rather than through `issues`) is what keeps "violates policy"
 distinct from "couldn't be checked". There's no built-in "the sponsor must be paid" rule, because
@@ -47,8 +49,10 @@ expiration), which most validators read. Alongside it: `balanceFlows` (signed va
 `transactionResponse` (the dry-run, including effects), `commands`, `moveFunctions`, `objects`,
 `coins`, `inputs`, and `bytes`, plus the sponsor's `currentEpoch`, and any others the analyzer
 package adds (see [`@mysten/wallet-sdk`](https://www.npmjs.com/package/@mysten/wallet-sdk) for the
-full set). All are re-exported as `analyzers` (with `currentEpoch` and `createAnalyzer` alongside).
-A failed analyzer never reaches your `analyze`: it short-circuits to an `ANALYSIS_FAILED` rejection.
+full set). All are re-exported as `analyzers` (with `currentEpoch`, `createAnalyzer`, and `optional`
+alongside). A failed required analyzer never reaches your validator's `analyze`: that validator
+contributes an `ANALYSIS_FAILED` issue while independent validators can still report policy
+rejections.
 
 ## Loading data, and sharing it across validators
 
@@ -121,7 +125,7 @@ await sponsor.signAndExecuteTransaction({
 
 ## How it runs
 
-`createSponsor` makes every validator a dependency of **`sponsor.analyzer`**, and validation is just
+`createSponsor` aggregates every validator through **`sponsor.analyzer`**, and validation is just
 `analyze({ check: sponsor.analyzer }, { transaction, client })`. The analyzer framework then
 handles:
 
@@ -131,13 +135,15 @@ handles:
   declare, because it falls out of the dependency graph.
 - **Deduped**: `data` and `balanceFlows` and so on resolve once even when many validators (and a
   host graph) depend on them.
-- **Propagated**: a failed analyzer becomes an `ANALYSIS_FAILED` rejection rather than reaching a
-  validator with a broken value.
+- **Independent failure reporting**: a failed validator becomes an `ANALYSIS_FAILED` entry in
+  `analysisIssues`, without suppressing policy rejections from validators that did run.
 
 When validation fails, the sponsor never signs and the method **returns**
-`{ $kind: 'Rejected', issues, reason }`, where `issues` lists every reason, and `reason` is
-`'POLICY_REJECTED'` or `'ANALYSIS_FAILED'`. To turn a rejection into a thrown error, the exported
-`SponsorValidationError` class takes `(issues, reason)`.
+`{ $kind: 'Rejected', issues, policyIssues, analysisIssues, reason }`. `issues` preserves the
+combined list for existing callers, while `policyIssues` and `analysisIssues` separate policy
+rejections from checks that could not run. `reason` is `'POLICY_REJECTED'` when every reported issue
+is policy-only and `'ANALYSIS_FAILED'` when any check could not run. To turn a rejection into a
+thrown error, the exported `SponsorValidationError` class takes `(issues, reason)`.
 
 **`sponsor.analyzer`** is also the composable handle: drop it into any other `analyze()` graph and
 it contributes `SponsorRejection | null`, deduping its analyzers with that graph.

--- a/packages/docs/content/sponsor/validators.mdx
+++ b/packages/docs/content/sponsor/validators.mdx
@@ -6,11 +6,14 @@ keywords: [Sponsor validation, custom validation analyzers, transaction analyzer
 
 A validator is an analyzer used for policy checks. Create one with `createAnalyzer(...)`, return the
 issues it found, and pass it to `createSponsor({ validate })`. It declares the analyzers it reads
-through `dependencies` and reports one of three outcomes:
+through `dependencies` and reports these outcomes:
 
 - **pass**: `{ result: null }` (or `{ result: [] }`);
 - **reject**: `{ result: [{ code, message }] }`: the transaction is well-formed but violates policy
   (`POLICY_REJECTED`);
+- **partial**: `{ result: [{ code, message }], issues: [{ message }] }`: the validator found a
+  policy rejection but also hit an analysis issue, so sponsor validation reports both and treats the
+  overall reason as `ANALYSIS_FAILED`;
 - **couldn't analyze**: `{ issues: [{ message }] }` or `throw`: the analyzer itself couldn't decide
   (a failed lookup, an unreachable service), producing `ANALYSIS_FAILED`. This is the analyzer
   framework's own channel, so it propagates through strict dependencies. Sponsor validation treats

--- a/packages/sponsor/README.md
+++ b/packages/sponsor/README.md
@@ -271,11 +271,14 @@ service.
 ## Custom validators
 
 A validator **is an analyzer** — just `createAnalyzer(...)` — whose result is the issues it found.
-It declares the analyzers it reads via `dependencies` and reports one of three outcomes:
+It declares the analyzers it reads via `dependencies` and reports these outcomes:
 
 - **pass** — `{ result: null }` (or `{ result: [] }`);
 - **reject** — `{ result: [{ code, message }] }`: the transaction is well-formed but violates policy
   → `POLICY_REJECTED`;
+- **partial** — `{ result: [{ code, message }], issues: [{ message }] }`: the validator found a
+  policy rejection but also hit an analysis issue, so sponsor validation reports both and treats the
+  overall reason as `ANALYSIS_FAILED`;
 - **couldn't analyze** — `{ issues: [{ message }] }` or `throw`: the analyzer itself couldn't decide
   (a failed lookup, an unreachable service) → `ANALYSIS_FAILED`. This is the analyzer framework's
   own channel, so it propagates through strict dependencies. Sponsor validation treats each

--- a/packages/sponsor/README.md
+++ b/packages/sponsor/README.md
@@ -278,7 +278,9 @@ It declares the analyzers it reads via `dependencies` and reports one of three o
   → `POLICY_REJECTED`;
 - **couldn't analyze** — `{ issues: [{ message }] }` or `throw`: the analyzer itself couldn't decide
   (a failed lookup, an unreachable service) → `ANALYSIS_FAILED`. This is the analyzer framework's
-  own channel, so it propagates — dependents don't run.
+  own channel, so it propagates through strict dependencies. Sponsor validation treats each
+  configured validator independently, so one validator's analysis failure doesn't suppress policy
+  rejections from other validators.
 
 Reporting findings as the `result` (rather than via `issues`) is what keeps "violates policy"
 distinct from "couldn't be checked". There's no built-in "the sponsor must be paid" rule —
@@ -310,8 +312,10 @@ commands, expiration), which most validators read. Alongside it: `balanceFlows` 
 deltas), `transactionResponse` (the dry-run, incl. effects), `commands`, `moveFunctions`, `objects`,
 `coins`, `inputs`, and `bytes` — plus the sponsor's `currentEpoch`, and any others the analyzer
 package adds (see [`@mysten/wallet-sdk`](https://www.npmjs.com/package/@mysten/wallet-sdk) for the
-full set). All are re-exported as `analyzers` (with `currentEpoch` and `createAnalyzer` alongside).
-A failed analyzer never reaches your `analyze`: it short-circuits to an `ANALYSIS_FAILED` rejection.
+full set). All are re-exported as `analyzers` (with `currentEpoch`, `createAnalyzer`, and `optional`
+alongside). A failed required analyzer never reaches your validator's `analyze`: that validator
+contributes an `ANALYSIS_FAILED` issue while independent validators can still report policy
+rejections.
 
 ## Loading data, and sharing it across validators
 
@@ -384,7 +388,7 @@ await sponsor.signAndExecuteTransaction({
 
 ## How it runs
 
-`createSponsor` makes every validator a dependency of **`sponsor.analyzer`**, and validation is just
+`createSponsor` aggregates every validator through **`sponsor.analyzer`**, and validation is just
 `analyze({ check: sponsor.analyzer }, { transaction, client })`. The analyzer framework then gives,
 for free:
 
@@ -394,13 +398,15 @@ for free:
   declare — it falls out of the dependency graph.
 - **Deduped** — `data` / `balanceFlows` etc. resolve once even when many validators (and a host
   graph) depend on them.
-- **Propagated** — a failed analyzer becomes an `ANALYSIS_FAILED` rejection rather than reaching a
-  validator with a broken value.
+- **Independent failure reporting** — a failed validator becomes an `ANALYSIS_FAILED` entry in
+  `analysisIssues`, without suppressing policy rejections from validators that did run.
 
 When validation fails, the sponsor never signs and the method **returns**
-`{ $kind: 'Rejected', issues, reason }` — `issues` lists every reason, and `reason` is
-`'POLICY_REJECTED'` or `'ANALYSIS_FAILED'`. To turn a rejection into a thrown error, the exported
-`SponsorValidationError` class takes `(issues, reason)`.
+`{ $kind: 'Rejected', issues, policyIssues, analysisIssues, reason }`. `issues` preserves the
+combined list for existing callers, while `policyIssues` and `analysisIssues` separate policy
+rejections from checks that could not run. `reason` is `'POLICY_REJECTED'` when every reported issue
+is policy-only and `'ANALYSIS_FAILED'` when any check could not run. To turn a rejection into a
+thrown error, the exported `SponsorValidationError` class takes `(issues, reason)`.
 
 **`sponsor.analyzer`** is also the composable handle: drop it into any other `analyze()` graph and
 it contributes `SponsorRejection | null`, deduping its analyzers with that graph.

--- a/packages/sponsor/src/index.ts
+++ b/packages/sponsor/src/index.ts
@@ -51,5 +51,5 @@ export type {
 	AnalyzerResult,
 	AnalyzerStatus,
 	AnalyzeStatus,
-	OptionalAnalyzer,
+	Dependency,
 } from '@mysten/wallet-sdk';

--- a/packages/sponsor/src/index.ts
+++ b/packages/sponsor/src/index.ts
@@ -44,5 +44,12 @@ export {
 export type { AnalyzerMap, AnalysisResults } from './validators.js';
 
 // Re-export the analyzer toolkit so authoring/composing validators is a single import.
-export { analyze, analyzers, createAnalyzer } from '@mysten/wallet-sdk';
-export type { Analyzer, AnalyzerResult } from '@mysten/wallet-sdk';
+export { analyze, analyzers, createAnalyzer, optional } from '@mysten/wallet-sdk';
+export type {
+	Analyzer,
+	AnalyzerDependency,
+	AnalyzerResult,
+	AnalyzerStatus,
+	AnalyzeStatus,
+	OptionalAnalyzer,
+} from '@mysten/wallet-sdk';

--- a/packages/sponsor/src/sponsor.ts
+++ b/packages/sponsor/src/sponsor.ts
@@ -5,10 +5,16 @@ import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import type { Signer } from '@mysten/sui/cryptography';
 import { Transaction, TransactionDataBuilder } from '@mysten/sui/transactions';
 import { fromBase64, normalizeSuiAddress } from '@mysten/sui/utils';
-import { analyze, createAnalyzer, type Analyzer } from '@mysten/wallet-sdk';
+import {
+	analyze,
+	createAnalyzer,
+	optional,
+	type Analyzer,
+	type AnalyzerResult,
+} from '@mysten/wallet-sdk';
 
 import type { SponsorRejection, ValidationIssue, Validator } from './validation.js';
-import { reasonOf } from './validation.js';
+import { createSponsorRejection } from './validation.js';
 import { defaults } from './validators.js';
 
 /** A delay, in milliseconds — a fixed number, or `{ min, max }` for a uniform random delay. */
@@ -397,8 +403,9 @@ export class Sponsor<TOptions extends object = object> {
 	 * The sponsor's validation as a composable {@link Analyzer}: it depends on every
 	 * configured validator, so dropping it into any `analyze()` graph contributes
 	 * `SponsorRejection | null` (a rejection, or `null` if the policy passed) while
-	 * sharing/deduping analyzers with that graph. A failed analyzer propagates as
-	 * this analyzer's `issues`.
+	 * sharing/deduping analyzers with that graph. Validators are optional
+	 * dependencies of the aggregate so one validator's analysis failure is reported
+	 * in `analysisIssues` without suppressing policy findings from other validators.
 	 */
 	get analyzer(): Analyzer<SponsorRejection | null, TOptions & { client: ClientWithCoreApi }> {
 		// Memoized: a stable instance gives the framework a stable identity to dedupe
@@ -406,18 +413,36 @@ export class Sponsor<TOptions extends object = object> {
 		// than once) shares its analyzers rather than re-resolving them.
 		if (!this.#analyzer) {
 			const dependencies = Object.fromEntries(
-				this.#validators.map((validator, index) => [`v${index}`, validator]),
+				this.#validators.map((validator, index) => [`v${index}`, optional(validator)]),
 			);
 			this.#analyzer = createAnalyzer({
 				dependencies,
 				analyze:
-					(_options, _transaction) => (results: Record<string, ValidationIssue[] | null>) => {
-						// Each validator's result is its issues, or `null`/empty for a pass.
-						const issues = Object.values(results).flatMap((result) => result ?? []);
+					(_options, _transaction) =>
+					(results: Record<string, AnalyzerResult<ValidationIssue[] | null>>) => {
+						const policyIssues: ValidationIssue[] = [];
+						const analysisIssues: ValidationIssue[] = [];
+
+						for (const result of Object.values(results)) {
+							if ('result' in result) {
+								policyIssues.push(...(result.result ?? []));
+							}
+
+							if (result.issues) {
+								analysisIssues.push(
+									...result.issues.map((issue) => ({
+										code: 'ANALYSIS_FAILED',
+										message: issue.message,
+									})),
+								);
+							}
+						}
+
 						return {
-							result: issues.length
-								? { $kind: 'Rejected', issues, reason: reasonOf(issues) }
-								: null,
+							result:
+								policyIssues.length || analysisIssues.length
+									? createSponsorRejection({ policyIssues, analysisIssues })
+									: null,
 						};
 					},
 			}) as Analyzer<SponsorRejection | null, TOptions & { client: ClientWithCoreApi }>;
@@ -453,14 +478,16 @@ export class Sponsor<TOptions extends object = object> {
 		} as never);
 
 		const check = analysis.check;
-		if (check.issues) {
-			return {
-				$kind: 'Rejected',
-				issues: check.issues.map((issue) => ({ code: 'ANALYSIS_FAILED', message: issue.message })),
-				reason: 'ANALYSIS_FAILED',
-			};
+		if ('result' in check) {
+			return check.result ?? null;
 		}
-		return check.result ?? null;
+		return createSponsorRejection({
+			policyIssues: [],
+			analysisIssues: check.issues.map((issue) => ({
+				code: 'ANALYSIS_FAILED',
+				message: issue.message,
+			})),
+		});
 	}
 
 	#runDelay(spec: DelaySpec | undefined): Promise<void> {

--- a/packages/sponsor/src/sponsor.ts
+++ b/packages/sponsor/src/sponsor.ts
@@ -421,52 +421,53 @@ export class Sponsor<TOptions extends object = object> {
 			);
 			this.#analyzer = createAnalyzer({
 				dependencies,
-				analyze:
-					(_options, _transaction) =>
-					(results: Record<string, AnalyzerResult<ValidationIssue[] | null>>) => {
-						const policyIssues: ValidationIssue[] = [];
-						const analysisIssues: ValidationIssue[] = [];
+				analyze: (_options, _transaction) => (results) => {
+					const validatorResults = Object.values(results) as AnalyzerResult<
+						ValidationIssue[] | null
+					>[];
+					const policyIssues: ValidationIssue[] = [];
+					const analysisIssues: ValidationIssue[] = [];
 
-						for (const result of Object.values(results)) {
-							// Fail closed: any validator that could not run (`failed`/`skipped`)
-							// must reject, even when it surfaced no message. Key this off `status`,
-							// NOT the presence of issues — a validator that returns `{ issues: [] }`
-							// or is skipped by an empty-issues required dep would otherwise contribute
-							// nothing to either bucket and let the sponsor sign.
-							if (result.status === 'failed' || result.status === 'skipped') {
-								const messages = (result.issues ?? []).map((issue) => ({
-									code: 'ANALYSIS_FAILED',
-									message: issue.message,
-								}));
-								analysisIssues.push(
-									...(messages.length
-										? messages
-										: [{ code: 'ANALYSIS_FAILED', message: 'Validator could not run' }]),
-								);
-								continue;
-							}
-
-							// `success`/`partial`: the validator ran. Its policy findings are the
-							// result; any issues alongside a `partial` result are analysis failures.
-							policyIssues.push(...(result.result ?? []));
-
-							if (result.issues) {
-								analysisIssues.push(
-									...result.issues.map((issue) => ({
-										code: 'ANALYSIS_FAILED',
-										message: issue.message,
-									})),
-								);
-							}
+					for (const result of validatorResults) {
+						// Fail closed: any validator that could not run (`failed`/`skipped`)
+						// must reject, even when it surfaced no message. Key this off `status`,
+						// NOT the presence of issues — a validator that returns `{ issues: [] }`
+						// or is skipped by an empty-issues required dep would otherwise contribute
+						// nothing to either bucket and let the sponsor sign.
+						if (result.status === 'failed' || result.status === 'skipped') {
+							const messages = (result.issues ?? []).map((issue) => ({
+								code: 'ANALYSIS_FAILED',
+								message: issue.message,
+							}));
+							analysisIssues.push(
+								...(messages.length
+									? messages
+									: [{ code: 'ANALYSIS_FAILED', message: 'Validator could not run' }]),
+							);
+							continue;
 						}
 
-						return {
-							result:
-								policyIssues.length || analysisIssues.length
-									? createSponsorRejection({ policyIssues, analysisIssues })
-									: null,
-						};
-					},
+						// `success`/`partial`: the validator ran. Its policy findings are the
+						// result; any issues alongside a `partial` result are analysis failures.
+						policyIssues.push(...(result.result ?? []));
+
+						if (result.issues) {
+							analysisIssues.push(
+								...result.issues.map((issue) => ({
+									code: 'ANALYSIS_FAILED',
+									message: issue.message,
+								})),
+							);
+						}
+					}
+
+					return {
+						result:
+							policyIssues.length || analysisIssues.length
+								? createSponsorRejection({ policyIssues, analysisIssues })
+								: null,
+					};
+				},
 			}) as Analyzer<SponsorRejection | null, TOptions & { client: ClientWithCoreApi }>;
 		}
 		return this.#analyzer;

--- a/packages/sponsor/src/sponsor.ts
+++ b/packages/sponsor/src/sponsor.ts
@@ -11,6 +11,7 @@ import {
 	optional,
 	type Analyzer,
 	type AnalyzerResult,
+	type Dependency,
 } from '@mysten/wallet-sdk';
 
 import type { SponsorRejection, ValidationIssue, Validator } from './validation.js';
@@ -412,7 +413,10 @@ export class Sponsor<TOptions extends object = object> {
 		// on, so dropping `sponsor.analyzer` into a host `analyze()` graph (even more
 		// than once) shares its analyzers rather than re-resolving them.
 		if (!this.#analyzer) {
-			const dependencies = Object.fromEntries(
+			const dependencies: Record<
+				string,
+				Dependency<ValidationIssue[] | null, AnalyzerResult<ValidationIssue[] | null>, any, any>
+			> = Object.fromEntries(
 				this.#validators.map((validator, index) => [`v${index}`, optional(validator)]),
 			);
 			this.#analyzer = createAnalyzer({
@@ -424,9 +428,27 @@ export class Sponsor<TOptions extends object = object> {
 						const analysisIssues: ValidationIssue[] = [];
 
 						for (const result of Object.values(results)) {
-							if ('result' in result) {
-								policyIssues.push(...(result.result ?? []));
+							// Fail closed: any validator that could not run (`failed`/`skipped`)
+							// must reject, even when it surfaced no message. Key this off `status`,
+							// NOT the presence of issues — a validator that returns `{ issues: [] }`
+							// or is skipped by an empty-issues required dep would otherwise contribute
+							// nothing to either bucket and let the sponsor sign.
+							if (result.status === 'failed' || result.status === 'skipped') {
+								const messages = (result.issues ?? []).map((issue) => ({
+									code: 'ANALYSIS_FAILED',
+									message: issue.message,
+								}));
+								analysisIssues.push(
+									...(messages.length
+										? messages
+										: [{ code: 'ANALYSIS_FAILED', message: 'Validator could not run' }]),
+								);
+								continue;
 							}
+
+							// `success`/`partial`: the validator ran. Its policy findings are the
+							// result; any issues alongside a `partial` result are analysis failures.
+							policyIssues.push(...(result.result ?? []));
 
 							if (result.issues) {
 								analysisIssues.push(

--- a/packages/sponsor/src/validation.ts
+++ b/packages/sponsor/src/validation.ts
@@ -27,13 +27,15 @@ export interface ValidationIssue {
  * - **Couldn't analyze** — return `{ issues: [{ message }] }` or `throw`. The
  *   analyzer itself couldn't decide (a failed lookup, an unreachable service) →
  *   `ANALYSIS_FAILED`. This is the analyzer framework's own channel, so it
- *   propagates: dependents don't run, and the issue surfaces on the result.
+ *   propagates through strict dependencies. Sponsor validation treats each
+ *   configured validator independently, so one validator's analysis failure
+ *   doesn't suppress policy rejections from other validators.
  *
  * Reporting findings as the `result` (rather than via `issues`) is what keeps
- * "violates policy" distinct from "couldn't be checked". `createSponsor` makes
- * every validator a dependency of `sponsor.analyzer` (so the framework resolves
- * only what's depended on, dedupes, and propagates failures) and infers the
- * `options` each requires onto `signTransaction`.
+ * "violates policy" distinct from "couldn't be checked". `createSponsor`
+ * aggregates every configured validator through `sponsor.analyzer` (so the
+ * framework resolves only what's depended on and dedupes shared analyzers) and
+ * infers the `options` each requires onto `signTransaction`.
  *
  * The options and dependencies are `any` because validators are heterogeneous —
  * a validator always carries `client` in its options (its dependencies fetch data
@@ -53,18 +55,42 @@ export type SponsorRejectionReason = 'POLICY_REJECTED' | 'ANALYSIS_FAILED';
 /**
  * A validator-rejected outcome. The sponsor methods *return* this (rather than
  * throwing) so callers handle it alongside the execution result's `$kind`. The
- * `$kind` discriminates the union; `reason` says *why* it was rejected.
+ * `$kind` discriminates the union; `reason` says which class of issue requires
+ * the most conservative handling.
  */
 export interface SponsorRejection {
 	$kind: 'Rejected';
+	/** All rejection issues, preserved for existing callers. */
 	issues: ValidationIssue[];
+	/** Policy validators that ran and rejected the transaction. */
+	policyIssues: ValidationIssue[];
+	/** Analyzer/framework failures that made one or more validators unavailable. */
+	analysisIssues: ValidationIssue[];
 	reason: SponsorRejectionReason;
 }
 
-export function reasonOf(issues: ValidationIssue[]): SponsorRejectionReason {
-	return issues.some((issue) => issue.code === 'ANALYSIS_FAILED')
-		? 'ANALYSIS_FAILED'
-		: 'POLICY_REJECTED';
+export function reasonOf(
+	issues: ValidationIssue[],
+	analysisIssues: ValidationIssue[] = issues.filter((issue) => issue.code === 'ANALYSIS_FAILED'),
+): SponsorRejectionReason {
+	return analysisIssues.length > 0 ? 'ANALYSIS_FAILED' : 'POLICY_REJECTED';
+}
+
+export function createSponsorRejection({
+	policyIssues,
+	analysisIssues,
+}: {
+	policyIssues: ValidationIssue[];
+	analysisIssues: ValidationIssue[];
+}): SponsorRejection {
+	const issues = [...policyIssues, ...analysisIssues];
+	return {
+		$kind: 'Rejected',
+		issues,
+		policyIssues,
+		analysisIssues,
+		reason: reasonOf(issues, analysisIssues),
+	};
 }
 
 /**

--- a/packages/sponsor/src/validation.ts
+++ b/packages/sponsor/src/validation.ts
@@ -19,11 +19,14 @@ export interface ValidationIssue {
  * A validator is an `Analyzer` whose result is the issues it found — just
  * `createAnalyzer(...)`. Declare the analyzers it reads via `dependencies`, read
  * request-scoped inputs (an auth token, a tenant id) off `options`, and report
- * the outcome through one of three channels:
+ * the outcome through these channels:
  *
  * - **Pass** — return `{ result: null }` (or `{ result: [] }`).
  * - **Reject (policy)** — return `{ result: [{ code, message }] }`. The
  *   transaction is well-formed but violates policy → `POLICY_REJECTED`.
+ * - **Partial** — return `{ result: [{ code, message }], issues: [{ message }] }`.
+ *   The validator found a policy rejection and also hit an analysis issue; sponsor
+ *   validation reports both and uses `ANALYSIS_FAILED`.
  * - **Couldn't analyze** — return `{ issues: [{ message }] }` or `throw`. The
  *   analyzer itself couldn't decide (a failed lookup, an unreachable service) →
  *   `ANALYSIS_FAILED`. This is the analyzer framework's own channel, so it

--- a/packages/sponsor/test/sponsor.test.ts
+++ b/packages/sponsor/test/sponsor.test.ts
@@ -258,6 +258,35 @@ describe('Sponsor.signTransaction — analyzer behavior', () => {
 		}
 	});
 
+	it('reports both policy and analysis issues from a partial validator result', async () => {
+		const sponsorKey = new Ed25519Keypair();
+		const partialValidator = createAnalyzer({
+			analyze: () => () => ({
+				result: [{ code: 'POLICY_FINDING', message: 'policy finding' }],
+				issues: [{ message: 'partial lookup failed' }],
+			}),
+		}) as Validator;
+		const sponsor = createSponsor({
+			signer: sponsorKey,
+			client: {} as ClientWithCoreApi,
+			validate: [partialValidator],
+		});
+
+		const result = await sponsor.signTransaction({ transaction: txFor(sponsorKey) });
+		expect(result.$kind).toBe('Rejected');
+		if (result.$kind === 'Rejected') {
+			expect(result.reason).toBe('ANALYSIS_FAILED');
+			expect(result.policyIssues).toEqual([{ code: 'POLICY_FINDING', message: 'policy finding' }]);
+			expect(result.analysisIssues).toEqual([
+				{ code: 'ANALYSIS_FAILED', message: 'partial lookup failed' },
+			]);
+			expect(result.issues).toEqual([
+				{ code: 'POLICY_FINDING', message: 'policy finding' },
+				{ code: 'ANALYSIS_FAILED', message: 'partial lookup failed' },
+			]);
+		}
+	});
+
 	it('fails closed when a validator could not run but surfaced no issue', async () => {
 		const sponsorKey = new Ed25519Keypair();
 		// Degenerate "couldn't analyze" with an EMPTY issues array: status `failed`,

--- a/packages/sponsor/test/sponsor.test.ts
+++ b/packages/sponsor/test/sponsor.test.ts
@@ -258,6 +258,54 @@ describe('Sponsor.signTransaction — analyzer behavior', () => {
 		}
 	});
 
+	it('fails closed when a validator could not run but surfaced no issue', async () => {
+		const sponsorKey = new Ed25519Keypair();
+		// Degenerate "couldn't analyze" with an EMPTY issues array: status `failed`,
+		// no `result`, no message. Must still reject — never sign on a non-running validator.
+		const cantCheck = createAnalyzer({
+			analyze: () => () => ({ issues: [] }),
+		}) as Validator;
+		const sponsor = createSponsor({
+			signer: sponsorKey,
+			client: {} as ClientWithCoreApi,
+			validate: [cantCheck],
+		});
+
+		const result = await sponsor.signTransaction({ transaction: txFor(sponsorKey) });
+		expect(result.$kind).toBe('Rejected');
+		if (result.$kind === 'Rejected') {
+			expect(result.reason).toBe('ANALYSIS_FAILED');
+			expect(result.analysisIssues.map((issue) => issue.code)).toEqual(['ANALYSIS_FAILED']);
+		}
+	});
+
+	it('fails closed when a validator is skipped by an empty-issues required dependency', async () => {
+		const sponsorKey = new Ed25519Keypair();
+		// A required dependency that fails with an EMPTY issues array → the validator
+		// is `skipped` with `issues: []`. The aggregate must still reject.
+		const silentlyFailingDep = createAnalyzer({
+			cacheKey: 'test:silent-failing-dep',
+			analyze: () => () => ({ issues: [] }),
+		});
+		const skippedValidator = createAnalyzer({
+			dependencies: { silentlyFailingDep },
+			analyze:
+				() =>
+				({ silentlyFailingDep }) => ({ result: silentlyFailingDep ? null : null }),
+		}) as Validator;
+		const sponsor = createSponsor({
+			signer: sponsorKey,
+			client: {} as ClientWithCoreApi,
+			validate: [skippedValidator],
+		});
+
+		const result = await sponsor.signTransaction({ transaction: txFor(sponsorKey) });
+		expect(result.$kind).toBe('Rejected');
+		if (result.$kind === 'Rejected') {
+			expect(result.reason).toBe('ANALYSIS_FAILED');
+		}
+	});
+
 	it('threads request-scoped `validationOptions` to validators', async () => {
 		const sponsorKey = new Ed25519Keypair();
 		const requiresToken = createAnalyzer({

--- a/packages/sponsor/test/sponsor.test.ts
+++ b/packages/sponsor/test/sponsor.test.ts
@@ -232,6 +232,32 @@ describe('Sponsor.signTransaction — analyzer behavior', () => {
 		}
 	});
 
+	it('preserves policy rejections when an independent validator cannot analyze', async () => {
+		const sponsorKey = new Ed25519Keypair();
+		const tx = resolvedTransaction({
+			sender: sponsorKey.toSuiAddress(),
+			sponsor: sponsorKey.toSuiAddress(),
+		});
+		const cantCheck = createAnalyzer({
+			analyze: () => () => ({ issues: [{ message: 'service down' }] }),
+		}) as Validator;
+		const sponsor = createSponsor({
+			signer: sponsorKey,
+			client: {} as ClientWithCoreApi,
+			validate: [validSender(), cantCheck],
+		});
+
+		const result = await sponsor.signTransaction({ transaction: tx });
+		expect(result.$kind).toBe('Rejected');
+		if (result.$kind === 'Rejected') {
+			expect(result.reason).toBe('ANALYSIS_FAILED');
+			expect(result.policyIssues.map((issue) => issue.code)).toEqual(['SENDER_IS_SPONSOR']);
+			expect(result.analysisIssues.map((issue) => issue.message)).toEqual(['service down']);
+			expect(result.issues.map((issue) => issue.code)).toContain('SENDER_IS_SPONSOR');
+			expect(result.issues.map((issue) => issue.message)).toContain('service down');
+		}
+	});
+
 	it('threads request-scoped `validationOptions` to validators', async () => {
 		const sponsorKey = new Ed25519Keypair();
 		const requiresToken = createAnalyzer({

--- a/packages/wallet-sdk/src/auto-approvals/manager.ts
+++ b/packages/wallet-sdk/src/auto-approvals/manager.ts
@@ -10,6 +10,8 @@ import { AutoApprovalPolicySchema, AutoApprovalSettingsSchema } from './schemas/
 import { parseStructTag } from '@mysten/sui/utils';
 import type { AutoApprovalResult } from './analyzer.js';
 
+type SuccessfulAutoApprovalResult = Extract<AutoApprovalResult, { status: 'success' }>;
+
 export interface AutoApprovalManagerOptions {
 	policy: string;
 	state: string | null;
@@ -60,7 +62,12 @@ export class AutoApprovalManager {
 		const results: AutoApprovalCheck = {
 			matchesPolicy: false,
 			canAutoApprove: false,
-			analysisIssues: [...(analysis.issues ?? [])],
+			analysisIssues:
+				analysis.status === 'success'
+					? []
+					: analysis.issues.length
+						? [...analysis.issues]
+						: [{ message: 'Transaction analysis failed' }],
 			policyIssues: [],
 			settingsIssues: [],
 		};
@@ -93,7 +100,7 @@ export class AutoApprovalManager {
 	#matchesPolicy(analysis: AutoApprovalResult): AutoApprovalIssue[] {
 		const issues: AutoApprovalIssue[] = [];
 
-		if (analysis.issues) {
+		if (analysis.status !== 'success') {
 			issues.push({ message: 'Transaction analysis failed' });
 			return issues;
 		}
@@ -171,7 +178,7 @@ export class AutoApprovalManager {
 			return issues;
 		}
 
-		if (analysis.issues) {
+		if (analysis.status !== 'success') {
 			issues.push({ message: 'Transaction analysis failed' });
 			return issues;
 		}
@@ -231,12 +238,10 @@ export class AutoApprovalManager {
 
 	// TODO: we should ensure that only 1 tx is pending at a time, and pending txs can't increase budgets
 	commitTransaction(analysis: AutoApprovalResult): void {
+		assertSuccessfulAnalysis(analysis);
+
 		if (!this.#state.settings) {
 			throw new Error('No auto-approval settings configured');
-		}
-
-		if (!analysis.result) {
-			throw new Error('Transaction analysis failed');
 		}
 
 		if (this.#state.settings.remainingTransactions !== null && this.#state.settings) {
@@ -272,6 +277,8 @@ export class AutoApprovalManager {
 	}
 
 	revertTransaction(analysis: AutoApprovalResult): void {
+		assertSuccessfulAnalysis(analysis);
+
 		if (analysis.result?.digest) {
 			this.#removePendingDigest(analysis.result?.digest);
 		}
@@ -284,12 +291,10 @@ export class AutoApprovalManager {
 	}
 
 	#revertCoinFlows(analysis: AutoApprovalResult): void {
+		assertSuccessfulAnalysis(analysis);
+
 		if (!this.#state.settings) {
 			throw new Error('No auto-approval settings configured');
-		}
-
-		if (!analysis.result) {
-			throw new Error('Transaction analysis failed');
 		}
 
 		for (const outflow of analysis.result.coinFlows.outflows) {
@@ -328,14 +333,12 @@ export class AutoApprovalManager {
 		analysis: AutoApprovalResult,
 		result: SuiClientTypes.Transaction<{ balanceChanges: true }>,
 	): void {
+		assertSuccessfulAnalysis(analysis);
+
 		this.#removePendingDigest(result.digest);
 
 		if (!this.#state.settings) {
 			throw new Error('No auto-approval settings configured');
-		}
-
-		if (!analysis.result) {
-			throw new Error('Transaction analysis failed');
 		}
 
 		// Revert coin flows and use real balance changes instead
@@ -406,4 +409,12 @@ function isCoinType(type: string): boolean {
 		parsedType.name === parsedCoinType.name &&
 		parsedType.typeParams.length === 1
 	);
+}
+
+function assertSuccessfulAnalysis(
+	analysis: AutoApprovalResult,
+): asserts analysis is SuccessfulAutoApprovalResult {
+	if (analysis.status !== 'success') {
+		throw new Error('Transaction analysis failed');
+	}
 }

--- a/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
@@ -4,9 +4,20 @@
 import { Transaction } from '@mysten/sui/transactions';
 import type { Defined, Simplify, UnionToIntersection } from '../util.js';
 
+const OPTIONAL_ANALYZER = Symbol('optionalAnalyzer');
+
+export function optional<T extends Defined, Options, Analysis extends Record<string, Defined>>(
+	analyzer: Analyzer<T, Options, Analysis>,
+): OptionalAnalyzer<T, Options, Analysis> {
+	return {
+		[OPTIONAL_ANALYZER]: true,
+		analyzer,
+	};
+}
+
 export function createAnalyzer<
 	T extends Defined,
-	Deps extends Record<string, Analyzer<Defined, any, any>> = {},
+	Deps extends Record<string, AnalyzerDependency> = {},
 	Options = object,
 >({
 	cacheKey,
@@ -19,7 +30,7 @@ export function createAnalyzer<
 		options: Options,
 		transaction: Transaction,
 	) => (analysis: {
-		[k in keyof Deps]: Deps[k] extends Analyzer<infer R, any, any> ? R : never;
+		[k in keyof Deps]: DependencyResult<Deps[k]>;
 	}) => Promise<AnalyzerOutput<T>> | AnalyzerOutput<T>;
 }) {
 	return {
@@ -32,12 +43,12 @@ export function createAnalyzer<
 			UnionToIntersection<
 				| Options
 				| {
-						[k in keyof Deps]: Deps[k] extends Analyzer<any, infer O, any> ? O : never;
+						[k in keyof Deps]: DependencyOptions<Deps[k]>;
 				  }[keyof Deps]
 			>
 		>,
 		{
-			[k in keyof Deps]: Deps[k] extends Analyzer<infer R, any, any> ? R : never;
+			[k in keyof Deps]: DependencyResult<Deps[k]>;
 		}
 	>;
 }
@@ -49,6 +60,14 @@ type OptionsFromAnalyzers<T extends Record<string, Analyzer<Defined, any, any>>>
 		transaction: string | Uint8Array;
 	}
 >;
+
+function isOptionalAnalyzer(dep: AnalyzerDependency): dep is OptionalAnalyzer<Defined, any, any> {
+	return OPTIONAL_ANALYZER in dep;
+}
+
+function unwrapAnalyzer(dep: AnalyzerDependency): Analyzer<Defined> {
+	return isOptionalAnalyzer(dep) ? dep.analyzer : dep;
+}
 
 export async function analyze<T extends Record<string, Analyzer<Defined, any, any>>>(
 	analyzers: T,
@@ -64,10 +83,10 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 		const cacheKey = analyzer.cacheKey ?? analyzer;
 
 		if (!analyzerMap.has(cacheKey)) {
-			const deps: Record<string, Analyzer<Defined>> = analyzer.dependencies || {};
+			const deps: Record<string, AnalyzerDependency> = analyzer.dependencies || {};
 			analyzerMap.set(cacheKey, analyzer.analyze(options, tx));
 
-			Object.values(deps).forEach((dep) => initializeAnalyzer(dep));
+			Object.values(deps).forEach((dep) => initializeAnalyzer(unwrapAnalyzer(dep)));
 		}
 
 		return analyzerMap.get(cacheKey)!;
@@ -78,40 +97,59 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 	const analysisMap = new Map<unknown, Promise<AnalyzerResult>>();
 
 	async function runAnalyzer(analyzer: Analyzer<Defined>): Promise<AnalyzerResult> {
-		const deps: Record<string, AnalyzerResult> = Object.fromEntries(
-			await Promise.all(
-				Object.entries((analyzer.dependencies || {}) as Record<string, Analyzer<Defined>>).map(
-					async ([key, dep]) => [key, await getAnalysis(dep)],
-				),
+		const deps = await Promise.all(
+			Object.entries((analyzer.dependencies || {}) as Record<string, AnalyzerDependency>).map(
+				async ([key, dep]) => [key, dep, await getAnalysis(unwrapAnalyzer(dep))] as const,
 			),
 		);
 
+		const analysis: Record<string, Defined> = {};
 		const inherited = new Set<TransactionAnalysisIssue>();
+		let missingRequiredDependency = false;
 
-		for (const dep of Object.values(deps)) {
-			if (dep.issues) {
-				dep.issues.forEach((issue) => inherited.add(issue));
+		for (const [key, dep, result] of deps) {
+			if (isOptionalAnalyzer(dep)) {
+				analysis[key] = result;
+				continue;
+			}
+
+			if (result.issues) {
+				result.issues.forEach((issue) => inherited.add(issue));
+			}
+
+			if (result.status === 'success' || result.status === 'partial') {
+				analysis[key] = result.result;
+			} else {
+				missingRequiredDependency = true;
 			}
 		}
 
-		if (inherited.size) {
-			return { issues: [...inherited], ownIssues: [] };
+		if (missingRequiredDependency) {
+			return { status: 'skipped', issues: [...inherited], ownIssues: [] };
 		}
 
 		try {
-			const output = await analyzerMap.get(analyzer.cacheKey ?? analyzer)!(
-				Object.fromEntries(Object.entries(deps).map(([key, dep]) => [key, dep.result])),
-			);
+			const output = await analyzerMap.get(analyzer.cacheKey ?? analyzer)!(analysis);
+			const ownIssues = output.issues ? [...output.issues] : [];
+			const issues = [...new Set([...inherited, ...ownIssues])];
 
-			if (output.issues) {
-				return { issues: [...output.issues], ownIssues: [...output.issues] };
+			if (output.result !== undefined) {
+				if (issues.length) {
+					return { status: 'partial', result: output.result, issues, ownIssues };
+				}
+				return { status: 'success', result: output.result };
 			}
-			return { result: output.result };
+
+			return { status: 'failed', issues, ownIssues };
 		} catch (error) {
 			const issue = {
 				message: `Unexpected error while analyzing transaction: ${(error as Error).message}`,
 			};
-			return { issues: [issue], ownIssues: [issue] };
+			return {
+				status: 'failed',
+				issues: [...new Set([...inherited, issue])],
+				ownIssues: [issue],
+			};
 		}
 	}
 
@@ -139,8 +177,47 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 		if (result.ownIssues) issues.push(...result.ownIssues);
 	}
 
-	return { ...perAnalyzer, issues };
+	const topLevelResults = Object.values(perAnalyzer);
+	const hasSuccessfulResult = topLevelResults.some(
+		(result) => result.status === 'success' || result.status === 'partial',
+	);
+	const status: AnalyzeStatus = topLevelResults.every((result) => result.status === 'success')
+		? 'complete'
+		: hasSuccessfulResult
+			? 'partial'
+			: 'failed';
+
+	return { ...perAnalyzer, issues, status };
 }
+
+export type AnalyzerDependency = Analyzer<Defined, any, any> | OptionalAnalyzer<Defined, any, any>;
+
+type DependencyResult<T extends AnalyzerDependency> =
+	T extends OptionalAnalyzer<infer R, any, any>
+		? AnalyzerResult<R>
+		: T extends Analyzer<infer R, any, any>
+			? R
+			: never;
+
+type DependencyOptions<T extends AnalyzerDependency> =
+	T extends OptionalAnalyzer<any, infer O, any>
+		? O
+		: T extends Analyzer<any, infer O, any>
+			? O
+			: never;
+
+export interface OptionalAnalyzer<
+	T extends Defined,
+	Options = object,
+	Analysis extends Record<string, Defined> = {},
+> {
+	[OPTIONAL_ANALYZER]: true;
+	analyzer: Analyzer<T, Options, Analysis>;
+}
+
+export type AnalyzerStatus = 'success' | 'partial' | 'failed' | 'skipped';
+
+export type AnalyzeStatus = 'complete' | 'partial' | 'failed';
 
 export type Analyzer<
 	T extends Defined,
@@ -148,9 +225,7 @@ export type Analyzer<
 	Analysis extends Record<string, Defined> = {},
 > = {
 	cacheKey?: unknown;
-	dependencies: {
-		[k in keyof Analysis]: Analyzer<Analysis[k], Options>;
-	};
+	dependencies: Record<string, AnalyzerDependency>;
 	analyze: (
 		options: Options,
 		transaction: Transaction,
@@ -160,7 +235,7 @@ export type Analyzer<
 export type AnalyzerOutput<T extends Defined = Defined> =
 	| {
 			result: T;
-			issues?: never;
+			issues?: TransactionAnalysisIssue[];
 	  }
 	| {
 			issues: TransactionAnalysisIssue[];
@@ -169,14 +244,28 @@ export type AnalyzerOutput<T extends Defined = Defined> =
 
 export type AnalyzerResult<T extends Defined = Defined> =
 	| {
+			status: 'success';
 			result: T;
 			issues?: never;
 			ownIssues?: never;
 	  }
 	| {
+			status: 'partial';
+			result: T;
+			issues: TransactionAnalysisIssue[];
+			ownIssues: TransactionAnalysisIssue[];
+	  }
+	| {
+			status: 'failed';
 			result?: never;
 			issues: TransactionAnalysisIssue[];
 			ownIssues: TransactionAnalysisIssue[];
+	  }
+	| {
+			status: 'skipped';
+			result?: never;
+			issues: TransactionAnalysisIssue[];
+			ownIssues: [];
 	  };
 
 export interface TransactionAnalysisIssue {

--- a/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
@@ -81,16 +81,24 @@ function unwrapResult(result: AnalyzerResult): Defined {
 	return (result as { result?: Defined }).result as Defined;
 }
 
+/** The identity transform applied to optional dependency objects by default. */
+function identityResult(result: AnalyzerResult): Defined {
+	return result;
+}
+
 function isDependency(dep: AnalyzerDependency): dep is Dependency<Defined, Defined, any, any> {
 	return 'analyzer' in dep;
 }
 
 function normalizeDependency(dep: AnalyzerDependency): NormalizedDependency {
 	if (isDependency(dep)) {
+		const required = dep.required ?? true;
 		return {
 			analyzer: dep.analyzer,
-			required: dep.required ?? true,
-			transform: (dep.transform ?? unwrapResult) as (result: AnalyzerResult) => Defined,
+			required,
+			transform: (dep.transform ?? (required ? unwrapResult : identityResult)) as (
+				result: AnalyzerResult,
+			) => Defined,
 		};
 	}
 
@@ -101,6 +109,10 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 	analyzers: T,
 	{ transaction, ...options }: OptionsFromAnalyzers<T>,
 ) {
+	if (Object.prototype.hasOwnProperty.call(analyzers, 'status')) {
+		throw new Error('Analyzer key "status" is reserved for the top-level analysis status');
+	}
+
 	const tx = Transaction.from(transaction);
 	const analyzerMap = new Map<
 		unknown,
@@ -138,33 +150,34 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 		const inherited = new Set<TransactionAnalysisIssue>();
 		let missingRequiredDependency = false;
 
-		for (const [key, { required, transform }, result] of deps) {
-			// Optional deps never gate and never inherit issues: the parent owns the full
-			// result (default `transform` for `optional()` is identity) and decides itself.
-			if (!required) {
-				analysis[key] = transform(result);
-				continue;
-			}
-
-			if (result.issues) {
-				result.issues.forEach((issue) => inherited.add(issue));
-			}
-
-			// A required dep that produced no result (`failed`/`skipped`) short-circuits the
-			// parent. `partial` still has a result, so it proceeds — `partial` is only
-			// meaningful at the outer `analyze()` layer, not at a dependency boundary.
-			if (result.status === 'success' || result.status === 'partial') {
-				analysis[key] = transform(result);
-			} else {
-				missingRequiredDependency = true;
-			}
-		}
-
-		if (missingRequiredDependency) {
-			return { status: 'skipped', issues: [...inherited], ownIssues: [] };
-		}
-
 		try {
+			for (const [key, { required, transform }, result] of deps) {
+				// Optional deps never gate and never inherit issues: the parent owns the full
+				// result (default `transform` for `optional()` and explicit optional objects is
+				// identity) and decides itself.
+				if (!required) {
+					analysis[key] = transform(result);
+					continue;
+				}
+
+				if (result.issues) {
+					result.issues.forEach((issue) => inherited.add(issue));
+				}
+
+				// A required dep that produced no result (`failed`/`skipped`) short-circuits the
+				// parent. `partial` still has a result, so it proceeds — `partial` is only
+				// meaningful at the outer `analyze()` layer, not at a dependency boundary.
+				if (result.status === 'success' || result.status === 'partial') {
+					analysis[key] = transform(result);
+				} else {
+					missingRequiredDependency = true;
+				}
+			}
+
+			if (missingRequiredDependency) {
+				return { status: 'skipped', issues: [...inherited], ownIssues: [] };
+			}
+
 			const output = await analyzerMap.get(analyzer.cacheKey ?? analyzer)!(analysis);
 			const ownIssues = output.issues ? [...output.issues] : [];
 			const issues = [...new Set([...inherited, ...ownIssues])];
@@ -234,6 +247,7 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
  * value is the unwrapped result. The explicit object form lets you declare an
  * edge `required: false` (the parent never short-circuits on it) and/or map the
  * dependency's full {@link AnalyzerResult} to a custom value via `transform`.
+ * An optional edge without a `transform` receives the full {@link AnalyzerResult}.
  */
 export interface Dependency<
 	R extends Defined,
@@ -244,18 +258,26 @@ export interface Dependency<
 	analyzer: Analyzer<R, Options, Analysis>;
 	/** Whether a failed/skipped dependency short-circuits the parent. Default: `true`. */
 	required?: boolean;
-	/** Maps the dependency's full result to the value the parent sees. Default: `(r) => r.result`. */
+	/**
+	 * Maps the dependency's full result to the value the parent sees. Default:
+	 * `(r) => r.result` for required edges and `(r) => r` for optional edges.
+	 */
 	transform?: (result: AnalyzerResult<R>) => V;
 }
 
 export type AnalyzerDependency = Analyzer<Defined, any, any> | Dependency<any, Defined, any, any>;
 
-type DependencyResult<T extends AnalyzerDependency> =
-	T extends Dependency<any, infer V, any, any>
-		? V
-		: T extends Analyzer<infer R, any, any>
-			? R
-			: never;
+type DependencyResult<T extends AnalyzerDependency> = T extends {
+	transform: (result: AnalyzerResult<any>) => infer V;
+}
+	? V
+	: T extends { analyzer: Analyzer<infer R, any, any>; required: false; transform?: undefined }
+		? AnalyzerResult<R>
+		: T extends Dependency<any, infer V, any, any>
+			? V
+			: T extends Analyzer<infer R, any, any>
+				? R
+				: never;
 
 type DependencyOptions<T extends AnalyzerDependency> =
 	T extends Dependency<any, any, infer O, any>
@@ -274,12 +296,18 @@ export type Analyzer<
 	Analysis extends Record<string, Defined> = {},
 > = {
 	cacheKey?: unknown;
-	dependencies: Record<string, AnalyzerDependency>;
+	dependencies: AnalyzerDependencies<Analysis>;
 	analyze: (
 		options: Options,
 		transaction: Transaction,
 	) => (analysis: Analysis) => AnalyzerOutput<T> | Promise<AnalyzerOutput<T>>;
 };
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AnalyzerDependencies<Analysis extends Record<string, Defined>> =
+	IsAny<Analysis> extends true
+		? Record<string, AnalyzerDependency>
+		: { [K in keyof Analysis]: AnalyzerDependency } & Record<string, AnalyzerDependency>;
 
 export type AnalyzerOutput<T extends Defined = Defined> =
 	| {

--- a/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/analyzer.ts
@@ -4,14 +4,20 @@
 import { Transaction } from '@mysten/sui/transactions';
 import type { Defined, Simplify, UnionToIntersection } from '../util.js';
 
-const OPTIONAL_ANALYZER = Symbol('optionalAnalyzer');
-
+/**
+ * Declare a dependency on `analyzer` that does NOT short-circuit the parent when
+ * it fails: the parent always runs and receives the dependency's full
+ * {@link AnalyzerResult} (so it can inspect `status`/`issues`) rather than the
+ * unwrapped result. Sugar for `{ analyzer, required: false, transform: (r) => r }`
+ * — see {@link Dependency} for the general (required + custom `transform`) form.
+ */
 export function optional<T extends Defined, Options, Analysis extends Record<string, Defined>>(
 	analyzer: Analyzer<T, Options, Analysis>,
-): OptionalAnalyzer<T, Options, Analysis> {
+): Dependency<T, AnalyzerResult<T>, Options, Analysis> {
 	return {
-		[OPTIONAL_ANALYZER]: true,
 		analyzer,
+		required: false,
+		transform: (result) => result,
 	};
 }
 
@@ -61,12 +67,34 @@ type OptionsFromAnalyzers<T extends Record<string, Analyzer<Defined, any, any>>>
 	}
 >;
 
-function isOptionalAnalyzer(dep: AnalyzerDependency): dep is OptionalAnalyzer<Defined, any, any> {
-	return OPTIONAL_ANALYZER in dep;
+/** A dependency edge, normalized to its three intrinsic parts. */
+interface NormalizedDependency {
+	analyzer: Analyzer<Defined>;
+	/** Required deps short-circuit the parent (→ `skipped`) when they produce no result. */
+	required: boolean;
+	/** Maps the dependency's full result to the value the parent sees. */
+	transform: (result: AnalyzerResult) => Defined;
 }
 
-function unwrapAnalyzer(dep: AnalyzerDependency): Analyzer<Defined> {
-	return isOptionalAnalyzer(dep) ? dep.analyzer : dep;
+/** The unwrapping transform applied to bare-analyzer dependencies by default. */
+function unwrapResult(result: AnalyzerResult): Defined {
+	return (result as { result?: Defined }).result as Defined;
+}
+
+function isDependency(dep: AnalyzerDependency): dep is Dependency<Defined, Defined, any, any> {
+	return 'analyzer' in dep;
+}
+
+function normalizeDependency(dep: AnalyzerDependency): NormalizedDependency {
+	if (isDependency(dep)) {
+		return {
+			analyzer: dep.analyzer,
+			required: dep.required ?? true,
+			transform: (dep.transform ?? unwrapResult) as (result: AnalyzerResult) => Defined,
+		};
+	}
+
+	return { analyzer: dep as Analyzer<Defined>, required: true, transform: unwrapResult };
 }
 
 export async function analyze<T extends Record<string, Analyzer<Defined, any, any>>>(
@@ -86,7 +114,7 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 			const deps: Record<string, AnalyzerDependency> = analyzer.dependencies || {};
 			analyzerMap.set(cacheKey, analyzer.analyze(options, tx));
 
-			Object.values(deps).forEach((dep) => initializeAnalyzer(unwrapAnalyzer(dep)));
+			Object.values(deps).forEach((dep) => initializeAnalyzer(normalizeDependency(dep).analyzer));
 		}
 
 		return analyzerMap.get(cacheKey)!;
@@ -99,7 +127,10 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 	async function runAnalyzer(analyzer: Analyzer<Defined>): Promise<AnalyzerResult> {
 		const deps = await Promise.all(
 			Object.entries((analyzer.dependencies || {}) as Record<string, AnalyzerDependency>).map(
-				async ([key, dep]) => [key, dep, await getAnalysis(unwrapAnalyzer(dep))] as const,
+				async ([key, dep]) => {
+					const normalized = normalizeDependency(dep);
+					return [key, normalized, await getAnalysis(normalized.analyzer)] as const;
+				},
 			),
 		);
 
@@ -107,9 +138,11 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 		const inherited = new Set<TransactionAnalysisIssue>();
 		let missingRequiredDependency = false;
 
-		for (const [key, dep, result] of deps) {
-			if (isOptionalAnalyzer(dep)) {
-				analysis[key] = result;
+		for (const [key, { required, transform }, result] of deps) {
+			// Optional deps never gate and never inherit issues: the parent owns the full
+			// result (default `transform` for `optional()` is identity) and decides itself.
+			if (!required) {
+				analysis[key] = transform(result);
 				continue;
 			}
 
@@ -117,8 +150,11 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 				result.issues.forEach((issue) => inherited.add(issue));
 			}
 
+			// A required dep that produced no result (`failed`/`skipped`) short-circuits the
+			// parent. `partial` still has a result, so it proceeds — `partial` is only
+			// meaningful at the outer `analyze()` layer, not at a dependency boundary.
 			if (result.status === 'success' || result.status === 'partial') {
-				analysis[key] = result.result;
+				analysis[key] = transform(result);
 			} else {
 				missingRequiredDependency = true;
 			}
@@ -133,6 +169,9 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 			const ownIssues = output.issues ? [...output.issues] : [];
 			const issues = [...new Set([...inherited, ...ownIssues])];
 
+			// Intentional `!== undefined` (not truthiness): falsy results (`0`, `''`,
+			// `false`, `null`) are valid and must stay `success`/`partial`. Do not refactor
+			// to `if (output.result)` — that would silently reclassify them as `failed`.
 			if (output.result !== undefined) {
 				if (issues.length) {
 					return { status: 'partial', result: output.result, issues, ownIssues };
@@ -190,30 +229,40 @@ export async function analyze<T extends Record<string, Analyzer<Defined, any, an
 	return { ...perAnalyzer, issues, status };
 }
 
-export type AnalyzerDependency = Analyzer<Defined, any, any> | OptionalAnalyzer<Defined, any, any>;
+/**
+ * A dependency edge. A bare {@link Analyzer} is sugar for a required edge whose
+ * value is the unwrapped result. The explicit object form lets you declare an
+ * edge `required: false` (the parent never short-circuits on it) and/or map the
+ * dependency's full {@link AnalyzerResult} to a custom value via `transform`.
+ */
+export interface Dependency<
+	R extends Defined,
+	V extends Defined = R,
+	Options = object,
+	Analysis extends Record<string, Defined> = {},
+> {
+	analyzer: Analyzer<R, Options, Analysis>;
+	/** Whether a failed/skipped dependency short-circuits the parent. Default: `true`. */
+	required?: boolean;
+	/** Maps the dependency's full result to the value the parent sees. Default: `(r) => r.result`. */
+	transform?: (result: AnalyzerResult<R>) => V;
+}
+
+export type AnalyzerDependency = Analyzer<Defined, any, any> | Dependency<any, Defined, any, any>;
 
 type DependencyResult<T extends AnalyzerDependency> =
-	T extends OptionalAnalyzer<infer R, any, any>
-		? AnalyzerResult<R>
+	T extends Dependency<any, infer V, any, any>
+		? V
 		: T extends Analyzer<infer R, any, any>
 			? R
 			: never;
 
 type DependencyOptions<T extends AnalyzerDependency> =
-	T extends OptionalAnalyzer<any, infer O, any>
+	T extends Dependency<any, any, infer O, any>
 		? O
 		: T extends Analyzer<any, infer O, any>
 			? O
 			: never;
-
-export interface OptionalAnalyzer<
-	T extends Defined,
-	Options = object,
-	Analysis extends Record<string, Defined> = {},
-> {
-	[OPTIONAL_ANALYZER]: true;
-	analyzer: Analyzer<T, Options, Analysis>;
-}
 
 export type AnalyzerStatus = 'success' | 'partial' | 'failed' | 'skipped';
 

--- a/packages/wallet-sdk/src/transaction-analyzer/index.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/index.ts
@@ -9,7 +9,7 @@ export type {
 	AnalyzeStatus,
 	AnalyzerResult,
 	AnalyzerOutput,
-	OptionalAnalyzer,
+	Dependency,
 	TransactionAnalysisIssue,
 } from './analyzer.js';
 

--- a/packages/wallet-sdk/src/transaction-analyzer/index.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/index.ts
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-export { analyze, createAnalyzer } from './analyzer.js';
+export { analyze, createAnalyzer, optional } from './analyzer.js';
 export type {
+	AnalyzerDependency,
 	Analyzer,
+	AnalyzerStatus,
+	AnalyzeStatus,
 	AnalyzerResult,
 	AnalyzerOutput,
+	OptionalAnalyzer,
 	TransactionAnalysisIssue,
 } from './analyzer.js';
 

--- a/packages/wallet-sdk/test/auto-approvals/manager.test.ts
+++ b/packages/wallet-sdk/test/auto-approvals/manager.test.ts
@@ -10,6 +10,8 @@ import {
 	AutoApprovalManager,
 	AutoApprovalPolicy,
 	operationType,
+	type AutoApprovalAnalysis,
+	type AutoApprovalResult,
 } from '../../src/index.js';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { MIST_PER_SUI } from '@mysten/sui/utils';
@@ -26,7 +28,84 @@ const policy: AutoApprovalPolicy = {
 	suggestedSettings: {},
 };
 
+function managerWithSettings() {
+	const manager = new AutoApprovalManager({
+		policy: JSON.stringify(policy),
+		state: null,
+	});
+	manager.updateSettings({
+		approvedOperations: ['test-operation'],
+		expiration: Date.now() + 1000 * 60 * 60,
+		remainingTransactions: 1,
+		sharedBudget: 10,
+		coinBudgets: {},
+	});
+	return manager;
+}
+
+function autoApprovalAnalysis(): AutoApprovalAnalysis {
+	return {
+		operationType: 'test-operation',
+		bytes: new Uint8Array([1, 2, 3]),
+		coinFlows: { outflows: [] },
+		coinValues: { total: 0, coinTypesWithoutPrice: [], coinTypes: [] },
+		accessLevel: {},
+		ownedObjects: [],
+		digest: 'test-digest',
+	};
+}
+
 describe('AutoApprovalManager', () => {
+	test('checkTransaction reports partial analysis as analysis issues', () => {
+		const manager = managerWithSettings();
+		const analysis: AutoApprovalResult = {
+			status: 'partial',
+			result: autoApprovalAnalysis(),
+			issues: [{ message: 'coin values unavailable' }],
+			ownIssues: [{ message: 'coin values unavailable' }],
+		};
+
+		expect(manager.checkTransaction(analysis)).toEqual({
+			matchesPolicy: false,
+			canAutoApprove: false,
+			analysisIssues: [{ message: 'coin values unavailable' }],
+			policyIssues: [],
+			settingsIssues: [],
+		});
+	});
+
+	test('commitTransaction rejects partial analysis without mutating state', () => {
+		const manager = managerWithSettings();
+		const analysis: AutoApprovalResult = {
+			status: 'partial',
+			result: autoApprovalAnalysis(),
+			issues: [{ message: 'coin values unavailable' }],
+			ownIssues: [{ message: 'coin values unavailable' }],
+		};
+
+		expect(() => manager.commitTransaction(analysis)).toThrow('Transaction analysis failed');
+		expect(manager.getSettings()?.remainingTransactions).toBe(1);
+		expect(manager.getState().pendingDigests).toEqual([]);
+	});
+
+	test('applyTransactionEffects rejects partial analysis before mutating pending digests', () => {
+		const manager = managerWithSettings();
+		const analysis: AutoApprovalResult = {
+			status: 'partial',
+			result: autoApprovalAnalysis(),
+			issues: [{ message: 'coin values unavailable' }],
+			ownIssues: [{ message: 'coin values unavailable' }],
+		};
+
+		expect(() =>
+			manager.applyTransactionEffects(analysis, {
+				digest: 'test-digest',
+				balanceChanges: [],
+			} as unknown as Parameters<AutoApprovalManager['applyTransactionEffects']>[1]),
+		).toThrow('Transaction analysis failed');
+		expect(manager.getState().pendingDigests).toEqual([]);
+	});
+
 	test.skip('placeholder example', async () => {
 		const keypair = new Ed25519Keypair();
 		const client = new SuiGrpcClient({

--- a/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
 
-import { analyze, createAnalyzer } from '../../src/transaction-analyzer/analyzer.js';
+import { analyze, createAnalyzer, optional } from '../../src/transaction-analyzer/analyzer.js';
 import { DEFAULT_SENDER } from '../mocks/mockData.js';
 
 const failingDep = createAnalyzer({
@@ -35,6 +35,31 @@ const ownIssuesAnalyzer = createAnalyzer({
 	analyze: () => () => ({ issues: [{ message: 'own-issue emitted by this analyzer' }] }),
 });
 
+const partialAnalyzer = createAnalyzer({
+	cacheKey: 'test-partial',
+	analyze: () => () => ({
+		result: 'partial-result',
+		issues: [{ message: 'partial analyzer warning' }],
+	}),
+});
+
+const optionalDepAnalyzer = createAnalyzer({
+	cacheKey: 'test-optional-dep',
+	dependencies: { failingDep: optional(failingDep), leafOk },
+	analyze:
+		() =>
+		({ failingDep, leafOk }) => ({
+			result: {
+				depStatus: failingDep.status,
+				value: leafOk,
+			},
+			issues:
+				failingDep.status === 'success'
+					? undefined
+					: [{ message: `optional dependency was ${failingDep.status}` }],
+		}),
+});
+
 async function txJson() {
 	const tx = new Transaction();
 	tx.setSender(DEFAULT_SENDER);
@@ -42,8 +67,10 @@ async function txJson() {
 }
 
 describe('analyze — issue handling', () => {
-	it('inherited dep issues populate `issues` but leave `ownIssues` empty', async () => {
+	it('failed dep issues skip required dependents and leave `ownIssues` empty', async () => {
 		const r = await analyze({ analyzerA }, { transaction: await txJson() });
+		expect(r.status).toBe('failed');
+		expect(r.analyzerA.status).toBe('skipped');
 		expect(r.analyzerA.result).toBeUndefined();
 		expect(r.analyzerA.issues).toEqual([{ message: 'shared-dep failed' }]);
 		expect(r.analyzerA.ownIssues).toEqual([]);
@@ -51,6 +78,8 @@ describe('analyze — issue handling', () => {
 
 	it('own issues appear in both `issues` and `ownIssues`', async () => {
 		const r = await analyze({ ownIssuesAnalyzer }, { transaction: await txJson() });
+		expect(r.status).toBe('failed');
+		expect(r.ownIssuesAnalyzer.status).toBe('failed');
 		expect(r.ownIssuesAnalyzer.result).toBeUndefined();
 		expect(r.ownIssuesAnalyzer.issues).toEqual([{ message: 'own-issue emitted by this analyzer' }]);
 		expect(r.ownIssuesAnalyzer.ownIssues).toEqual([
@@ -60,6 +89,8 @@ describe('analyze — issue handling', () => {
 
 	it('successful analyzers have no issues or ownIssues', async () => {
 		const r = await analyze({ leafOk }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
+		expect(r.leafOk.status).toBe('success');
 		expect(r.leafOk.result).toBe(42);
 		expect(r.leafOk.issues).toBeUndefined();
 		expect(r.leafOk.ownIssues).toBeUndefined();
@@ -67,6 +98,7 @@ describe('analyze — issue handling', () => {
 
 	it('top-level `issues` reports each failing analyzer exactly once', async () => {
 		const r = await analyze({ analyzerA, analyzerB }, { transaction: await txJson() });
+		expect(r.status).toBe('failed');
 		expect(r.analyzerA.issues).toEqual([{ message: 'shared-dep failed' }]);
 		expect(r.analyzerB.issues).toEqual([{ message: 'shared-dep failed' }]);
 		expect(r.issues).toEqual([{ message: 'shared-dep failed' }]);
@@ -74,12 +106,47 @@ describe('analyze — issue handling', () => {
 
 	it('top-level `issues` includes own-issues from every analyzer, not just top-level ones', async () => {
 		const r = await analyze({ analyzerA, ownIssuesAnalyzer }, { transaction: await txJson() });
+		expect(r.status).toBe('failed');
 		const messages = r.issues.map((i) => i.message).sort();
 		expect(messages).toEqual(['own-issue emitted by this analyzer', 'shared-dep failed']);
 	});
 
 	it('top-level `issues` is empty when nothing fails', async () => {
 		const r = await analyze({ leafOk }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
 		expect(r.issues).toEqual([]);
+	});
+
+	it('top-level status is partial when independent analyzers have mixed outcomes', async () => {
+		const r = await analyze({ analyzerA, leafOk }, { transaction: await txJson() });
+		expect(r.status).toBe('partial');
+		expect(r.analyzerA.status).toBe('skipped');
+		expect(r.leafOk.status).toBe('success');
+		expect(r.leafOk.result).toBe(42);
+	});
+
+	it('an analyzer can return a partial result with issues', async () => {
+		const r = await analyze({ partialAnalyzer }, { transaction: await txJson() });
+		expect(r.status).toBe('partial');
+		expect(r.partialAnalyzer.status).toBe('partial');
+		expect(r.partialAnalyzer.result).toBe('partial-result');
+		expect(r.partialAnalyzer.issues).toEqual([{ message: 'partial analyzer warning' }]);
+		expect(r.partialAnalyzer.ownIssues).toEqual([{ message: 'partial analyzer warning' }]);
+		expect(r.issues).toEqual([{ message: 'partial analyzer warning' }]);
+	});
+
+	it('optional dependency failures do not skip the parent analyzer', async () => {
+		const r = await analyze({ optionalDepAnalyzer }, { transaction: await txJson() });
+		expect(r.status).toBe('partial');
+		expect(r.optionalDepAnalyzer.status).toBe('partial');
+		expect(r.optionalDepAnalyzer.result).toEqual({
+			depStatus: 'failed',
+			value: 42,
+		});
+		expect(r.optionalDepAnalyzer.issues).toEqual([{ message: 'optional dependency was failed' }]);
+		expect(r.issues.map((issue) => issue.message).sort()).toEqual([
+			'optional dependency was failed',
+			'shared-dep failed',
+		]);
 	});
 });

--- a/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
 
-import type { AnalyzerResult } from '../../src/transaction-analyzer/analyzer.js';
+import type { Analyzer, AnalyzerResult } from '../../src/transaction-analyzer/analyzer.js';
 import { analyze, createAnalyzer, optional } from '../../src/transaction-analyzer/analyzer.js';
 import { DEFAULT_SENDER } from '../mocks/mockData.js';
 
@@ -86,6 +86,42 @@ const transformedOptionalDep = createAnalyzer({
 	analyze:
 		() =>
 		({ failingDep }) => ({ result: failingDep }),
+});
+
+const optionalObjectDep = createAnalyzer({
+	cacheKey: 'test-optional-object-dep',
+	dependencies: {
+		failingDep: {
+			analyzer: failingDep,
+			required: false,
+		},
+	},
+	analyze:
+		() =>
+		({ failingDep }) => ({ result: failingDep.status }),
+});
+
+const parentOfPartialDep = createAnalyzer({
+	cacheKey: 'test-parent-of-partial-dep',
+	dependencies: { partialAnalyzer },
+	analyze:
+		() =>
+		({ partialAnalyzer }) => ({ result: `parent saw ${partialAnalyzer}` }),
+});
+
+const throwingTransformDep = createAnalyzer({
+	cacheKey: 'test-throwing-transform',
+	dependencies: {
+		leaf: {
+			analyzer: leafOk,
+			transform: (_result: AnalyzerResult<number>): string => {
+				throw new Error('transform boom');
+			},
+		},
+	},
+	analyze:
+		() =>
+		({ leaf }) => ({ result: leaf }),
 });
 
 async function txJson() {
@@ -194,5 +230,69 @@ describe('analyze — issue handling', () => {
 		// since top-level `issues` collects every analyzer's own-issues).
 		expect(r.transformedOptionalDep.result).toBe('fallback');
 		expect(r.transformedOptionalDep.issues).toBeUndefined();
+	});
+
+	it('an optional dependency object without a transform receives the full dependency result', async () => {
+		const r = await analyze({ optionalObjectDep }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
+		expect(r.optionalObjectDep.status).toBe('success');
+		expect(r.optionalObjectDep.result).toBe('failed');
+	});
+
+	it('transform errors are reported as analyzer failures', async () => {
+		const r = await analyze({ throwingTransformDep }, { transaction: await txJson() });
+		expect(r.status).toBe('failed');
+		expect(r.throwingTransformDep.status).toBe('failed');
+		if (r.throwingTransformDep.status !== 'failed') {
+			throw new Error(`Expected failed status, got ${r.throwingTransformDep.status}`);
+		}
+		expect(r.throwingTransformDep.issues.map((issue) => issue.message)).toEqual([
+			'Unexpected error while analyzing transaction: transform boom',
+		]);
+		expect(r.issues.map((issue) => issue.message)).toEqual([
+			'Unexpected error while analyzing transaction: transform boom',
+		]);
+	});
+
+	it('a required partial dependency still feeds the parent and inherits issues', async () => {
+		const r = await analyze({ parentOfPartialDep }, { transaction: await txJson() });
+		expect(r.status).toBe('partial');
+		expect(r.parentOfPartialDep.status).toBe('partial');
+		expect(r.parentOfPartialDep.result).toBe('parent saw partial-result');
+		expect(r.parentOfPartialDep.issues).toEqual([{ message: 'partial analyzer warning' }]);
+		expect(r.parentOfPartialDep.ownIssues).toEqual([]);
+	});
+
+	it.each([
+		['zero', 0],
+		['empty string', ''],
+		['false', false],
+		['null', null],
+	] as const)('keeps %s analyzer results as success', async (_name, value) => {
+		const falsyAnalyzer = createAnalyzer({
+			analyze: () => () => ({ result: value }),
+		});
+		const r = await analyze({ falsyAnalyzer }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
+		expect(r.falsyAnalyzer.status).toBe('success');
+		expect(r.falsyAnalyzer.result).toBe(value);
+	});
+
+	it('rejects analyzer key `status` because it is reserved for top-level status', async () => {
+		await expect(analyze({ status: leafOk }, { transaction: await txJson() })).rejects.toThrow(
+			'Analyzer key "status" is reserved for the top-level analysis status',
+		);
+	});
+
+	it('requires annotated Analyzer dependencies to include analysis keys', () => {
+		const invalidAnalyzer: Analyzer<string, object, { foo: number }> = {
+			// @ts-expect-error The `foo` analysis key must have a corresponding dependency.
+			dependencies: {},
+			analyze:
+				() =>
+				({ foo }) => ({ result: foo.toFixed() }),
+		};
+
+		expect(invalidAnalyzer.dependencies).toEqual({});
 	});
 });

--- a/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/issue-aggregation.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
 
+import type { AnalyzerResult } from '../../src/transaction-analyzer/analyzer.js';
 import { analyze, createAnalyzer, optional } from '../../src/transaction-analyzer/analyzer.js';
 import { DEFAULT_SENDER } from '../mocks/mockData.js';
 
@@ -58,6 +59,33 @@ const optionalDepAnalyzer = createAnalyzer({
 					? undefined
 					: [{ message: `optional dependency was ${failingDep.status}` }],
 		}),
+});
+
+// A required dependency edge with a custom `transform` that maps the dependency's
+// full result to a derived value (here: its status). Required edges still
+// short-circuit the parent when the dependency produces no result.
+const transformedRequiredDep = createAnalyzer({
+	cacheKey: 'test-transformed-required',
+	dependencies: { leaf: { analyzer: leafOk, transform: (r: AnalyzerResult<number>) => r.status } },
+	analyze:
+		() =>
+		({ leaf }) => ({ result: `leaf-was-${leaf}` }),
+});
+
+// An optional dependency edge with a custom `transform` that falls back to a
+// default when the dependency could not run, instead of receiving the full result.
+const transformedOptionalDep = createAnalyzer({
+	cacheKey: 'test-transformed-optional',
+	dependencies: {
+		failingDep: {
+			analyzer: failingDep,
+			required: false,
+			transform: (r: AnalyzerResult<string>) => r.result ?? 'fallback',
+		},
+	},
+	analyze:
+		() =>
+		({ failingDep }) => ({ result: failingDep }),
 });
 
 async function txJson() {
@@ -148,5 +176,23 @@ describe('analyze — issue handling', () => {
 			'optional dependency was failed',
 			'shared-dep failed',
 		]);
+	});
+
+	it('a required dependency can transform the dependency result into a derived value', async () => {
+		const r = await analyze({ transformedRequiredDep }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
+		expect(r.transformedRequiredDep.status).toBe('success');
+		expect(r.transformedRequiredDep.result).toBe('leaf-was-success');
+	});
+
+	it('an optional dependency transform can supply a fallback when the dependency fails', async () => {
+		const r = await analyze({ transformedOptionalDep }, { transaction: await txJson() });
+		expect(r.status).toBe('complete');
+		expect(r.transformedOptionalDep.status).toBe('success');
+		// Optional edges never inherit issues into the parent, so the parent stays `success`
+		// and reports no issues of its own (the dep's own-issue still surfaces at top level,
+		// since top-level `issues` collects every analyzer's own-issues).
+		expect(r.transformedOptionalDep.result).toBe('fallback');
+		expect(r.transformedOptionalDep.issues).toBeUndefined();
 	});
 });

--- a/packages/wallet-sdk/test/transaction-analyzer/partial-security.test.ts
+++ b/packages/wallet-sdk/test/transaction-analyzer/partial-security.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { Transaction } from '@mysten/sui/transactions';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
+
+import { analyze, createAnalyzer } from '../../src/transaction-analyzer/analyzer.js';
+import { commands } from '../../src/transaction-analyzer/rules/commands.js';
+import { data } from '../../src/transaction-analyzer/rules/core.js';
+import { MockSuiClient } from '../mocks/MockSuiClient.js';
+import { DEFAULT_SENDER } from '../mocks/mockData.js';
+
+const BLOCKED_PACKAGE = normalizeSuiAddress('0xbad');
+
+const blockedMoveCallChecks = createAnalyzer({
+	cacheKey: 'test-blocked-move-call-checks',
+	dependencies: { data },
+	analyze:
+		() =>
+		({ data }) => {
+			return {
+				result: data.commands.flatMap((command) => {
+					if (
+						command.$kind !== 'MoveCall' ||
+						normalizeSuiAddress(command.MoveCall.package) !== BLOCKED_PACKAGE
+					) {
+						return [];
+					}
+					return [
+						{
+							code: 'BLOCKED_PACKAGE',
+							target: `${command.MoveCall.package}::${command.MoveCall.module}::${command.MoveCall.function}`,
+						},
+					];
+				}),
+			};
+		},
+});
+
+describe('transaction analyzer partial security results', () => {
+	it('returns independent static findings when unrelated enrichment fails', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.moveCall({
+			target: `${BLOCKED_PACKAGE}::blocked::entry`,
+		});
+
+		const results = await analyze(
+			{ blockedMoveCallChecks, commands },
+			{
+				client,
+				transaction: await tx.toJSON(),
+			},
+		);
+
+		expect(results.status).toBe('partial');
+		expect(results.blockedMoveCallChecks.status).toBe('success');
+		expect(results.blockedMoveCallChecks.result).toEqual([
+			{
+				code: 'BLOCKED_PACKAGE',
+				target: `${BLOCKED_PACKAGE}::blocked::entry`,
+			},
+		]);
+		expect(results.commands.status).toBe('skipped');
+		expect(results.commands.issues?.some((issue) => issue.message.includes(BLOCKED_PACKAGE))).toBe(
+			true,
+		);
+	});
+});


### PR DESCRIPTION
## Description

Adds explicit health/status to wallet-sdk transaction analyzer results and introduces `optional(analyzer)` for dependency edges that should not cause the parent analyzer to short-circuit when the optional analyzer fails.

This keeps strict dependencies as the default while allowing aggregate/security-style analyzers to inspect optional dependency results and preserve independent findings. Sponsor validation now uses optional validator dependencies so policy rejections from validators that ran are preserved even when another validator reports an analysis failure. Sponsor rejections now also expose `policyIssues` and `analysisIssues` alongside the existing combined `issues` array.

Docs and changesets are included.

Downstream note: dev-wallet in `ts-sdks-incubation` should gate its analyzer bridge on `commands.status === 'success'` when it upgrades to this wallet-sdk result shape; `coinFlows` can remain preview-only enrichment.

## Test plan

- `pnpm --filter @mysten/wallet-sdk test`
- `pnpm --filter @mysten-incubation/sponsor test`
- `pnpm --filter @mysten/wallet-sdk lint`
- `pnpm --filter @mysten-incubation/sponsor lint`
- `pnpm --filter @mysten/docs validate-docs`
- `pnpm --filter @mysten/wallet-sdk build`
- `pnpm --filter @mysten-incubation/sponsor build`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
