### PR TITLE
fix: Forwards cursor & limit options

### DIFF
--- a/.changeset/list-balances-list-coins-pagination.md
+++ b/.changeset/list-balances-list-coins-pagination.md
@@ -1,0 +1,11 @@
+---
+'@mysten/sui': patch
+---
+
+Fix pagination options being dropped on the unified core client.
+
+`GraphQLCoreClient.listBalances` now forwards the `limit` and `cursor` options to the
+underlying query (previously both were ignored, so it always returned the full, unpaginated
+list). `GrpcCoreClient.listCoins` now forwards `limit` as the request `pageSize` (previously
+only `cursor` was passed, so `limit` had no effect). This brings both methods in line with the
+other transports and list methods.

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -317,7 +317,11 @@ export class GraphQLCoreClient extends CoreClient {
 		const balances = await this.#graphqlQuery(
 			{
 				query: GetAllBalancesDocument,
-				variables: { owner: options.owner },
+				variables: {
+					owner: options.owner,
+					limit: options.limit,
+					cursor: options.cursor,
+				},
 			},
 			(result) => result.address?.balances,
 		);

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -211,6 +211,7 @@ export class GrpcCoreClient extends CoreClient {
 			owner: options.owner,
 			objectType: `0x2::coin::Coin<${(await this.mvr.resolveType({ type: coinType })).type}>`,
 			pageToken: options.cursor ? fromBase64(options.cursor) : undefined,
+			pageSize: options.limit,
 			readMask: {
 				paths,
 			},

--- a/packages/sui/test/e2e/clients/core/coins.test.ts
+++ b/packages/sui/test/e2e/clients/core/coins.test.ts
@@ -187,34 +187,41 @@ describe('Core API - Coins', () => {
 			expect(BigInt(firstBalance.balance)).toBeGreaterThan(0n);
 		});
 
-		testWithAllClients('should paginate all balances', async (client) => {
-			// Get first page with limit
-			const firstPage = await client.core.listBalances({
-				owner: testAddress,
-				limit: 1,
-			});
+		// Skipped for JSON-RPC: its `suix_getAllBalances` endpoint takes no pagination
+		// parameters, so listBalances always returns every balance and cannot honor `limit`
+		// or `cursor`. gRPC and GraphQL both paginate natively.
+		testWithAllClients(
+			'should paginate all balances',
+			async (client) => {
+				// Get first page with limit
+				const firstPage = await client.core.listBalances({
+					owner: testAddress,
+					limit: 1,
+				});
 
-			expect(firstPage.balances.length).toBe(1);
-			expect(firstPage.hasNextPage).toBe(true);
-			expect(firstPage.cursor).toBeTruthy();
+				expect(firstPage.balances.length).toBe(1);
+				expect(firstPage.hasNextPage).toBe(true);
+				expect(firstPage.cursor).toBeTruthy();
 
-			// Get second page using the cursor
-			const secondPage = await client.core.listBalances({
-				owner: testAddress,
-				limit: 1,
-				cursor: firstPage.cursor,
-			});
+				// Get second page using the cursor
+				const secondPage = await client.core.listBalances({
+					owner: testAddress,
+					limit: 1,
+					cursor: firstPage.cursor,
+				});
 
-			expect(secondPage.balances.length).toBe(1);
+				expect(secondPage.balances.length).toBe(1);
 
-			// Verify different coin types on second page
-			const firstPageTypes = new Set(firstPage.balances.map((b) => b.coinType));
-			const secondPageTypes = secondPage.balances.map((b) => b.coinType);
+				// Verify different coin types on second page
+				const firstPageTypes = new Set(firstPage.balances.map((b) => b.coinType));
+				const secondPageTypes = secondPage.balances.map((b) => b.coinType);
 
-			for (const coinType of secondPageTypes) {
-				expect(firstPageTypes.has(coinType)).toBe(false);
-			}
-		});
+				for (const coinType of secondPageTypes) {
+					expect(firstPageTypes.has(coinType)).toBe(false);
+				}
+			},
+			{ skip: ['jsonrpc'] },
+		);
 
 		testWithAllClients('should return empty for address with no balances', async (client) => {
 			// Use a new keypair address that has no coins

--- a/packages/sui/test/e2e/clients/core/coins.test.ts
+++ b/packages/sui/test/e2e/clients/core/coins.test.ts
@@ -72,35 +72,6 @@ describe('Core API - Coins', () => {
 			}
 		});
 
-		testWithAllClients('should paginate coins', async (client) => {
-			// Get first page with limit
-			const firstPage = await client.core.listCoins({
-				owner: testAddress,
-				coinType: SUI_TYPE_ARG,
-				limit: 2,
-			});
-
-			expect(firstPage.objects.length).toBeLessThanOrEqual(2);
-
-			if (firstPage.hasNextPage && firstPage.cursor) {
-				// Get second page
-				const secondPage = await client.core.listCoins({
-					owner: testAddress,
-					coinType: SUI_TYPE_ARG,
-					limit: 2,
-					cursor: firstPage.cursor,
-				});
-
-				// Verify different coins on second page
-				const firstPageIds = new Set(firstPage.objects.map((coin) => coin.objectId));
-				const secondPageIds = secondPage.objects.map((coin) => coin.objectId);
-
-				for (const id of secondPageIds) {
-					expect(firstPageIds.has(id)).toBe(false);
-				}
-			}
-		});
-
 		testWithAllClients('should return empty for address with no coins', async (client) => {
 			// Use a new keypair address that has no coins
 			const emptyAddress = new Ed25519Keypair().toSuiAddress();
@@ -111,6 +82,46 @@ describe('Core API - Coins', () => {
 
 			expect(result.objects).toEqual([]);
 			expect(result.hasNextPage).toBe(false);
+		});
+	});
+
+	describe('listCoins pagination limit', () => {
+		let multiCoinAddress: string;
+
+		beforeAll(async () => {
+			const { address } = await toolbox.getSigner({
+				coins: [1_000_000n, 1_000_000n, 1_000_000n],
+			});
+			multiCoinAddress = address;
+		});
+
+		testWithAllClients('should respect the limit and paginate', async (client) => {
+			const firstPage = await client.core.listCoins({
+				owner: multiCoinAddress,
+				coinType: SUI_TYPE_ARG,
+				limit: 2,
+			});
+
+			// The address has exactly 3 SUI coins, so a limit of 2 must return exactly 2
+			// with a next page available.
+			expect(firstPage.objects.length).toBe(2);
+			expect(firstPage.hasNextPage).toBe(true);
+			expect(firstPage.cursor).toBeTruthy();
+
+			const secondPage = await client.core.listCoins({
+				owner: multiCoinAddress,
+				coinType: SUI_TYPE_ARG,
+				limit: 2,
+				cursor: firstPage.cursor,
+			});
+
+			// Remaining coin on the second page, and it must not overlap with the first.
+			expect(secondPage.objects.length).toBe(1);
+
+			const firstPageIds = new Set(firstPage.objects.map((coin) => coin.objectId));
+			for (const coin of secondPage.objects) {
+				expect(firstPageIds.has(coin.objectId)).toBe(false);
+			}
 		});
 	});
 
@@ -183,23 +194,25 @@ describe('Core API - Coins', () => {
 				limit: 1,
 			});
 
-			expect(firstPage.balances.length).toBeGreaterThan(0);
+			expect(firstPage.balances.length).toBe(1);
+			expect(firstPage.hasNextPage).toBe(true);
+			expect(firstPage.cursor).toBeTruthy();
 
-			if (firstPage.hasNextPage && firstPage.cursor) {
-				// Get second page
-				const secondPage = await client.core.listBalances({
-					owner: testAddress,
-					limit: 1,
-					cursor: firstPage.cursor,
-				});
+			// Get second page using the cursor
+			const secondPage = await client.core.listBalances({
+				owner: testAddress,
+				limit: 1,
+				cursor: firstPage.cursor,
+			});
 
-				// Verify different coin types on second page
-				const firstPageTypes = new Set(firstPage.balances.map((b) => b.coinType));
-				const secondPageTypes = secondPage.balances.map((b) => b.coinType);
+			expect(secondPage.balances.length).toBe(1);
 
-				for (const coinType of secondPageTypes) {
-					expect(firstPageTypes.has(coinType)).toBe(false);
-				}
+			// Verify different coin types on second page
+			const firstPageTypes = new Set(firstPage.balances.map((b) => b.coinType));
+			const secondPageTypes = secondPage.balances.map((b) => b.coinType);
+
+			for (const coinType of secondPageTypes) {
+				expect(firstPageTypes.has(coinType)).toBe(false);
 			}
 		});
 


### PR DESCRIPTION
## Description

Ensure pagination options are forwarded in GraphQL and gRPC clients. Adds tests to ensure limit and pagination work as expected for listCoins and listBalances

## Test plan

- `listCoins` pagination limit **(new)**: 
Funds an address with exactly 3 SUI coins, then asserts across all three transports that limit: 2 returns exactly 2 objects with hasNextPage: true, and that the cursor fetches the remaining 1 non-overlapping coin. This is the regression guard for the gRPC listCoins dropped-limit bug.

- should paginate all balances **(strengthened)**: 
Now unconditionally asserts limit: 1 returns exactly 1 balance with hasNextPage: true and that the cursor advances to a different coinType, instead of guarding those checks behind if (hasNextPage). This catches the GraphQL listBalances bug that previously slipped through the vacuous guard.

- should paginate coins **(removed)**: 
Deleted because the new deterministic test strictly supersedes it — its toBeLessThanOrEqual(2) assertion behind an if (hasNextPage) guard is exactly what let the gRPC bug pass unnoticed.---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [ ] This PR was primarily written by AI.
- [x] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
