### PR TITLE
Use balance flows for wallet SDK auto approvals

### DIFF
--- a/.changeset/soft-cameras-happen.md
+++ b/.changeset/soft-cameras-happen.md
@@ -1,0 +1,5 @@
+---
+'@mysten/wallet-sdk': minor
+---
+
+Update auto-approval analysis to accept explicit operation types and use effective sender balance flows for budget checks. Auto-approval policy and settings coin types are now normalized before matching analyzer balance flows.

--- a/packages/wallet-sdk/src/auto-approvals/analyzer.ts
+++ b/packages/wallet-sdk/src/auto-approvals/analyzer.ts
@@ -1,23 +1,43 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { normalizeSuiAddress } from '@mysten/sui/utils';
 import type { Analyzer, AnalyzerResult } from '../transaction-analyzer/analyzer.js';
 import { createAnalyzer } from '../transaction-analyzer/index.js';
 import { analyzers } from '../transaction-analyzer/index.js';
+import type { CoinFlow } from '../transaction-analyzer/rules/balance-flows.js';
+import type {
+	CoinValueAnalysis,
+	CoinValueAnalyzerOptions,
+} from '../transaction-analyzer/rules/coin-value.js';
+import { getCoinValues as getCoinValuesForFlows } from '../transaction-analyzer/rules/coin-value.js';
 import { extractOperationType, OPERATION_INTENT } from './intent.js';
+
+export interface AutoApprovalAnalyzerOptions {
+	senderAddresses?: string[];
+}
+
+interface AutoApprovalAnalyzeOptions {
+	operationType?: string;
+	getCoinPrices?: CoinValueAnalyzerOptions['getCoinPrices'];
+	autoApproval?: AutoApprovalAnalyzerOptions;
+}
 
 const operationType = createAnalyzer({
 	dependencies: {
 		bytes: analyzers.bytes,
 	},
-	analyze: (_options, tx) => {
-		let operationType: string | null = null;
-		tx.addIntentResolver(
-			OPERATION_INTENT,
-			extractOperationType((type) => {
-				operationType = type;
-			}),
-		);
+	analyze: (options: Pick<AutoApprovalAnalyzeOptions, 'operationType'>, tx) => {
+		let operationType = options.operationType ?? null;
+
+		if (!operationType) {
+			tx.addIntentResolver(
+				OPERATION_INTENT,
+				extractOperationType((type) => {
+					operationType = type;
+				}),
+			);
+		}
 
 		return async () => {
 			return {
@@ -31,20 +51,35 @@ export const autoApprovalAnalyzer = createAnalyzer({
 	dependencies: {
 		operationType,
 		bytes: analyzers.bytes,
-		coinFlows: analyzers.coinFlows,
-		coinValues: analyzers.coinValues,
+		data: analyzers.data,
+		balanceFlows: analyzers.balanceFlows,
 		accessLevel: analyzers.accessLevel,
 		ownedObjects: analyzers.ownedObjects,
 		digest: analyzers.digest,
 	},
 	analyze:
-		() =>
-		async ({ bytes, coinFlows, accessLevel, ownedObjects, digest, operationType, coinValues }) => {
+		(options: AutoApprovalAnalyzeOptions) =>
+		async ({ bytes, data, balanceFlows, accessLevel, ownedObjects, digest, operationType }) => {
+			const senderAddresses = uniqueNormalizedAddresses([
+				...(data.sender ? [data.sender] : []),
+				...(options.autoApproval?.senderAddresses ?? []),
+			]);
+			const senderBalanceFlows = aggregateBalanceFlowsForAddresses(
+				balanceFlows.byAddress,
+				senderAddresses,
+			);
+
+			const coinValues = options.getCoinPrices
+				? await getCoinValuesForFlows(senderBalanceFlows, options.getCoinPrices)
+				: getCoinValuesUnavailable(senderBalanceFlows);
+
 			return {
 				result: {
 					operationType,
+					senderAddresses,
 					bytes,
-					coinFlows,
+					balanceFlows,
+					senderBalanceFlows,
 					accessLevel,
 					ownedObjects,
 					digest,
@@ -57,3 +92,45 @@ export const autoApprovalAnalyzer = createAnalyzer({
 export type AutoApprovalAnalysis =
 	typeof autoApprovalAnalyzer extends Analyzer<infer R, any, any> ? R : never;
 export type AutoApprovalResult = AnalyzerResult<AutoApprovalAnalysis>;
+
+function uniqueNormalizedAddresses(addresses: string[]): string[] {
+	return [...new Set(addresses.map((address) => normalizeSuiAddress(address)))];
+}
+
+function aggregateBalanceFlowsForAddresses(
+	byAddress: Record<string, CoinFlow[]>,
+	addresses: string[],
+): CoinFlow[] {
+	const senderAddresses = new Set(addresses);
+	const flowsByCoinType = new Map<string, bigint>();
+
+	for (const [address, flows] of Object.entries(byAddress)) {
+		if (!senderAddresses.has(normalizeSuiAddress(address))) {
+			continue;
+		}
+
+		for (const flow of flows) {
+			flowsByCoinType.set(flow.coinType, (flowsByCoinType.get(flow.coinType) ?? 0n) + flow.amount);
+		}
+	}
+
+	return Array.from(flowsByCoinType, ([coinType, amount]) => ({ coinType, amount })).filter(
+		(flow) => flow.amount !== 0n,
+	);
+}
+
+function getCoinValuesUnavailable(balanceFlows: CoinFlow[]): CoinValueAnalysis {
+	const outflows = balanceFlows
+		.filter((flow) => flow.amount < 0n)
+		.map((flow) => ({ coinType: flow.coinType, amount: -flow.amount }));
+
+	if (outflows.length === 0) {
+		return { total: 0, coinTypesWithoutPrice: [], coinTypes: [] };
+	}
+
+	return {
+		total: 0,
+		coinTypesWithoutPrice: [...new Set(outflows.map((flow) => flow.coinType))],
+		coinTypes: [],
+	};
+}

--- a/packages/wallet-sdk/src/auto-approvals/index.ts
+++ b/packages/wallet-sdk/src/auto-approvals/index.ts
@@ -3,7 +3,11 @@
 
 export { operationType, extractOperationType, OPERATION_INTENT } from './intent.js';
 export { autoApprovalAnalyzer } from './analyzer.js';
-export type { AutoApprovalResult, AutoApprovalAnalysis } from './analyzer.js';
+export type {
+	AutoApprovalAnalyzerOptions,
+	AutoApprovalResult,
+	AutoApprovalAnalysis,
+} from './analyzer.js';
 
 export { AutoApprovalManager } from './manager.js';
 export type { AutoApprovalIssue, AutoApprovalCheck } from './manager.js';

--- a/packages/wallet-sdk/src/auto-approvals/manager.ts
+++ b/packages/wallet-sdk/src/auto-approvals/manager.ts
@@ -7,8 +7,9 @@ import type { AutoApprovalState } from './schemas/state.js';
 import { AutoApprovalStateSchema } from './schemas/state.js';
 import type { AutoApprovalSettings } from './schemas/policy.js';
 import { AutoApprovalPolicySchema, AutoApprovalSettingsSchema } from './schemas/policy.js';
-import { parseStructTag } from '@mysten/sui/utils';
+import { normalizeSuiAddress, parseStructTag } from '@mysten/sui/utils';
 import type { AutoApprovalResult } from './analyzer.js';
+import type { CoinFlow } from '../transaction-analyzer/rules/balance-flows.js';
 
 type SuccessfulAutoApprovalResult = Extract<AutoApprovalResult, { status: 'success' }>;
 
@@ -121,10 +122,10 @@ export class AutoApprovalManager {
 		}
 
 		if (!operation.permissions.anyBalance) {
-			for (const flow of analysis.result.coinFlows.outflows) {
-				if (!operation.permissions.balances?.find((b) => b.coinType === flow.coinType)) {
+			for (const outflow of getSenderOutflows(analysis)) {
+				if (!operation.permissions.balances?.find((b) => b.coinType === outflow.coinType)) {
 					issues.push({
-						message: `Operation does not have permission to use coin type ${flow.coinType}`,
+						message: `Operation does not have permission to use coin type ${outflow.coinType}`,
 					});
 				}
 			}
@@ -201,11 +202,7 @@ export class AutoApprovalManager {
 			issues.push({ message: 'Operation type not approved for auto-approval' });
 		}
 
-		for (const outflow of analysis.result.coinFlows.outflows) {
-			if (outflow.amount <= 0n) {
-				continue;
-			}
-
+		for (const outflow of getSenderOutflows(analysis)) {
 			if (this.#state.settings.coinBudgets[outflow.coinType] !== undefined) {
 				const coinBudget = this.#state.settings.coinBudgets[outflow.coinType];
 
@@ -251,7 +248,7 @@ export class AutoApprovalManager {
 			);
 		}
 
-		for (const outflow of analysis.result.coinFlows.outflows) {
+		for (const outflow of getSenderOutflows(analysis)) {
 			if (this.#state.settings.coinBudgets[outflow.coinType] !== undefined) {
 				const currentBudget = BigInt(this.#state.settings?.coinBudgets[outflow.coinType] ?? '0');
 				const newBalance = currentBudget - outflow.amount;
@@ -287,17 +284,17 @@ export class AutoApprovalManager {
 			this.#state.settings.remainingTransactions += 1;
 		}
 
-		this.#revertCoinFlows(analysis);
+		this.#revertBalanceFlows(analysis);
 	}
 
-	#revertCoinFlows(analysis: AutoApprovalResult): void {
+	#revertBalanceFlows(analysis: AutoApprovalResult): void {
 		assertSuccessfulAnalysis(analysis);
 
 		if (!this.#state.settings) {
 			throw new Error('No auto-approval settings configured');
 		}
 
-		for (const outflow of analysis.result.coinFlows.outflows) {
+		for (const outflow of getSenderOutflows(analysis)) {
 			if (this.#state.settings?.coinBudgets[outflow.coinType] !== undefined) {
 				const currentBudget = BigInt(this.#state.settings?.coinBudgets[outflow.coinType] ?? '0');
 				const newBalance = currentBudget + outflow.amount;
@@ -341,10 +338,19 @@ export class AutoApprovalManager {
 			throw new Error('No auto-approval settings configured');
 		}
 
-		// Revert coin flows and use real balance changes instead
-		this.#revertCoinFlows(analysis);
+		// Revert provisional balance flows and use real sender balance changes instead.
+		this.#revertBalanceFlows(analysis);
+
+		const outflowCoinTypes = new Set(getSenderOutflows(analysis).map((flow) => flow.coinType));
 
 		for (const change of result.balanceChanges) {
+			if (
+				!analysis.result.senderAddresses.includes(normalizeSuiAddress(change.address)) ||
+				!outflowCoinTypes.has(change.coinType)
+			) {
+				continue;
+			}
+
 			if (this.#state.settings.coinBudgets[change.coinType] !== undefined) {
 				const currentBudget = BigInt(this.#state.settings?.coinBudgets[change.coinType] ?? '0');
 				const newBalance = currentBudget + BigInt(change.amount);
@@ -397,6 +403,15 @@ export class AutoApprovalManager {
 		const validatedSettings = parse(AutoApprovalSettingsSchema, settings);
 		this.#state.settings = validatedSettings;
 	}
+}
+
+function getSenderOutflows(analysis: SuccessfulAutoApprovalResult): CoinFlow[] {
+	return analysis.result.senderBalanceFlows
+		.filter((flow) => flow.amount < 0n)
+		.map((flow) => ({
+			coinType: flow.coinType,
+			amount: -flow.amount,
+		}));
 }
 
 const parsedCoinType = parseStructTag('0x2::coin::Coin');

--- a/packages/wallet-sdk/src/auto-approvals/schemas/policy.ts
+++ b/packages/wallet-sdk/src/auto-approvals/schemas/policy.ts
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as v from 'valibot';
+import { normalizeStructTag } from '@mysten/sui/utils';
 
 const AccessLevelSchema = v.union([v.literal('read'), v.literal('mutate'), v.literal('transfer')]);
 
 const BasePermissionSchema = v.object({
 	description: v.string(),
 });
+
+const CoinTypeSchema = v.pipe(
+	v.string(),
+	v.transform((coinType) => normalizeStructTag(coinType)),
+);
 
 const ObjectTypePermissionSchema = v.object({
 	...BasePermissionSchema.entries,
@@ -19,7 +25,7 @@ const ObjectTypePermissionSchema = v.object({
 const CoinBalancePermissionSchema = v.object({
 	...BasePermissionSchema.entries,
 	$kind: v.literal('CoinBalance'),
-	coinType: v.string(),
+	coinType: CoinTypeSchema,
 });
 
 const AnyBalancesPermissionSchema = v.object({
@@ -50,8 +56,7 @@ export const AutoApprovalSettingsSchema = v.looseObject({
 	// TODO: figure out a better name
 	remainingTransactions: v.nullable(v.number()),
 	sharedBudget: v.nullable(v.number()),
-	// TODO: normalize coin types
-	coinBudgets: v.record(v.string(), v.string()),
+	coinBudgets: v.record(CoinTypeSchema, v.string()),
 });
 
 export const AutoApprovalPolicySchema = v.object({

--- a/packages/wallet-sdk/src/transaction-analyzer/rules/coin-value.ts
+++ b/packages/wallet-sdk/src/transaction-analyzer/rules/coin-value.ts
@@ -3,6 +3,7 @@
 
 import { createAnalyzer } from '../analyzer.js';
 import { balanceFlows } from './balance-flows.js';
+import type { CoinFlow } from './balance-flows.js';
 
 export interface CoinValueAnalyzerOptions {
 	getCoinPrices: (coinTypes: string[]) => Promise<
@@ -31,33 +32,39 @@ export const coinValues = createAnalyzer({
 	analyze:
 		({ getCoinPrices }: CoinValueAnalyzerOptions) =>
 		async ({ balanceFlows }) => {
-			const outflows = balanceFlows.sender
-				.filter((f) => f.amount < 0n)
-				.map((f) => ({ coinType: f.coinType, amount: -f.amount }));
-
-			const prices = await getCoinPrices(outflows.map((cf) => cf.coinType));
-
-			let total = 0;
-			const coinTypesWithoutPrice: string[] = [];
-			const coinTypes: CoinValueAnalysis['coinTypes'] = [];
-
-			for (const flow of outflows) {
-				const price = prices.find((p) => p.coinType === flow.coinType);
-				if (price?.price != null) {
-					const convertedAmount = (Number(flow.amount) / 10 ** price.decimals) * price.price;
-					total += convertedAmount;
-					coinTypes.push({
-						coinType: flow.coinType,
-						decimals: price.decimals,
-						price: price.price,
-						amount: flow.amount,
-						convertedAmount,
-					});
-				} else {
-					coinTypesWithoutPrice.push(flow.coinType);
-				}
-			}
-
-			return { result: { total, coinTypesWithoutPrice, coinTypes } };
+			return { result: await getCoinValues(balanceFlows.sender, getCoinPrices) };
 		},
 });
+
+export async function getCoinValues(
+	balanceFlows: CoinFlow[],
+	getCoinPrices: CoinValueAnalyzerOptions['getCoinPrices'],
+): Promise<CoinValueAnalysis> {
+	const outflows = balanceFlows
+		.filter((flow) => flow.amount < 0n)
+		.map((flow) => ({ coinType: flow.coinType, amount: -flow.amount }));
+	const prices = await getCoinPrices(outflows.map((flow) => flow.coinType));
+
+	let total = 0;
+	const coinTypesWithoutPrice: string[] = [];
+	const coinTypes: CoinValueAnalysis['coinTypes'] = [];
+
+	for (const flow of outflows) {
+		const price = prices.find((price) => price.coinType === flow.coinType);
+		if (price?.price != null) {
+			const convertedAmount = (Number(flow.amount) / 10 ** price.decimals) * price.price;
+			total += convertedAmount;
+			coinTypes.push({
+				coinType: flow.coinType,
+				decimals: price.decimals,
+				price: price.price,
+				amount: flow.amount,
+				convertedAmount,
+			});
+		} else {
+			coinTypesWithoutPrice.push(flow.coinType);
+		}
+	}
+
+	return { total, coinTypesWithoutPrice, coinTypes };
+}

--- a/packages/wallet-sdk/test/auto-approvals/manager.test.ts
+++ b/packages/wallet-sdk/test/auto-approvals/manager.test.ts
@@ -6,6 +6,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import {
 	analyze,
+	analyzers,
 	autoApprovalAnalyzer,
 	AutoApprovalManager,
 	AutoApprovalPolicy,
@@ -14,7 +15,12 @@ import {
 	type AutoApprovalResult,
 } from '../../src/index.js';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { MIST_PER_SUI } from '@mysten/sui/utils';
+import { MIST_PER_SUI, normalizeSuiAddress } from '@mysten/sui/utils';
+import { MockSuiClient } from '../mocks/MockSuiClient.js';
+import { DEFAULT_SENDER } from '../mocks/mockData.js';
+
+const RAW_SUI = '0x2::sui::SUI';
+const SUI = normalizeSuiAddress('0x2') + '::sui::SUI';
 
 const policy: AutoApprovalPolicy = {
 	schemaVersion: '1.0.0',
@@ -23,6 +29,26 @@ const policy: AutoApprovalPolicy = {
 			id: 'test-operation',
 			description: 'Test operation',
 			permissions: {},
+		},
+	],
+	suggestedSettings: {},
+};
+
+const balancePolicy: AutoApprovalPolicy = {
+	schemaVersion: '1.0.0',
+	operations: [
+		{
+			id: 'test-operation',
+			description: 'Test operation',
+			permissions: {
+				balances: [
+					{
+						$kind: 'CoinBalance',
+						description: 'SUI',
+						coinType: SUI,
+					},
+				],
+			},
 		},
 	],
 	suggestedSettings: {},
@@ -43,19 +69,173 @@ function managerWithSettings() {
 	return manager;
 }
 
-function autoApprovalAnalysis(): AutoApprovalAnalysis {
+function managerWithBalanceSettings() {
+	const manager = new AutoApprovalManager({
+		policy: JSON.stringify(balancePolicy),
+		state: null,
+	});
+	manager.updateSettings({
+		approvedOperations: ['test-operation'],
+		expiration: Date.now() + 1000 * 60 * 60,
+		remainingTransactions: 1,
+		sharedBudget: null,
+		coinBudgets: {
+			[SUI]: '10',
+		},
+	});
+	return manager;
+}
+
+function autoApprovalAnalysis(overrides: Partial<AutoApprovalAnalysis> = {}): AutoApprovalAnalysis {
+	const balanceFlows = overrides.balanceFlows ?? {
+		byAddress: {},
+		sender: [],
+		sponsor: null,
+	};
+	const senderAddresses = overrides.senderAddresses ?? [normalizeSuiAddress('0x1')];
+	const senderBalanceFlows =
+		overrides.senderBalanceFlows ??
+		senderAddresses.flatMap((address) => balanceFlows.byAddress[address] ?? []);
+
 	return {
 		operationType: 'test-operation',
+		senderAddresses,
 		bytes: new Uint8Array([1, 2, 3]),
-		coinFlows: { outflows: [] },
+		balanceFlows,
+		senderBalanceFlows,
 		coinValues: { total: 0, coinTypesWithoutPrice: [], coinTypes: [] },
 		accessLevel: {},
 		ownedObjects: [],
 		digest: 'test-digest',
+		...overrides,
 	};
 }
 
 describe('AutoApprovalManager', () => {
+	test('analyzes bytes once with explicit operation type and shared balance flows', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.setGasBudget(10_000_000n);
+		tx.setGasPrice(1_000n);
+		const bytes = await tx.build({ client });
+
+		const results = await analyze(
+			{
+				balanceFlows: analyzers.balanceFlows,
+				autoApproval: autoApprovalAnalyzer,
+			},
+			{
+				transaction: bytes,
+				client,
+				operationType: 'increment-counter',
+			},
+		);
+
+		expect(results.autoApproval.status).toBe('success');
+		expect(results.autoApproval.result?.operationType).toBe('increment-counter');
+		expect(results.autoApproval.result?.balanceFlows).toBe(results.balanceFlows.result);
+		expect(results.autoApproval.result?.senderBalanceFlows).toEqual([
+			{ coinType: SUI, amount: -10_000_000n },
+		]);
+	});
+
+	test('adds configured sender addresses to the transaction sender', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.setGasBudget(10_000_000n);
+		tx.setGasPrice(1_000n);
+		const bytes = await tx.build({ client });
+
+		const extraSender = normalizeSuiAddress('0x456');
+		const results = await analyze(
+			{
+				autoApproval: autoApprovalAnalyzer,
+			},
+			{
+				transaction: bytes,
+				client,
+				operationType: 'increment-counter',
+				autoApproval: { senderAddresses: [extraSender] },
+				getCoinPrices: async () => [],
+			},
+		);
+
+		expect(results.autoApproval.result?.senderAddresses).toEqual([DEFAULT_SENDER, extraSender]);
+	});
+
+	test('matches unnormalized policy and budget coin types against analyzer balance flows', async () => {
+		const client = new MockSuiClient();
+		const tx = new Transaction();
+		tx.setSender(DEFAULT_SENDER);
+		tx.setGasBudget(10_000_000n);
+		tx.setGasPrice(1_000n);
+		const bytes = await tx.build({ client });
+
+		const results = await analyze(
+			{
+				autoApproval: autoApprovalAnalyzer,
+			},
+			{
+				transaction: bytes,
+				client,
+				operationType: 'test-operation',
+			},
+		);
+
+		expect(results.autoApproval.status).toBe('success');
+		expect(results.autoApproval.result?.senderBalanceFlows).toEqual([
+			{ coinType: SUI, amount: -10_000_000n },
+		]);
+
+		const manager = new AutoApprovalManager({
+			policy: JSON.stringify({
+				schemaVersion: '1.0.0',
+				operations: [
+					{
+						id: 'test-operation',
+						description: 'Test operation',
+						permissions: {
+							balances: [
+								{
+									$kind: 'CoinBalance',
+									description: 'SUI',
+									coinType: RAW_SUI,
+								},
+							],
+						},
+					},
+				],
+				suggestedSettings: {},
+			} satisfies AutoApprovalPolicy),
+			state: null,
+		});
+
+		manager.updateSettings({
+			approvedOperations: ['test-operation'],
+			expiration: Date.now() + 1000 * 60 * 60,
+			remainingTransactions: 1,
+			sharedBudget: null,
+			coinBudgets: {
+				[RAW_SUI]: '10000000',
+			},
+		});
+
+		expect(manager.getSettings()?.coinBudgets).toEqual({ [SUI]: '10000000' });
+		expect(manager.checkTransaction(results.autoApproval)).toEqual({
+			matchesPolicy: true,
+			canAutoApprove: true,
+			analysisIssues: [],
+			policyIssues: [],
+			settingsIssues: [],
+		});
+
+		manager.commitTransaction(results.autoApproval);
+
+		expect(manager.getSettings()?.coinBudgets).toEqual({ [SUI]: '0' });
+	});
+
 	test('checkTransaction reports partial analysis as analysis issues', () => {
 		const manager = managerWithSettings();
 		const analysis: AutoApprovalResult = {
@@ -85,6 +265,166 @@ describe('AutoApprovalManager', () => {
 
 		expect(() => manager.commitTransaction(analysis)).toThrow('Transaction analysis failed');
 		expect(manager.getSettings()?.remainingTransactions).toBe(1);
+		expect(manager.getState().pendingDigests).toEqual([]);
+	});
+
+	test('uses signed sender balance outflows for policy and budget checks', () => {
+		const manager = managerWithBalanceSettings();
+		const sender = normalizeSuiAddress('0x1');
+		const analysis: AutoApprovalResult = {
+			status: 'success',
+			result: autoApprovalAnalysis({
+				senderAddresses: [sender],
+				senderBalanceFlows: [{ coinType: SUI, amount: -4n }],
+				balanceFlows: {
+					byAddress: { [sender]: [{ coinType: SUI, amount: -4n }] },
+					sender: [{ coinType: SUI, amount: -4n }],
+					sponsor: null,
+				},
+			}),
+		};
+
+		expect(manager.checkTransaction(analysis)).toEqual({
+			matchesPolicy: true,
+			canAutoApprove: true,
+			analysisIssues: [],
+			policyIssues: [],
+			settingsIssues: [],
+		});
+
+		manager.commitTransaction(analysis);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('6');
+
+		manager.revertTransaction(analysis);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('10');
+		expect(manager.getState().pendingDigests).toEqual([]);
+	});
+
+	test('uses multiple sender addresses for policy and budget checks', () => {
+		const manager = managerWithBalanceSettings();
+		const sender = normalizeSuiAddress('0x1');
+		const extraSender = normalizeSuiAddress('0x2');
+		const analysis: AutoApprovalResult = {
+			status: 'success',
+			result: autoApprovalAnalysis({
+				senderAddresses: [sender, extraSender],
+				senderBalanceFlows: [{ coinType: SUI, amount: -6n }],
+				balanceFlows: {
+					byAddress: {
+						[sender]: [{ coinType: SUI, amount: -4n }],
+						[extraSender]: [{ coinType: SUI, amount: -2n }],
+					},
+					sender: [{ coinType: SUI, amount: -4n }],
+					sponsor: null,
+				},
+			}),
+		};
+
+		manager.commitTransaction(analysis);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('4');
+	});
+
+	test('gas-only SUI outflows are budgeted and reconciled from effects', () => {
+		const manager = managerWithBalanceSettings();
+		manager.updateSettings({
+			approvedOperations: ['test-operation'],
+			expiration: Date.now() + 1000 * 60 * 60,
+			remainingTransactions: 1,
+			sharedBudget: null,
+			coinBudgets: { [SUI]: '10000000' },
+		});
+		const sender = normalizeSuiAddress('0x1');
+		const analysis: AutoApprovalResult = {
+			status: 'success',
+			result: autoApprovalAnalysis({
+				senderAddresses: [sender],
+				senderBalanceFlows: [{ coinType: SUI, amount: -10_000_000n }],
+				coinValues: { total: 0, coinTypesWithoutPrice: [], coinTypes: [] },
+				balanceFlows: {
+					byAddress: {
+						[sender]: [{ coinType: SUI, amount: -10_000_000n }],
+					},
+					sender: [{ coinType: SUI, amount: -10_000_000n }],
+					sponsor: null,
+				},
+			}),
+		};
+
+		expect(manager.checkTransaction(analysis)).toEqual({
+			matchesPolicy: true,
+			canAutoApprove: true,
+			analysisIssues: [],
+			policyIssues: [],
+			settingsIssues: [],
+		});
+
+		manager.commitTransaction(analysis);
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('0');
+
+		manager.applyTransactionEffects(analysis, {
+			digest: 'test-digest',
+			balanceChanges: [{ address: sender, coinType: SUI, amount: '-5000000' }],
+		} as unknown as Parameters<AutoApprovalManager['applyTransactionEffects']>[1]);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('5000000');
+		expect(manager.getState().pendingDigests).toEqual([]);
+	});
+
+	test('does not spend budgets for positive sender balance flows', () => {
+		const manager = managerWithBalanceSettings();
+		const sender = normalizeSuiAddress('0x1');
+		const analysis: AutoApprovalResult = {
+			status: 'success',
+			result: autoApprovalAnalysis({
+				senderAddresses: [sender],
+				senderBalanceFlows: [{ coinType: SUI, amount: 4n }],
+				balanceFlows: {
+					byAddress: { [sender]: [{ coinType: SUI, amount: 4n }] },
+					sender: [{ coinType: SUI, amount: 4n }],
+					sponsor: null,
+				},
+			}),
+		};
+
+		manager.commitTransaction(analysis);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('10');
+	});
+
+	test('reconciles transaction effects with sender balance changes only', () => {
+		const manager = managerWithBalanceSettings();
+		const sender = normalizeSuiAddress('0x1');
+		const extraSender = normalizeSuiAddress('0x2');
+		const analysis: AutoApprovalResult = {
+			status: 'success',
+			result: autoApprovalAnalysis({
+				senderAddresses: [sender, extraSender],
+				senderBalanceFlows: [{ coinType: SUI, amount: -6n }],
+				balanceFlows: {
+					byAddress: {
+						[sender]: [{ coinType: SUI, amount: -4n }],
+						[extraSender]: [{ coinType: SUI, amount: -2n }],
+					},
+					sender: [{ coinType: SUI, amount: -4n }],
+					sponsor: null,
+				},
+			}),
+		};
+
+		manager.commitTransaction(analysis);
+		manager.applyTransactionEffects(analysis, {
+			digest: 'test-digest',
+			balanceChanges: [
+				{ address: sender, coinType: SUI, amount: '-4' },
+				{ address: extraSender, coinType: SUI, amount: '-3' },
+				{ address: '0x3', coinType: SUI, amount: '7' },
+			],
+		} as unknown as Parameters<AutoApprovalManager['applyTransactionEffects']>[1]);
+
+		expect(manager.getSettings()?.coinBudgets[SUI]).toBe('3');
 		expect(manager.getState().pendingDigests).toEqual([]);
 	});
 


### PR DESCRIPTION
## Description

- Update `autoApprovalAnalyzer` so backend callers can pass transaction bytes with an explicit `operationType`, while keeping intent extraction as a fallback.
- Produce auto-approval analysis from the shared `balanceFlows` analyzer, including effective `senderAddresses` and `senderBalanceFlows` for one or more sender-equivalent addresses.
- Update `AutoApprovalManager` to evaluate outgoing effective balance flows, including gas-only policies with empty budgets/prices.

## Test plan

- `pnpm --filter @mysten/wallet-sdk test`
- `pnpm --filter @mysten/wallet-sdk build`
- `pnpm --filter @mysten/wallet-sdk prettier:check`
- `pnpm --filter @mysten/wallet-sdk oxlint:check`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.