### PR TITLE
Deprecate JSON-RPC APIs

### DIFF
--- a/.changeset/deprecate-json-rpc-apis.md
+++ b/.changeset/deprecate-json-rpc-apis.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Deprecate JSON-RPC client APIs, transport APIs, and JSON-RPC-specific types. Migrate to `SuiGrpcClient` or `SuiGraphQLClient`.

--- a/packages/sui/scripts/generate.ts
+++ b/packages/sui/scripts/generate.ts
@@ -41,6 +41,9 @@ export const LICENSE_HEADER = `
  */
 `.trim();
 
+const JSON_RPC_DEPRECATION_NOTICE =
+	'@deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.';
+
 const options: {
 	types: Record<
 		string,
@@ -179,7 +182,7 @@ const options: {
 					typeAlias: 'string | string[]',
 				},
 				requestType: {
-					deprecated: 'requestType will be ignored by JSON RPC in the future',
+					deprecated: 'requestType is deprecated and should not be used',
 				},
 			},
 		},
@@ -265,7 +268,7 @@ fileGenerator.statements.push(
 				const typeOptions = options.types[name] ?? {};
 				if ('anyOf' in schema) {
 					return withDescription(
-						schema,
+						withJsonRpcDeprecation(schema),
 						ts.factory.createTypeAliasDeclaration(
 							[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 							normalizeName(name),
@@ -281,7 +284,7 @@ fileGenerator.statements.push(
 
 				if ('oneOf' in schema) {
 					return withDescription(
-						schema,
+						withJsonRpcDeprecation(schema),
 						ts.factory.createTypeAliasDeclaration(
 							[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 							normalizeName(name),
@@ -297,7 +300,7 @@ fileGenerator.statements.push(
 
 				if ('type' in schema && schema.type === 'string') {
 					return withDescription(
-						schema,
+						withJsonRpcDeprecation(schema),
 						ts.factory.createTypeAliasDeclaration(
 							[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 							normalizeName(name),
@@ -308,7 +311,7 @@ fileGenerator.statements.push(
 				}
 
 				return await withDescription(
-					schema,
+					withJsonRpcDeprecation(schema),
 					ts.factory.createInterfaceDeclaration(
 						[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 						normalizeName(name),
@@ -398,7 +401,7 @@ async function createMethodParams(method: OpenRpcMethod) {
 	]);
 	if (methodOptions.flattenParams && methodOptions.flattenParams?.length > 0) {
 		return withDescription(
-			method,
+			withJsonRpcDeprecation(method),
 			ts.factory.createTypeAliasDeclaration(
 				[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 				`${normalizeMethodName(method.name)}Params`,
@@ -416,7 +419,7 @@ async function createMethodParams(method: OpenRpcMethod) {
 	}
 
 	return withDescription(
-		method,
+		withJsonRpcDeprecation(method),
 		ts.factory.createInterfaceDeclaration(
 			[ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
 			`${normalizeMethodName(method.name)}Params`,
@@ -501,6 +504,13 @@ async function createObjectMembers(
 	);
 
 	return members;
+}
+
+function withJsonRpcDeprecation<T extends { description?: string }>(options: T): T {
+	return {
+		...options,
+		description: [options.description, JSON_RPC_DEPRECATION_NOTICE].filter(Boolean).join('\n\n'),
+	};
 }
 
 async function withDescription<T extends ts.Node>(

--- a/packages/sui/src/jsonRpc/client.ts
+++ b/packages/sui/src/jsonRpc/client.ts
@@ -97,6 +97,10 @@ import { isValidNamedPackage } from '../utils/move-registry.js';
 import { hasMvrName } from '../client/mvr.js';
 import { JSONRpcCoreClient } from './core.js';
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface PaginationArguments<Cursor> {
 	/** Optional paging cursor */
 	cursor?: Cursor;
@@ -104,6 +108,10 @@ export interface PaginationArguments<Cursor> {
 	limit?: number | null;
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface OrderArguments {
 	order?: Order | null;
 }
@@ -111,6 +119,8 @@ export interface OrderArguments {
 /**
  * Configuration options for the SuiJsonRpcClient
  * You must provide either a `url` or a `transport`
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export type SuiJsonRpcClientOptions = NetworkOrTransport & {
 	network: SuiClientTypes.Network;
@@ -129,14 +139,30 @@ type NetworkOrTransport =
 
 const SUI_CLIENT_BRAND = Symbol.for('@mysten/SuiJsonRpcClient') as never;
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export function isSuiJsonRpcClient(client: unknown): client is SuiJsonRpcClient {
 	return (
 		typeof client === 'object' && client !== null && (client as any)[SUI_CLIENT_BRAND] === true
 	);
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class SuiJsonRpcClient extends BaseClient {
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	core: JSONRpcCoreClient;
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	jsonRpc = this;
 	protected transport: JsonRpcTransport;
 
@@ -148,6 +174,8 @@ export class SuiJsonRpcClient extends BaseClient {
 	 * Establish a connection to a Sui RPC endpoint
 	 *
 	 * @param options configuration options for the API Client
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	constructor(options: SuiJsonRpcClientOptions) {
 		super({ network: options.network });
@@ -158,6 +186,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getRpcApiVersion({ signal }: { signal?: AbortSignal } = {}): Promise<string | undefined> {
 		const resp = await this.transport.request<{ info: { version: string } }>({
 			method: 'rpc.discover',
@@ -170,6 +202,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get all Coin<`coin_type`> objects owned by an address.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCoins({
 		coinType,
@@ -204,6 +238,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get all Coin objects owned by an address.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getAllCoins(input: GetAllCoinsParams): Promise<PaginatedCoins> {
 		if (!input.owner || !isValidSuiAddress(normalizeSuiAddress(input.owner))) {
@@ -224,6 +260,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get the total coin balance for one coin type, owned by the address owner.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getBalance({ owner, coinType, signal }: GetBalanceParams): Promise<CoinBalance> {
 		if (!owner || !isValidSuiAddress(normalizeSuiAddress(owner))) {
@@ -247,6 +285,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get the total coin balance for all coin types, owned by the address owner.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getAllBalances(input: GetAllBalancesParams): Promise<CoinBalance[]> {
 		if (!input.owner || !isValidSuiAddress(normalizeSuiAddress(input.owner))) {
@@ -261,6 +301,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Fetch CoinMetadata for a given coin type
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCoinMetadata({ coinType, signal }: GetCoinMetadataParams): Promise<CoinMetadata | null> {
 		if (coinType && hasMvrName(coinType)) {
@@ -280,6 +322,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 *  Fetch total supply for a coin
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getTotalSupply({ coinType, signal }: GetTotalSupplyParams): Promise<CoinSupply> {
 		if (coinType && hasMvrName(coinType)) {
@@ -301,6 +345,8 @@ export class SuiJsonRpcClient extends BaseClient {
 	 * Invoke any RPC method
 	 * @param method the method to be invoked
 	 * @param args the arguments to be passed to the RPC request
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async call<T = unknown>(
 		method: string,
@@ -312,6 +358,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get Move function argument types like read, write and full access
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getMoveFunctionArgTypes({
 		package: pkg,
@@ -337,6 +385,8 @@ export class SuiJsonRpcClient extends BaseClient {
 	/**
 	 * Get a map from module name to
 	 * structured representations of Move modules
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getNormalizedMoveModulesByPackage({
 		package: pkg,
@@ -359,6 +409,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get a structured representation of Move module
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getNormalizedMoveModule({
 		package: pkg,
@@ -382,6 +434,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get a structured representation of Move function
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getNormalizedMoveFunction({
 		package: pkg,
@@ -406,6 +460,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get a structured representation of Move struct
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getNormalizedMoveStruct({
 		package: pkg,
@@ -430,6 +486,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get all objects owned by an address
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getOwnedObjects(input: GetOwnedObjectsParams): Promise<PaginatedObjectsResponse> {
 		if (!input.owner || !isValidSuiAddress(normalizeSuiAddress(input.owner))) {
@@ -476,6 +534,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get details about an object
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getObject(input: GetObjectParams): Promise<SuiObjectResponse> {
 		if (!input.id || !isValidSuiObjectId(normalizeSuiObjectId(input.id))) {
@@ -488,6 +548,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async tryGetPastObject(input: TryGetPastObjectParams): Promise<ObjectRead> {
 		return await this.transport.request({
 			method: 'sui_tryGetPastObject',
@@ -498,6 +562,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Batch get details about a list of objects. If any of the object ids are duplicates the call will fail
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async multiGetObjects(input: MultiGetObjectsParams): Promise<SuiObjectResponse[]> {
 		input.ids.forEach((id) => {
@@ -519,6 +585,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get transaction blocks for a given query criteria
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async queryTransactionBlocks({
 		filter,
@@ -556,6 +624,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getTransactionBlock(
 		input: GetTransactionBlockParams,
 	): Promise<SuiTransactionBlockResponse> {
@@ -569,6 +641,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async multiGetTransactionBlocks(
 		input: MultiGetTransactionBlocksParams,
 	): Promise<SuiTransactionBlockResponse[]> {
@@ -590,6 +666,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async executeTransactionBlock({
 		transactionBlock,
 		signature,
@@ -609,6 +689,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		return result;
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async signAndExecuteTransaction({
 		transaction,
 		signer,
@@ -642,6 +726,10 @@ export class SuiJsonRpcClient extends BaseClient {
 	 * Get total number of transactions
 	 */
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getTotalTransactionBlocks({ signal }: { signal?: AbortSignal } = {}): Promise<bigint> {
 		const resp = await this.transport.request<string>({
 			method: 'sui_getTotalTransactionBlocks',
@@ -653,6 +741,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Getting the reference gas price for the network
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getReferenceGasPrice({ signal }: GetReferenceGasPriceParams = {}): Promise<bigint> {
 		const resp = await this.transport.request<string>({
@@ -665,6 +755,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the delegated stakes for an address
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getStakes(input: GetStakesParams): Promise<DelegatedStake[]> {
 		if (!input.owner || !isValidSuiAddress(normalizeSuiAddress(input.owner))) {
@@ -679,6 +771,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the delegated stakes queried by id.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getStakesByIds(input: GetStakesByIdsParams): Promise<DelegatedStake[]> {
 		input.stakedSuiIds.forEach((id) => {
@@ -695,6 +789,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the latest system state content.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getLatestSuiSystemState({
 		signal,
@@ -708,6 +804,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get events for a given query criteria
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async queryEvents({
 		query,
@@ -766,6 +864,8 @@ export class SuiJsonRpcClient extends BaseClient {
 	 * Runs the transaction block in dev-inspect mode. Which allows for nearly any
 	 * transaction (or Move call) with any arguments. Detailed results are
 	 * provided, including both the transaction effects and any return values.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async devInspectTransactionBlock(
 		input: DevInspectTransactionBlockParams,
@@ -798,6 +898,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Dry run a transaction block and return the result.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async dryRunTransactionBlock(
 		input: DryRunTransactionBlockParams,
@@ -814,6 +916,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the list of dynamic field objects owned by an object
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getDynamicFields(input: GetDynamicFieldsParams): Promise<DynamicFieldPage> {
 		if (!input.parentId || !isValidSuiObjectId(normalizeSuiObjectId(input.parentId))) {
@@ -828,6 +932,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the dynamic field object information for a specified object
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getDynamicFieldObject(input: GetDynamicFieldObjectParams): Promise<SuiObjectResponse> {
 		return await this.transport.request({
@@ -839,6 +945,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Get the sequence number of the latest checkpoint that has been executed
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getLatestCheckpointSequenceNumber({
 		signal,
@@ -853,6 +961,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Returns information about a given checkpoint
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCheckpoint(input: GetCheckpointParams): Promise<Checkpoint> {
 		return await this.transport.request({
@@ -864,6 +974,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Returns historical checkpoints paginated
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCheckpoints(
 		input: PaginationArguments<CheckpointPage['nextCursor']> & GetCheckpointsParams,
@@ -877,6 +989,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the committee information for the asked epoch
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCommitteeInfo(input?: GetCommitteeInfoParams): Promise<CommitteeInfo> {
 		return await this.transport.request({
@@ -886,6 +1000,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getNetworkMetrics({ signal }: { signal?: AbortSignal } = {}): Promise<NetworkMetrics> {
 		return await this.transport.request({
 			method: 'suix_getNetworkMetrics',
@@ -894,6 +1012,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getAddressMetrics({ signal }: { signal?: AbortSignal } = {}): Promise<AddressMetrics> {
 		return await this.transport.request({
 			method: 'suix_getLatestAddressMetrics',
@@ -902,6 +1024,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getEpochMetrics(
 		input?: {
 			descendingOrder?: boolean;
@@ -915,6 +1041,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getAllEpochAddressMetrics(input?: {
 		descendingOrder?: boolean;
 		signal?: AbortSignal;
@@ -928,6 +1058,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the committee information for the asked epoch
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getEpochs(
 		input?: {
@@ -944,6 +1076,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Returns list of top move calls by usage
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getMoveCallMetrics({ signal }: { signal?: AbortSignal } = {}): Promise<MoveCallMetrics> {
 		return await this.transport.request({
@@ -955,6 +1089,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the committee information for the asked epoch
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getCurrentEpoch({ signal }: { signal?: AbortSignal } = {}): Promise<EpochInfo> {
 		return await this.transport.request({
@@ -966,6 +1102,8 @@ export class SuiJsonRpcClient extends BaseClient {
 
 	/**
 	 * Return the Validators APYs
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async getValidatorsApy({ signal }: { signal?: AbortSignal } = {}): Promise<ValidatorsApy> {
 		return await this.transport.request({
@@ -976,12 +1114,20 @@ export class SuiJsonRpcClient extends BaseClient {
 	}
 
 	// TODO: Migrate this to `sui_getChainIdentifier` once it is widely available.
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getChainIdentifier({ signal }: { signal?: AbortSignal } = {}): Promise<string> {
 		const checkpoint = await this.getCheckpoint({ id: '0', signal });
 		const bytes = fromBase58(checkpoint.digest);
 		return toHex(bytes.slice(0, 4));
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async resolveNameServiceAddress(input: ResolveNameServiceAddressParams): Promise<string | null> {
 		return await this.transport.request({
 			method: 'suix_resolveNameServiceAddress',
@@ -990,6 +1136,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async resolveNameServiceNames({
 		format = 'dot',
 		...input
@@ -1010,6 +1160,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getProtocolConfig(input?: GetProtocolConfigParams): Promise<ProtocolConfig> {
 		return await this.transport.request({
 			method: 'sui_getProtocolConfig',
@@ -1018,6 +1172,10 @@ export class SuiJsonRpcClient extends BaseClient {
 		});
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async verifyZkLoginSignature(input: VerifyZkLoginSignatureParams): Promise<ZkLoginVerifyResult> {
 		return await this.transport.request({
 			method: 'sui_verifyZkLoginSignature',
@@ -1031,6 +1189,8 @@ export class SuiJsonRpcClient extends BaseClient {
 	 * This can be used in conjunction with `executeTransactionBlock` to wait for the transaction to
 	 * be available via the API.
 	 * This currently polls the `getTransactionBlock` API to check for the transaction.
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
 	async waitForTransaction({
 		signal,

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -103,9 +103,17 @@ function parseJsonRpcExecutionStatus(
 	};
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class JSONRpcCoreClient extends CoreClient {
 	#jsonRpcClient: SuiJsonRpcClient;
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	constructor({
 		jsonRpcClient,
 		mvr,
@@ -117,6 +125,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		this.#jsonRpcClient = jsonRpcClient;
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getObjects<Include extends SuiClientTypes.ObjectInclude = {}>(
 		options: SuiClientTypes.GetObjectsOptions<Include>,
 	) {
@@ -151,6 +163,10 @@ export class JSONRpcCoreClient extends CoreClient {
 			objects: results,
 		};
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async listOwnedObjects<Include extends SuiClientTypes.ObjectInclude = {}>(
 		options: SuiClientTypes.ListOwnedObjectsOptions<Include>,
 	) {
@@ -197,6 +213,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async listCoins(options: SuiClientTypes.ListCoinsOptions) {
 		const coins = await this.#jsonRpcClient.getCoins({
 			owner: options.owner,
@@ -225,6 +245,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getBalance(options: SuiClientTypes.GetBalanceOptions) {
 		const balance = await this.#jsonRpcClient.getBalance({
 			owner: options.owner,
@@ -244,6 +268,10 @@ export class JSONRpcCoreClient extends CoreClient {
 			},
 		};
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getCoinMetadata(
 		options: SuiClientTypes.GetCoinMetadataOptions,
 	): Promise<SuiClientTypes.GetCoinMetadataResponse> {
@@ -270,6 +298,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async listBalances(options: SuiClientTypes.ListBalancesOptions) {
 		const balances = await this.#jsonRpcClient.getAllBalances({
 			owner: options.owner,
@@ -291,6 +323,10 @@ export class JSONRpcCoreClient extends CoreClient {
 			cursor: null,
 		};
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.GetTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
@@ -311,6 +347,10 @@ export class JSONRpcCoreClient extends CoreClient {
 
 		return parseTransaction(transaction, options.include);
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async executeTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.ExecuteTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
@@ -332,6 +372,10 @@ export class JSONRpcCoreClient extends CoreClient {
 
 		return parseTransaction(transaction, options.include);
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
 		options: SuiClientTypes.SimulateTransactionOptions<Include>,
 	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
@@ -469,6 +513,10 @@ export class JSONRpcCoreClient extends CoreClient {
 						commandResults as SuiClientTypes.SimulateTransactionResult<Include>['commandResults'],
 				};
 	}
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getReferenceGasPrice(options?: SuiClientTypes.GetReferenceGasPriceOptions) {
 		const referenceGasPrice = await this.#jsonRpcClient.getReferenceGasPrice({
 			signal: options?.signal,
@@ -479,6 +527,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getProtocolConfig(
 		options?: SuiClientTypes.GetProtocolConfigOptions,
 	): Promise<SuiClientTypes.GetProtocolConfigResponse> {
@@ -513,6 +565,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getCurrentSystemState(
 		options?: SuiClientTypes.GetCurrentSystemStateOptions,
 	): Promise<SuiClientTypes.GetCurrentSystemStateResponse> {
@@ -555,6 +611,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async listDynamicFields(options: SuiClientTypes.ListDynamicFieldsOptions) {
 		const dynamicFields = await this.#jsonRpcClient.getDynamicFields({
 			parentId: options.parentId,
@@ -590,6 +650,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async verifyZkLoginSignature(options: SuiClientTypes.VerifyZkLoginSignatureOptions) {
 		const result = await this.#jsonRpcClient.verifyZkLoginSignature({
 			bytes: options.bytes,
@@ -604,6 +668,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async defaultNameServiceName(
 		options: SuiClientTypes.DefaultNameServiceNameOptions,
 	): Promise<SuiClientTypes.DefaultNameServiceNameResponse> {
@@ -615,10 +683,18 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	resolveTransactionPlugin() {
 		return coreClientResolveTransactionPlugin;
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getMoveFunction(
 		options: SuiClientTypes.GetMoveFunctionOptions,
 	): Promise<SuiClientTypes.GetMoveFunctionResponse> {
@@ -647,6 +723,10 @@ export class JSONRpcCoreClient extends CoreClient {
 		};
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async getChainIdentifier(
 		_options?: SuiClientTypes.GetChainIdentifierOptions,
 	): Promise<SuiClientTypes.GetChainIdentifierResponse> {

--- a/packages/sui/src/jsonRpc/errors.ts
+++ b/packages/sui/src/jsonRpc/errors.ts
@@ -20,8 +20,16 @@ const CODE_TO_ERROR_TYPE: Record<number, string> = {
 	'-32002': 'TransactionExecutionClientError',
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class SuiHTTPTransportError extends Error {}
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class JsonRpcError extends SuiHTTPTransportError {
 	code: number;
 	type: string;
@@ -33,6 +41,10 @@ export class JsonRpcError extends SuiHTTPTransportError {
 	}
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class SuiHTTPStatusError extends SuiHTTPTransportError {
 	status: number;
 	statusText: string;

--- a/packages/sui/src/jsonRpc/http-transport.ts
+++ b/packages/sui/src/jsonRpc/http-transport.ts
@@ -6,9 +6,15 @@ import { JsonRpcError, SuiHTTPStatusError } from './errors.js';
 
 /**
  * An object defining headers to be passed to the RPC server
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export type HttpHeaders = { [header: string]: string };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface JsonRpcHTTPTransportOptions {
 	fetch?: typeof fetch;
 	url: string;
@@ -18,24 +24,44 @@ export interface JsonRpcHTTPTransportOptions {
 	};
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface JsonRpcTransportRequestOptions {
 	method: string;
 	params: unknown[];
 	signal?: AbortSignal;
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface JsonRpcTransport {
 	request<T = unknown>(input: JsonRpcTransportRequestOptions): Promise<T>;
 }
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export class JsonRpcHTTPTransport implements JsonRpcTransport {
 	#requestId = 0;
 	#options: JsonRpcHTTPTransportOptions;
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	constructor(options: JsonRpcHTTPTransportOptions) {
 		this.#options = options;
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
 		const fetchFn = this.#options.fetch ?? fetch;
 
@@ -48,6 +74,10 @@ export class JsonRpcHTTPTransport implements JsonRpcTransport {
 		return fetchFn(input, init);
 	}
 
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	async request<T>(input: JsonRpcTransportRequestOptions): Promise<T> {
 		this.#requestId += 1;
 

--- a/packages/sui/src/jsonRpc/network.ts
+++ b/packages/sui/src/jsonRpc/network.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export function getJsonRpcFullnodeUrl(network: 'mainnet' | 'testnet' | 'devnet' | 'localnet') {
 	switch (network) {
 		case 'mainnet':

--- a/packages/sui/src/jsonRpc/types/chain.ts
+++ b/packages/sui/src/jsonRpc/types/chain.ts
@@ -11,12 +11,20 @@ import type {
 	SuiValidatorSummary,
 } from './generated.js';
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ResolvedNameServiceNames = {
 	data: string[];
 	hasNextPage: boolean;
 	nextCursor: string | null;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type EpochInfo = {
 	epoch: string;
 	validators: SuiValidatorSummary[];
@@ -27,6 +35,10 @@ export type EpochInfo = {
 	referenceGasPrice: number | null;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type EpochMetrics = {
 	epoch: string;
 	epochTotalTransactions: string;
@@ -35,18 +47,30 @@ export type EpochMetrics = {
 	endOfEpochInfo: EndOfEpochInfo | null;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type EpochPage = {
 	data: EpochInfo[];
 	nextCursor: string | null;
 	hasNextPage: boolean;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type EpochMetricsPage = {
 	data: EpochMetrics[];
 	nextCursor: string | null;
 	hasNextPage: boolean;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type EndOfEpochInfo = {
 	lastCheckpointId: string;
 	epochEndTimestamp: string;
@@ -63,12 +87,20 @@ export type EndOfEpochInfo = {
 	leftoverStorageFundInflow: string;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type CheckpointPage = {
 	data: Checkpoint[];
 	nextCursor: string | null;
 	hasNextPage: boolean;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type NetworkMetrics = {
 	currentTps: number;
 	tps30Days: number;
@@ -79,6 +111,10 @@ export type NetworkMetrics = {
 	totalPackages: string;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type AddressMetrics = {
 	checkpoint: number;
 	epoch: number;
@@ -88,14 +124,26 @@ export type AddressMetrics = {
 	dailyActiveAddresses: number;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type AllEpochsAddressMetrics = AddressMetrics[];
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type MoveCallMetrics = {
 	rank3Days: MoveCallMetric[];
 	rank7Days: MoveCallMetric[];
 	rank30Days: MoveCallMetric[];
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type MoveCallMetric = [
 	{
 		module: string;
@@ -105,17 +153,37 @@ export type MoveCallMetric = [
 	string,
 ];
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type DynamicFieldPage = {
 	data: DynamicFieldInfo[];
 	nextCursor: string | null;
 	hasNextPage: boolean;
 };
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveNormalizedModules = Record<string, SuiMoveNormalizedModule>;
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveObject = Extract<SuiParsedData, { dataType: 'moveObject' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMovePackage = Extract<SuiParsedData, { dataType: 'package' }>;
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ProgrammableTransaction = {
 	transactions: SuiTransaction[];
 	inputs: SuiCallArg[];

--- a/packages/sui/src/jsonRpc/types/changes.ts
+++ b/packages/sui/src/jsonRpc/types/changes.ts
@@ -3,9 +3,33 @@
 
 import type { SuiObjectChange } from './generated.js';
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangePublished = Extract<SuiObjectChange, { type: 'published' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangeTransferred = Extract<SuiObjectChange, { type: 'transferred' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangeMutated = Extract<SuiObjectChange, { type: 'mutated' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangeDeleted = Extract<SuiObjectChange, { type: 'deleted' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangeWrapped = Extract<SuiObjectChange, { type: 'wrapped' }>;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectChangeCreated = Extract<SuiObjectChange, { type: 'created' }>;

--- a/packages/sui/src/jsonRpc/types/coins.ts
+++ b/packages/sui/src/jsonRpc/types/coins.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type CoinBalance = {
 	coinType: string;
 	coinObjectCount: number;

--- a/packages/sui/src/jsonRpc/types/common.ts
+++ b/packages/sui/src/jsonRpc/types/common.ts
@@ -1,4 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+ * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type Order = 'ascending' | 'descending';

--- a/packages/sui/src/jsonRpc/types/generated.ts
+++ b/packages/sui/src/jsonRpc/types/generated.ts
@@ -10,6 +10,10 @@
  * /crates/sui-open-rpc/spec/openrpc.json
  */
 
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface AccumulatorEvent {
 	accumulatorObj: string;
 	address: string;
@@ -17,7 +21,15 @@ export interface AccumulatorEvent {
 	ty: string;
 	value: AccumulatorValue;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type AccumulatorOperation = 'merge' | 'split';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type AccumulatorValue =
 	| {
 			integer: string;
@@ -28,6 +40,10 @@ export type AccumulatorValue =
 	| {
 			eventDigest: [string, string][];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface Balance {
 	coinObjectCount: number;
 	coinType: string;
@@ -42,6 +58,10 @@ export interface Balance {
 	};
 	totalBalance: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface BalanceChange {
 	/**
 	 * The amount indicate the balance value changes, negative amount means spending coin value and
@@ -52,6 +72,10 @@ export interface BalanceChange {
 	/** Owner of the balance change */
 	owner: ObjectOwner;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface Checkpoint {
 	/** Commitments to checkpoint state */
 	checkpointCommitments: CheckpointCommitment[];
@@ -83,6 +107,10 @@ export interface Checkpoint {
 	/** Validator Signature */
 	validatorSignature: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type CheckpointCommitment =
 	| {
 			ECMHLiveObjectSetDigest: ECMHLiveObjectSetDigest;
@@ -90,12 +118,25 @@ export type CheckpointCommitment =
 	| {
 			CheckpointArtifactsDigest: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type CheckpointId = string | string;
-/** A claim consists of value and index_mod_4. */
+/**
+ * A claim consists of value and index_mod_4.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface Claim {
 	indexMod4: number;
 	value: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface CoinStruct {
 	balance: string;
 	coinObjectId: string;
@@ -104,12 +145,22 @@ export interface CoinStruct {
 	previousTransaction: string;
 	version: string;
 }
-/** RPC representation of the [Committee] type. */
+/**
+ * RPC representation of the [Committee] type.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface CommitteeInfo {
 	epoch: string;
 	validators: [string, string][];
 }
-/** Unlike [enum Signature], [enum CompressedSignature] does not contain public key. */
+/**
+ * Unlike [enum Signature], [enum CompressedSignature] does not contain public key.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type CompressedSignature =
 	| {
 			Ed25519: string;
@@ -126,6 +177,10 @@ export type CompressedSignature =
 	| {
 			Passkey: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ConsensusDeterminedVersionAssignments =
 	| {
 			CancelledTransactions: [string, [string, string][]][];
@@ -133,6 +188,10 @@ export type ConsensusDeterminedVersionAssignments =
 	| {
 			CancelledTransactionsV2: [string, [[string, string], string][]][];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiParsedData =
 	| {
 			dataType: 'moveObject';
@@ -146,6 +205,10 @@ export type SuiParsedData =
 				[key: string]: unknown;
 			};
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DelegatedStake {
 	stakes: StakeObject[];
 	/** Staking pool object id. */
@@ -153,7 +216,12 @@ export interface DelegatedStake {
 	/** Validator's Address. */
 	validatorAddress: string;
 }
-/** Additional rguments supplied to dev inspect beyond what is allowed in today's API. */
+/**
+ * Additional rguments supplied to dev inspect beyond what is allowed in today's API.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DevInspectArgs {
 	/** The gas budget for the transaction. */
 	gasBudget?: string | null;
@@ -166,7 +234,12 @@ export interface DevInspectArgs {
 	/** Whether to skip transaction checks for the transaction. */
 	skipChecks?: boolean | null;
 }
-/** The response from processing a dev inspect transaction */
+/**
+ * The response from processing a dev inspect transaction
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DevInspectResults {
 	/**
 	 * Summary of effects that likely would be generated if the transaction is actually run. Note however,
@@ -185,12 +258,20 @@ export interface DevInspectResults {
 	/** Execution results (including return values) from executing the transactions */
 	results?: SuiExecutionResult[] | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DisplayFieldsResponse {
 	data?: {
 		[key: string]: unknown;
 	} | null;
 	error?: ObjectResponseError | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DryRunTransactionBlockResponse {
 	balanceChanges: BalanceChange[];
 	effects: TransactionEffects;
@@ -200,6 +281,10 @@ export interface DryRunTransactionBlockResponse {
 	objectChanges: SuiObjectChange[];
 	suggestedGasPrice?: string | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type DynamicFieldInfo =
 	| {
 			digest: string;
@@ -221,15 +306,32 @@ export type DynamicFieldInfo =
 			bcsEncoding: 'base58';
 			bcsName: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface DynamicFieldName {
 	type: string;
 	value: unknown;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type DynamicFieldType = 'DynamicField' | 'DynamicObject';
-/** The Sha256 digest of an EllipticCurveMultisetHash committing to the live object set. */
+/**
+ * The Sha256 digest of an EllipticCurveMultisetHash committing to the live object set.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ECMHLiveObjectSetDigest {
 	digest: number[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface EndOfEpochData {
 	/** Commitments to epoch specific state (e.g. live object set) */
 	epochCommitments: CheckpointCommitment[];
@@ -248,6 +350,10 @@ export interface EndOfEpochData {
 	 */
 	nextEpochProtocolVersion: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiEvent =
 	| {
 			/**
@@ -293,6 +399,10 @@ export type SuiEvent =
 			bcs: string;
 			bcsEncoding: 'base58';
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiEventFilter =
 	/** Return all events. */
 	| {
@@ -345,12 +455,25 @@ export type SuiEventFilter =
 				startTime: string;
 			};
 	  };
-/** Unique ID of a Sui Event, the ID is a combination of transaction digest and event seq number. */
+/**
+ * Unique ID of a Sui Event, the ID is a combination of transaction digest and event seq number.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface EventId {
 	eventSeq: string;
 	txDigest: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ExecuteTransactionRequestType = 'WaitForEffectsCert' | 'WaitForLocalExecution';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ExecutionStatus = {
 	status: 'success' | 'failure';
 	error?: string;
@@ -373,6 +496,9 @@ export type ExecutionStatus = {
  * objects added up to a pool of "potential rebate". This rebate then is reduced by the "nonrefundable
  * rate" such that:
  * `potential_rebate(storage cost of deleted/mutated objects) = storage_rebate + non_refundable_storage_fee`
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface GasCostSummary {
 	/** Cost of computation/execution */
@@ -387,18 +513,30 @@ export interface GasCostSummary {
 	 */
 	storageRebate: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiGasData {
 	budget: string;
 	owner: string;
 	payment: SuiObjectRef[];
 	price: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetPastObjectRequest {
 	/** the ID of the queried object */
 	objectId: string;
 	/** the version of the queried object. */
 	version: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type InputObjectKind =
 	| {
 			MovePackage: string;
@@ -413,6 +551,10 @@ export type InputObjectKind =
 				mutable?: boolean;
 			};
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface MoveCallParams {
 	arguments: unknown[];
 	function: string;
@@ -420,11 +562,19 @@ export interface MoveCallParams {
 	packageObjectId: string;
 	typeArguments?: string[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveFunctionArgType =
 	| 'Pure'
 	| {
 			Object: ObjectValueKind;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type MoveStruct =
 	| MoveValue[]
 	| {
@@ -436,6 +586,10 @@ export type MoveStruct =
 	| {
 			[key: string]: MoveValue;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type MoveValue =
 	| number
 	| boolean
@@ -448,6 +602,10 @@ export type MoveValue =
 	| MoveStruct
 	| null
 	| MoveVariant;
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface MoveVariant {
 	fields: {
 		[key: string]: MoveValue;
@@ -455,7 +613,12 @@ export interface MoveVariant {
 	type: string;
 	variant: string;
 }
-/** The struct that contains signatures and public keys necessary for authenticating a MultiSig. */
+/**
+ * The struct that contains signatures and public keys necessary for authenticating a MultiSig.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface MultiSig {
 	/** A bitmap that indicates the position of which public key the signature should be authenticated with. */
 	bitmap: number;
@@ -470,6 +633,9 @@ export interface MultiSig {
 /**
  * Deprecated, use [struct MultiSig] instead. The struct that contains signatures and public keys
  * necessary for authenticating a MultiSigLegacy.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface MultiSigLegacy {
 	/** A bitmap that indicates the position of which public key the signature should be authenticated with. */
@@ -482,7 +648,12 @@ export interface MultiSigLegacy {
 	/** The plain signature encoded with signature scheme. */
 	sigs: CompressedSignature[];
 }
-/** The struct that contains the public key used for authenticating a MultiSig. */
+/**
+ * The struct that contains the public key used for authenticating a MultiSig.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface MultiSigPublicKey {
 	/** A list of public key and its corresponding weight. */
 	pk_map: [PublicKey, number][];
@@ -495,6 +666,9 @@ export interface MultiSigPublicKey {
 /**
  * Deprecated, use [struct MultiSigPublicKey] instead. The struct that contains the public key used for
  * authenticating a MultiSig.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface MultiSigPublicKeyLegacy {
 	/** A list of public key and its corresponding weight. */
@@ -508,6 +682,9 @@ export interface MultiSigPublicKeyLegacy {
 /**
  * ObjectChange are derived from the object mutations in the TransactionEffect to provide richer object
  * information.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export type SuiObjectChange =
 	/** Module published */
@@ -560,6 +737,10 @@ export type SuiObjectChange =
 			type: 'created';
 			version: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiObjectData {
 	/**
 	 * Move object content or package content in BCS, default to be None unless
@@ -597,6 +778,10 @@ export interface SuiObjectData {
 	/** Object version. */
 	version: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiObjectDataOptions {
 	/** Whether to show the content in BCS format. Default to be False */
 	showBcs?: boolean;
@@ -616,6 +801,10 @@ export interface SuiObjectDataOptions {
 	/** Whether to show the type of the object. Default to be False */
 	showType?: boolean;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ObjectRead =
 	/** The object exists and is found with this version */
 	| {
@@ -642,6 +831,10 @@ export type ObjectRead =
 			};
 			status: 'VersionTooHigh';
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiObjectRef {
 	/** Base64 string representing the object digest */
 	digest: string;
@@ -650,6 +843,10 @@ export interface SuiObjectRef {
 	/** Object version. */
 	version: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ObjectResponseError =
 	| {
 			code: 'notExists';
@@ -674,17 +871,33 @@ export type ObjectResponseError =
 			code: 'displayError';
 			error: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiObjectResponseQuery {
 	/** If None, no filter will be applied */
 	filter?: SuiObjectDataFilter | null;
 	/** config which fields to include in the response, by default only digest is included */
 	options?: SuiObjectDataOptions | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ObjectValueKind = 'ByImmutableReference' | 'ByMutableReference' | 'ByValue';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface OwnedObjectRef {
 	owner: ObjectOwner;
 	reference: SuiObjectRef;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ObjectOwner =
 	/** Object is exclusively owned by a single address, and is mutable. */
 	| {
@@ -717,6 +930,9 @@ export type ObjectOwner =
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedCheckpoints {
 	data: Checkpoint[];
@@ -727,6 +943,9 @@ export interface PaginatedCheckpoints {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedCoins {
 	data: CoinStruct[];
@@ -737,6 +956,9 @@ export interface PaginatedCoins {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedDynamicFieldInfos {
 	data: DynamicFieldInfo[];
@@ -747,6 +969,9 @@ export interface PaginatedDynamicFieldInfos {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedEvents {
 	data: SuiEvent[];
@@ -757,6 +982,9 @@ export interface PaginatedEvents {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedStrings {
 	data: string[];
@@ -767,6 +995,9 @@ export interface PaginatedStrings {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedObjectsResponse {
 	data: SuiObjectResponse[];
@@ -777,6 +1008,9 @@ export interface PaginatedObjectsResponse {
  * `next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the
  * next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first
  * item.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PaginatedTransactionResponse {
 	data: SuiTransactionBlockResponse[];
@@ -786,6 +1020,9 @@ export interface PaginatedTransactionResponse {
 /**
  * An passkey authenticator with parsed fields. See field defition below. Can be initialized from
  * [struct RawPasskeyAuthenticator].
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface PasskeyAuthenticator {
 	/**
@@ -801,6 +1038,10 @@ export interface PasskeyAuthenticator {
 	 */
 	client_data_json: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ProtocolConfig {
 	attributes: {
 		[key: string]: ProtocolConfigValue | null;
@@ -812,6 +1053,10 @@ export interface ProtocolConfig {
 	minSupportedProtocolVersion: string;
 	protocolVersion: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ProtocolConfigValue =
 	| {
 			u16: string;
@@ -828,6 +1073,10 @@ export type ProtocolConfigValue =
 	| {
 			bool: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type PublicKey =
 	| {
 			Ed25519: string;
@@ -844,6 +1093,10 @@ export type PublicKey =
 	| {
 			Passkey: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type RPCTransactionRequestParams =
 	| {
 			transferObjectRequestParams: TransferObjectParams;
@@ -851,6 +1104,10 @@ export type RPCTransactionRequestParams =
 	| {
 			moveCallRequestParams: MoveCallParams;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type RawData =
 	| {
 			bcsBytes: string;
@@ -871,6 +1128,10 @@ export type RawData =
 			typeOriginTable: TypeOrigin[];
 			version: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type Signature =
 	| {
 			Ed25519SuiSignature: string;
@@ -881,6 +1142,10 @@ export type Signature =
 	| {
 			Secp256r1SuiSignature: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type StakeObject =
 	| {
 			principal: string;
@@ -907,12 +1172,21 @@ export type StakeObject =
 			stakedSuiId: string;
 			status: 'Unstaked';
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiActiveJwk {
 	epoch: string;
 	jwk: SuiJWK;
 	jwk_id: SuiJwkId;
 }
-/** An argument to a transaction in a programmable transaction block */
+/**
+ * An argument to a transaction in a programmable transaction block
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiArgument =
 	| 'GasCoin' /** One of the input objects or primitive values (from `ProgrammableTransactionBlock` inputs) */
 	| {
@@ -927,9 +1201,17 @@ export type SuiArgument =
 	| {
 			NestedResult: [number, number];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiAuthenticatorStateExpire {
 	min_epoch: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiCallArg =
 	| {
 			type: 'object';
@@ -963,6 +1245,10 @@ export type SuiCallArg =
 			typeArg: SuiWithdrawalTypeArg;
 			withdrawFrom: SuiWithdrawFrom;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiChangeEpoch {
 	computation_charge: string;
 	epoch: string;
@@ -970,6 +1256,10 @@ export interface SuiChangeEpoch {
 	storage_charge: string;
 	storage_rebate: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface CoinMetadata {
 	/** Number of decimal places the coin uses. */
 	decimals: number;
@@ -984,6 +1274,10 @@ export interface CoinMetadata {
 	/** Symbol for the token */
 	symbol: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiEndOfEpochTransactionKind =
 	| 'AuthenticatorStateCreate'
 	| 'RandomnessStateCreate'
@@ -1006,36 +1300,68 @@ export type SuiEndOfEpochTransactionKind =
 	| {
 			BridgeCommitteeUpdate: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiExecutionResult {
 	/** The value of any arguments that were mutably borrowed. Non-mut borrowed values are not included */
 	mutableReferenceOutputs?: [SuiArgument, number[], string][];
 	/** The return values from the transaction */
 	returnValues?: [number[], string][];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiJWK {
 	alg: string;
 	e: string;
 	kty: string;
 	n: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiJwkId {
 	iss: string;
 	kid: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveAbility = 'Copy' | 'Drop' | 'Store' | 'Key';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveAbilitySet {
 	abilities: SuiMoveAbility[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveAbort {
 	error_code?: string | null;
 	function?: string | null;
 	line?: number | null;
 	module_id?: string | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveModuleId {
 	address: string;
 	name: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveNormalizedEnum {
 	abilities: SuiMoveAbilitySet;
 	typeParameters: SuiMoveStructTypeParameter[];
@@ -1044,10 +1370,18 @@ export interface SuiMoveNormalizedEnum {
 		[key: string]: SuiMoveNormalizedField[];
 	};
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveNormalizedField {
 	name: string;
 	type: SuiMoveNormalizedType;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveNormalizedFunction {
 	isEntry: boolean;
 	parameters: SuiMoveNormalizedType[];
@@ -1055,6 +1389,10 @@ export interface SuiMoveNormalizedFunction {
 	typeParameters: SuiMoveAbilitySet[];
 	visibility: SuiMoveVisibility;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveNormalizedModule {
 	address: string;
 	enums?: {
@@ -1070,11 +1408,19 @@ export interface SuiMoveNormalizedModule {
 		[key: string]: SuiMoveNormalizedStruct;
 	};
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveNormalizedStruct {
 	abilities: SuiMoveAbilitySet;
 	fields: SuiMoveNormalizedField[];
 	typeParameters: SuiMoveStructTypeParameter[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveNormalizedType =
 	| 'Bool'
 	| 'U8'
@@ -1105,11 +1451,23 @@ export type SuiMoveNormalizedType =
 	| {
 			MutableReference: SuiMoveNormalizedType;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiMoveStructTypeParameter {
 	constraints: SuiMoveAbilitySet;
 	isPhantom: boolean;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiMoveVisibility = 'Private' | 'Public' | 'Friend';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiObjectDataFilter =
 	| {
 			MatchAll: SuiObjectDataFilter[];
@@ -1149,6 +1507,10 @@ export type SuiObjectDataFilter =
 	| {
 			Version: string;
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiObjectResponse {
 	data?: SuiObjectData | null;
 	error?: ObjectResponseError | null;
@@ -1156,6 +1518,9 @@ export interface SuiObjectResponse {
 /**
  * The transaction for calling a Move function, either an entry function or a public function (which
  * cannot return references).
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface MoveCallSuiTransaction {
 	/** The arguments to the function. */
@@ -1169,6 +1534,10 @@ export interface MoveCallSuiTransaction {
 	/** The type arguments to the function. */
 	type_arguments?: string[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiReservation = {
 	maxAmountU64: string;
 };
@@ -1176,6 +1545,9 @@ export type SuiReservation = {
  * This is the JSON-RPC type for the SUI system state object. It flattens all fields to make them
  * top-level fields such that it as minimum dependencies to the internal data structures of the SUI
  * system state type.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface SuiSystemStateSummary {
 	/** The list of active validators in the current epoch. */
@@ -1285,7 +1657,12 @@ export interface SuiSystemStateSummary {
 	 */
 	validatorVeryLowStakeThreshold: string;
 }
-/** A single transaction in a programmable transaction block. */
+/**
+ * A single transaction in a programmable transaction block.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiTransaction =
 	/** A call to either an entry or a public Move function */
 	| {
@@ -1322,10 +1699,17 @@ export type SuiTransaction =
 	| {
 			MakeMoveVec: [string | null, SuiArgument[]];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiTransactionBlockBuilderMode = 'Commit' | 'DevInspect';
 /**
  * This is the JSON-RPC type for the SUI validator. It flattens all inner structures to top-level
  * fields so that they are decoupled from the internal definitions.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface SuiValidatorSummary {
 	commissionRate: string;
@@ -1379,17 +1763,37 @@ export interface SuiValidatorSummary {
 	workerAddress: string;
 	workerPubkeyBytes: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiWithdrawFrom = 'sender' | 'sponsor';
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiWithdrawalTypeArg = {
 	balance: string;
 };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface CoinSupply {
 	value: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiTransactionBlock {
 	data: TransactionBlockData;
 	txSignatures: string[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface TransactionBlockBytes {
 	/** the gas objects to be used */
 	gas: SuiObjectRef[];
@@ -1398,12 +1802,20 @@ export interface TransactionBlockBytes {
 	/** BCS serialized transaction data bytes without its type tag, as base-64 encoded string. */
 	txBytes: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type TransactionBlockData = {
 	gasData: SuiGasData;
 	messageVersion: 'v1';
 	sender: string;
 	transaction: SuiTransactionBlockKind;
 };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type TransactionEffects =
 	/** The response from processing a transaction or a certified transaction */
 	{
@@ -1456,10 +1868,18 @@ export type TransactionEffects =
 		/** Object refs of objects now wrapped in other objects. */
 		wrapped?: SuiObjectRef[];
 	};
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface TransactionBlockEffectsModifiedAtVersions {
 	objectId: string;
 	sequenceNumber: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type SuiTransactionBlockKind =
 	/** A system transaction that will update epoch information on-chain. */
 	| {
@@ -1542,6 +1962,10 @@ export type SuiTransactionBlockKind =
 			 */
 			transactions: SuiTransaction[];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiTransactionBlockResponse {
 	balanceChanges?: BalanceChange[] | null;
 	/**
@@ -1565,6 +1989,10 @@ export interface SuiTransactionBlockResponse {
 	/** Transaction input data */
 	transaction?: SuiTransactionBlock | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiTransactionBlockResponseOptions {
 	/** Whether to show balance_changes. Default to be False */
 	showBalanceChanges?: boolean;
@@ -1581,12 +2009,20 @@ export interface SuiTransactionBlockResponseOptions {
 	/** Whether to show bcs-encoded transaction input data */
 	showRawInput?: boolean;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SuiTransactionBlockResponseQuery {
 	/** If None, no filter will be applied */
 	filter?: TransactionFilter | null;
 	/** config which fields to include in the response, by default only digest is included */
 	options?: SuiTransactionBlockResponseOptions | null;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type TransactionFilter =
 	/** CURRENTLY NOT SUPPORTED. Query by checkpoint. */
 	| {
@@ -1631,51 +2067,96 @@ export type TransactionFilter =
 	| {
 			TransactionKindIn: string[];
 	  };
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface TransferObjectParams {
 	objectId: string;
 	recipient: string;
 }
-/** Identifies a struct and the module it was defined in */
+/**
+ * Identifies a struct and the module it was defined in
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface TypeOrigin {
 	datatype_name: string;
 	module_name: string;
 	package: string;
 }
-/** Upgraded package info for the linkage table */
+/**
+ * Upgraded package info for the linkage table
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UpgradeInfo {
 	/** ID of the upgraded packages */
 	upgraded_id: string;
 	/** Version of the upgraded package */
 	upgraded_version: string;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ValidatorApy {
 	address: string;
 	apy: number;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ValidatorsApy {
 	apys: ValidatorApy[];
 	epoch: string;
 }
-/** An zk login authenticator with all the necessary fields. */
+/**
+ * An zk login authenticator with all the necessary fields.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ZkLoginAuthenticator {
 	inputs: ZkLoginInputs;
 	maxEpoch: string;
 	userSignature: Signature;
 }
-/** All inputs required for the zk login proof verification and other public inputs. */
+/**
+ * All inputs required for the zk login proof verification and other public inputs.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ZkLoginInputs {
 	addressSeed: string;
 	headerBase64: string;
 	issBase64Details: Claim;
 	proofPoints: ZkLoginProof;
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type ZkLoginIntentScope = 'TransactionData' | 'PersonalMessage';
-/** The struct for zk login proof. */
+/**
+ * The struct for zk login proof.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ZkLoginProof {
 	a: string[];
 	b: string[][];
 	c: string[];
 }
+/**
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ZkLoginVerifyResult {
 	/** The errors field captures any verification error */
 	errors: string[];

--- a/packages/sui/src/jsonRpc/types/params.ts
+++ b/packages/sui/src/jsonRpc/types/params.ts
@@ -16,6 +16,9 @@ import type { Transaction } from '../../transactions/index.js';
  * Runs the transaction in dev-inspect mode. Which allows for nearly any transaction (or Move call)
  * with any arguments. Detailed results are provided, including both the transaction effects and any
  * return values.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface DevInspectTransactionBlockParams {
 	sender: string;
@@ -32,6 +35,9 @@ export interface DevInspectTransactionBlockParams {
 /**
  * Return transaction execution effects including the gas cost summary, while the effects are not
  * committed to the chain.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface DryRunTransactionBlockParams {
 	transactionBlock: Uint8Array | string;
@@ -46,6 +52,9 @@ export interface DryRunTransactionBlockParams {
  * the transaction locally in a timely manner, a bool type in the response is set to false to indicated
  * the case. request_type is default to be `WaitForEffectsCert` unless options.show_events or
  * options.show_effects is true
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface ExecuteTransactionBlockParams {
 	/** BCS serialized transaction data bytes without its type tag, as base-64 encoded string. */
@@ -57,21 +66,36 @@ export interface ExecuteTransactionBlockParams {
 	signature: string | string[];
 	/** options for specifying the content to be returned */
 	options?: RpcTypes.SuiTransactionBlockResponseOptions | null | undefined;
-	/** @deprecated requestType will be ignored by JSON RPC in the future */
+	/** @deprecated requestType is deprecated and should not be used */
 	requestType?: RpcTypes.ExecuteTransactionRequestType | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the first four bytes of the chain's genesis checkpoint digest. */
+/**
+ * Return the first four bytes of the chain's genesis checkpoint digest.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetChainIdentifierParams {
 	signal?: AbortSignal;
 }
-/** Return a checkpoint */
+/**
+ * Return a checkpoint
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetCheckpointParams {
 	/** Checkpoint identifier, can use either checkpoint digest, or checkpoint sequence number as input. */
 	id: RpcTypes.CheckpointId;
 	signal?: AbortSignal;
 }
-/** Return paginated list of checkpoints */
+/**
+ * Return paginated list of checkpoints
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetCheckpointsParams {
 	/**
 	 * An optional paging cursor. If provided, the query will start from the next item after the specified
@@ -84,49 +108,89 @@ export interface GetCheckpointsParams {
 	descendingOrder: boolean;
 	signal?: AbortSignal;
 }
-/** Return transaction events. */
+/**
+ * Return transaction events.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetEventsParams {
 	/** the event query criteria. */
 	transactionDigest: string;
 	signal?: AbortSignal;
 }
-/** Return the sequence number of the latest checkpoint that has been executed */
+/**
+ * Return the sequence number of the latest checkpoint that has been executed
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetLatestCheckpointSequenceNumberParams {
 	signal?: AbortSignal;
 }
-/** Return the argument types of a Move function, based on normalized Type. */
+/**
+ * Return the argument types of a Move function, based on normalized Type.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetMoveFunctionArgTypesParams {
 	package: string;
 	module: string;
 	function: string;
 	signal?: AbortSignal;
 }
-/** Return a structured representation of Move function */
+/**
+ * Return a structured representation of Move function
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetNormalizedMoveFunctionParams {
 	package: string;
 	module: string;
 	function: string;
 	signal?: AbortSignal;
 }
-/** Return a structured representation of Move module */
+/**
+ * Return a structured representation of Move module
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetNormalizedMoveModuleParams {
 	package: string;
 	module: string;
 	signal?: AbortSignal;
 }
-/** Return structured representations of all modules in the given package */
+/**
+ * Return structured representations of all modules in the given package
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetNormalizedMoveModulesByPackageParams {
 	package: string;
 	signal?: AbortSignal;
 }
-/** Return a structured representation of Move struct */
+/**
+ * Return a structured representation of Move struct
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetNormalizedMoveStructParams {
 	package: string;
 	module: string;
 	struct: string;
 	signal?: AbortSignal;
 }
-/** Return the object information for a specified object */
+/**
+ * Return the object information for a specified object
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetObjectParams {
 	/** the ID of the queried object */
 	id: string;
@@ -137,6 +201,9 @@ export interface GetObjectParams {
 /**
  * Return the protocol config table for the given version number. If none is specified, the node uses
  * the version of the latest epoch it has processed.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface GetProtocolConfigParams {
 	/**
@@ -146,11 +213,21 @@ export interface GetProtocolConfigParams {
 	version?: string | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the total number of transaction blocks known to the server. */
+/**
+ * Return the total number of transaction blocks known to the server.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetTotalTransactionBlocksParams {
 	signal?: AbortSignal;
 }
-/** Return the transaction response object. */
+/**
+ * Return the transaction response object.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetTransactionBlockParams {
 	/** the digest of the queried transaction */
 	digest: string;
@@ -158,7 +235,12 @@ export interface GetTransactionBlockParams {
 	options?: RpcTypes.SuiTransactionBlockResponseOptions | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the object data for a list of objects */
+/**
+ * Return the object data for a list of objects
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface MultiGetObjectsParams {
 	/** the IDs of the queried objects */
 	ids: string[];
@@ -169,6 +251,9 @@ export interface MultiGetObjectsParams {
 /**
  * Returns an ordered list of transaction responses The method will throw an error if the input
  * contains any duplicate or the input size exceeds QUERY_MAX_RESULT_LIMIT
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface MultiGetTransactionBlocksParams {
 	/** A list of transaction digests. */
@@ -181,6 +266,9 @@ export interface MultiGetTransactionBlocksParams {
  * Note there is no software-level guarantee/SLA that objects with past versions can be retrieved by
  * this API, even if the object and version exists/existed. The result may vary across nodes depending
  * on their pruning policies. Return the object information for a specified version
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface TryGetPastObjectParams {
 	/** the ID of the queried object */
@@ -195,6 +283,9 @@ export interface TryGetPastObjectParams {
  * Note there is no software-level guarantee/SLA that objects with past versions can be retrieved by
  * this API, even if the object and version exists/existed. The result may vary across nodes depending
  * on their pruning policies. Return the object information for a specified version
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface TryMultiGetPastObjectsParams {
 	/** a vector of object and versions to be queried */
@@ -203,7 +294,12 @@ export interface TryMultiGetPastObjectsParams {
 	options?: RpcTypes.SuiObjectDataOptions | null | undefined;
 	signal?: AbortSignal;
 }
-/** Verify a zklogin signature for the given bytes, intent scope and author. */
+/**
+ * Verify a zklogin signature for the given bytes, intent scope and author.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface VerifyZkLoginSignatureParams {
 	/**
 	 * The Base64 string of bcs bytes for raw transaction data or personal message indicated by
@@ -218,13 +314,23 @@ export interface VerifyZkLoginSignatureParams {
 	author: string;
 	signal?: AbortSignal;
 }
-/** Return the total coin balance for all coin type, owned by the address owner. */
+/**
+ * Return the total coin balance for all coin type, owned by the address owner.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetAllBalancesParams {
 	/** the owner's Sui address */
 	owner: string;
 	signal?: AbortSignal;
 }
-/** Return all Coin objects owned by an address. */
+/**
+ * Return all Coin objects owned by an address.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetAllCoinsParams {
 	/** the owner's Sui address */
 	owner: string;
@@ -234,7 +340,12 @@ export interface GetAllCoinsParams {
 	limit?: number | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the total coin balance for one coin type, owned by the address owner. */
+/**
+ * Return the total coin balance for one coin type, owned by the address owner.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetBalanceParams {
 	/** the owner's Sui address */
 	owner: string;
@@ -249,13 +360,21 @@ export interface GetBalanceParams {
  * Return metadata (e.g., symbol, decimals) for a coin. Note that if the coin's metadata was wrapped in
  * the transaction that published its marker type, or the latest version of the metadata object is
  * wrapped or deleted, it will not be found.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface GetCoinMetadataParams {
 	/** type name for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC) */
 	coinType: string;
 	signal?: AbortSignal;
 }
-/** Return all Coin<`coin_type`> objects owned by an address. */
+/**
+ * Return all Coin<`coin_type`> objects owned by an address.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetCoinsParams {
 	/** the owner's Sui address */
 	owner: string;
@@ -270,13 +389,23 @@ export interface GetCoinsParams {
 	limit?: number | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the committee information for the asked `epoch`. */
+/**
+ * Return the committee information for the asked `epoch`.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetCommitteeInfoParams {
 	/** The epoch of interest. If None, default to the latest epoch */
 	epoch?: string | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the dynamic field object information for a specified object */
+/**
+ * Return the dynamic field object information for a specified object
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetDynamicFieldObjectParams {
 	/** The ID of the queried parent object */
 	parentId: string;
@@ -284,7 +413,12 @@ export interface GetDynamicFieldObjectParams {
 	name: RpcTypes.DynamicFieldName;
 	signal?: AbortSignal;
 }
-/** Return the list of dynamic field objects owned by an object. */
+/**
+ * Return the list of dynamic field objects owned by an object.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetDynamicFieldsParams {
 	/** The ID of the parent object */
 	parentId: string;
@@ -297,7 +431,12 @@ export interface GetDynamicFieldsParams {
 	limit?: number | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return the latest SUI system state object on-chain. */
+/**
+ * Return the latest SUI system state object on-chain.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetLatestSuiSystemStateParams {
 	signal?: AbortSignal;
 }
@@ -305,6 +444,9 @@ export interface GetLatestSuiSystemStateParams {
  * Return the list of objects owned by an address. Note that if the address owns more than
  * `QUERY_MAX_RESULT_LIMIT` objects, the pagination is not accurate, because previous page may have
  * been updated when the next page is fetched. Please use suix_queryObjects if this is a concern.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export type GetOwnedObjectsParams = {
 	/** the owner's Sui address */
@@ -318,31 +460,61 @@ export type GetOwnedObjectsParams = {
 	limit?: number | null | undefined;
 	signal?: AbortSignal;
 } & RpcTypes.SuiObjectResponseQuery;
-/** Return the reference gas price for the network */
+/**
+ * Return the reference gas price for the network
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetReferenceGasPriceParams {
 	signal?: AbortSignal;
 }
-/** Return all [DelegatedStake]. */
+/**
+ * Return all [DelegatedStake].
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetStakesParams {
 	owner: string;
 	signal?: AbortSignal;
 }
-/** Return one or more [DelegatedStake]. If a Stake was withdrawn its status will be Unstaked. */
+/**
+ * Return one or more [DelegatedStake]. If a Stake was withdrawn its status will be Unstaked.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetStakesByIdsParams {
 	stakedSuiIds: string[];
 	signal?: AbortSignal;
 }
-/** Return total supply for a coin */
+/**
+ * Return total supply for a coin
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetTotalSupplyParams {
 	/** type name for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC) */
 	coinType: string;
 	signal?: AbortSignal;
 }
-/** Return the validator APY */
+/**
+ * Return the validator APY
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface GetValidatorsApyParams {
 	signal?: AbortSignal;
 }
-/** Return list of events for a specified query criteria. */
+/**
+ * Return list of events for a specified query criteria.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface QueryEventsParams {
 	/**
 	 * The event query criteria. See [Event filter](https://docs.sui.io/build/event_api#event-filters)
@@ -357,7 +529,12 @@ export interface QueryEventsParams {
 	order?: 'ascending' | 'descending' | null | undefined;
 	signal?: AbortSignal;
 }
-/** Return list of transactions for a specified query criteria. */
+/**
+ * Return list of transactions for a specified query criteria.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export type QueryTransactionBlocksParams = {
 	/**
 	 * An optional paging cursor. If provided, the query will start from the next item after the specified
@@ -370,7 +547,12 @@ export type QueryTransactionBlocksParams = {
 	order?: 'ascending' | 'descending' | null | undefined;
 	signal?: AbortSignal;
 } & RpcTypes.SuiTransactionBlockResponseQuery;
-/** Return the resolved address given resolver and name */
+/**
+ * Return the resolved address given resolver and name
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface ResolveNameServiceAddressParams {
 	/** The name to resolve */
 	name: string;
@@ -379,6 +561,9 @@ export interface ResolveNameServiceAddressParams {
 /**
  * Return the resolved names given address, if multiple names are resolved, the first one is the
  * primary name.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface ResolveNameServiceNamesParams {
 	/** The address to resolve */
@@ -387,7 +572,12 @@ export interface ResolveNameServiceNamesParams {
 	limit?: number | null | undefined;
 	signal?: AbortSignal;
 }
-/** Subscribe to a stream of Sui event */
+/**
+ * Subscribe to a stream of Sui event
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SubscribeEventParams {
 	/**
 	 * The filter criteria of the event stream. See
@@ -396,12 +586,22 @@ export interface SubscribeEventParams {
 	filter: RpcTypes.SuiEventFilter;
 	signal?: AbortSignal;
 }
-/** Subscribe to a stream of Sui transaction effects */
+/**
+ * Subscribe to a stream of Sui transaction effects
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface SubscribeTransactionParams {
 	filter: RpcTypes.TransactionFilter;
 	signal?: AbortSignal;
 }
-/** Create an unsigned batched transaction. */
+/**
+ * Create an unsigned batched transaction.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeBatchTransactionParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -418,7 +618,12 @@ export interface UnsafeBatchTransactionParams {
 	txnBuilderMode?: RpcTypes.SuiTransactionBlockBuilderMode | null | undefined;
 	signal?: AbortSignal;
 }
-/** Create an unsigned transaction to merge multiple coins into one coin. */
+/**
+ * Create an unsigned transaction to merge multiple coins into one coin.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeMergeCoinsParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -441,6 +646,9 @@ export interface UnsafeMergeCoinsParams {
 /**
  * Create an unsigned transaction to execute a Move call on the network, by calling the specified
  * function in the module of a given package.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafeMoveCallParams {
 	/** the transaction signer's Sui address */
@@ -477,6 +685,9 @@ export interface UnsafeMoveCallParams {
  * The object specified in the `gas` field will be used to pay the gas fee for the transaction. The gas
  * object can not appear in `input_coins`. If the gas object is not specified, the RPC server will
  * auto-select one.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafePayParams {
 	/** the transaction signer's Sui address */
@@ -502,6 +713,9 @@ export interface UnsafePayParams {
  * deposit all SUI to the first input coin 2. transfer the updated first coin to the recipient and also
  * use this first coin as gas coin object. 3. the balance of the first input coin after tx is
  * sum(input_coins) - actual_gas_cost. 4. all other input coins other than the first are deleted.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafePayAllSuiParams {
 	/** the transaction signer's Sui address */
@@ -522,6 +736,9 @@ export interface UnsafePayAllSuiParams {
  * input coin, then use the first input coin as the gas coin object. 3. the balance of the first input
  * coin after tx is sum(input_coins) - sum(amounts) - actual_gas_cost 4. all other input coins other
  * than the first one are deleted.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafePaySuiParams {
 	/** the transaction signer's Sui address */
@@ -536,7 +753,12 @@ export interface UnsafePaySuiParams {
 	gasBudget: string;
 	signal?: AbortSignal;
 }
-/** Create an unsigned transaction to publish a Move package. */
+/**
+ * Create an unsigned transaction to publish a Move package.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafePublishParams {
 	/** the transaction signer's Sui address */
 	sender: string;
@@ -553,7 +775,12 @@ export interface UnsafePublishParams {
 	gasBudget: string;
 	signal?: AbortSignal;
 }
-/** Add stake to a validator's staking pool using multiple coins and amount. */
+/**
+ * Add stake to a validator's staking pool using multiple coins and amount.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeRequestAddStakeParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -572,7 +799,12 @@ export interface UnsafeRequestAddStakeParams {
 	gasBudget: string;
 	signal?: AbortSignal;
 }
-/** Withdraw stake from a validator's staking pool. */
+/**
+ * Withdraw stake from a validator's staking pool.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeRequestWithdrawStakeParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -587,7 +819,12 @@ export interface UnsafeRequestWithdrawStakeParams {
 	gasBudget: string;
 	signal?: AbortSignal;
 }
-/** Create an unsigned transaction to split a coin object into multiple coins. */
+/**
+ * Create an unsigned transaction to split a coin object into multiple coins.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeSplitCoinParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -604,7 +841,12 @@ export interface UnsafeSplitCoinParams {
 	gasBudget: string;
 	signal?: AbortSignal;
 }
-/** Create an unsigned transaction to split a coin object into multiple equal-size coins. */
+/**
+ * Create an unsigned transaction to split a coin object into multiple equal-size coins.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+ */
 export interface UnsafeSplitCoinEqualParams {
 	/** the transaction signer's Sui address */
 	signer: string;
@@ -624,6 +866,9 @@ export interface UnsafeSplitCoinEqualParams {
 /**
  * Create an unsigned transaction to transfer an object from one address to another. The object's type
  * must allow public transfers
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafeTransferObjectParams {
 	/** the transaction signer's Sui address */
@@ -644,6 +889,9 @@ export interface UnsafeTransferObjectParams {
 /**
  * Create an unsigned transaction to send SUI coin object to a Sui address. The SUI object is also used
  * as the gas object.
+ *
+ * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient` from
+ * `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
  */
 export interface UnsafeTransferSuiParams {
 	/** the transaction signer's Sui address */


### PR DESCRIPTION
## Description

Marks the JSON-RPC surface in `@mysten/sui/jsonRpc` as deprecated and points users to the gRPC or GraphQL clients.

This adds deprecation JSDoc to the JSON-RPC client, transport, errors, network helper, JSON-RPC Core implementation, and JSON-RPC-specific exported types. It also updates the OpenRPC type generator so generated JSON-RPC declarations retain the deprecation notices.

## Test plan

- `pnpm --filter @mysten/sui oxlint:check`
- `pnpm exec prettier -c --ignore-unknown packages/sui/scripts/generate.ts "packages/sui/src/jsonRpc/**/*.ts" .changeset/deprecate-json-rpc-apis.md`
- `pnpm turbo build --filter=@mysten/sui`
- `pnpm --filter @mysten/sui test`
- Verified generated JSON-RPC type diffs are comment-only after stripping comments/whitespace.
- Verified exported JSON-RPC declarations and JSON-RPC class methods have `@deprecated` JSDoc.
- Verified JSON-RPC deprecation wording avoids point-in-time testnet/mainnet status language.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
