### PR TITLE
Add gRPC transaction response parsers

### DIFF
--- a/.changeset/clever-terms-relate.md
+++ b/.changeset/clever-terms-relate.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Expose gRPC transaction response parsers for converting protobuf transaction responses into SDK Core transaction result shapes.

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -45,6 +45,7 @@ import {
 	grpcTransactionToTransactionData,
 } from '../client/transaction-resolver.js';
 import { Value } from './proto/google/protobuf/struct.js';
+import type { SimulateTransactionResponse } from './proto/sui/rpc/v2/transaction_execution_service.js';
 import { SimulateTransactionRequest_TransactionChecks } from './proto/sui/rpc/v2/transaction_execution_service.js';
 
 export interface GrpcCoreClientOptions extends CoreClientOptions {
@@ -370,7 +371,7 @@ export class GrpcCoreClient extends CoreClient {
 			throw new Error(`Transaction ${options.digest} not found`);
 		}
 
-		return parseTransaction(response.transaction, options.include);
+		return parseGrpcTransactionResponse(response.transaction, { include: options.include });
 	}
 	async executeTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.ExecuteTransactionOptions<Include>,
@@ -423,7 +424,7 @@ export class GrpcCoreClient extends CoreClient {
 			{ abort: options.signal },
 		);
 
-		return parseTransaction(response.transaction!, options.include);
+		return parseGrpcTransactionResponse(response.transaction!, { include: options.include });
 	}
 	async simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
 		options: SuiClientTypes.SimulateTransactionOptions<Include>,
@@ -489,36 +490,7 @@ export class GrpcCoreClient extends CoreClient {
 			{ abort: options.signal },
 		);
 
-		const transactionResult = parseTransaction(response.transaction!, options.include);
-
-		// Add command results if requested
-		const commandResults =
-			options.include?.commandResults && response.commandOutputs
-				? response.commandOutputs.map((output) => ({
-						returnValues: (output.returnValues ?? []).map((rv) => ({
-							bcs: rv.value?.value ?? null,
-						})),
-						mutatedReferences: (output.mutatedByRef ?? []).map((mr) => ({
-							bcs: mr.value?.value ?? null,
-						})),
-					}))
-				: undefined;
-
-		if (transactionResult.$kind === 'Transaction') {
-			return {
-				$kind: 'Transaction',
-				Transaction: transactionResult.Transaction,
-				commandResults:
-					commandResults as SuiClientTypes.SimulateTransactionResult<Include>['commandResults'],
-			};
-		} else {
-			return {
-				$kind: 'FailedTransaction',
-				FailedTransaction: transactionResult.FailedTransaction,
-				commandResults:
-					commandResults as SuiClientTypes.SimulateTransactionResult<Include>['commandResults'],
-			};
-		}
+		return parseGrpcSimulateTransactionResponse(response, { include: options.include });
 	}
 	async getReferenceGasPrice(
 		options?: SuiClientTypes.GetReferenceGasPriceOptions,
@@ -1275,10 +1247,15 @@ export function parseTransactionEffects({
 	};
 }
 
-function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
+export function parseGrpcTransactionResponse<
+	Include extends SuiClientTypes.TransactionInclude = {},
+>(
 	transaction: ExecutedTransaction,
-	include?: Include,
+	options?: {
+		include?: Include & SuiClientTypes.TransactionInclude;
+	},
 ): SuiClientTypes.TransactionResult<Include> {
+	const include = options?.include;
 	const objectTypes: Record<string, string> = {};
 	if (include?.objectTypes) {
 		transaction.effects?.changedObjects?.forEach((change) => {
@@ -1367,6 +1344,46 @@ function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}
 				$kind: 'FailedTransaction',
 				FailedTransaction: result,
 			};
+}
+
+export function parseGrpcSimulateTransactionResponse<
+	Include extends SuiClientTypes.SimulateTransactionInclude = {},
+>(
+	response: SimulateTransactionResponse,
+	options?: {
+		include?: Include & SuiClientTypes.SimulateTransactionInclude;
+	},
+): SuiClientTypes.SimulateTransactionResult<Include> {
+	const include = options?.include;
+	const transactionResult = parseGrpcTransactionResponse(response.transaction!, { include });
+
+	const commandResults =
+		include?.commandResults && response.commandOutputs
+			? response.commandOutputs.map((output) => ({
+					returnValues: (output.returnValues ?? []).map((rv) => ({
+						bcs: rv.value?.value ?? null,
+					})),
+					mutatedReferences: (output.mutatedByRef ?? []).map((mr) => ({
+						bcs: mr.value?.value ?? null,
+					})),
+				}))
+			: undefined;
+
+	if (transactionResult.$kind === 'Transaction') {
+		return {
+			$kind: 'Transaction',
+			Transaction: transactionResult.Transaction,
+			commandResults:
+				commandResults as SuiClientTypes.SimulateTransactionResult<Include>['commandResults'],
+		};
+	}
+
+	return {
+		$kind: 'FailedTransaction',
+		FailedTransaction: transactionResult.FailedTransaction,
+		commandResults:
+			commandResults as SuiClientTypes.SimulateTransactionResult<Include>['commandResults'],
+	};
 }
 
 function parseNormalizedSuiMoveType(type: OpenSignature): SuiClientTypes.OpenSignature {

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { SuiGrpcClient, isSuiGrpcClient } from './client.js';
-export { GrpcCoreClient } from './core.js';
+export {
+	GrpcCoreClient,
+	parseGrpcSimulateTransactionResponse,
+	parseGrpcTransactionResponse,
+} from './core.js';
 export type { SuiGrpcClientOptions } from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 

--- a/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
+++ b/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { SuiClientTypes } from '../../../src/client/index.js';
+import {
+	GrpcTypes,
+	parseGrpcSimulateTransactionResponse,
+	parseGrpcTransactionResponse,
+} from '../../../src/grpc/index.js';
+
+function expectBytes(bytes: Uint8Array | undefined, expected: number[]) {
+	expect(bytes).toBeInstanceOf(Uint8Array);
+	expect(Array.from(bytes!)).toEqual(expected);
+}
+
+describe('gRPC transaction response parsers', () => {
+	it('parses protobuf JSON simulation responses into SDK simulation results', () => {
+		const response = GrpcTypes.SimulateTransactionResponse.fromJsonString(
+			JSON.stringify({
+				transaction: {
+					digest: 'transaction-digest',
+					transaction: {
+						digest: 'transaction-data-digest',
+						bcs: {
+							name: 'TransactionData',
+							value: 'AQIDBA==',
+						},
+					},
+					signatures: [
+						{
+							bcs: {
+								value: 'CQgH',
+							},
+						},
+					],
+					effects: {
+						status: {
+							success: true,
+						},
+						epoch: '42',
+						changedObjects: [
+							{
+								objectId: '0x2',
+								objectType: '0x2::coin::Coin<0x2::sui::SUI>',
+							},
+						],
+					},
+					events: {
+						events: [
+							{
+								packageId: '0x2',
+								module: 'test',
+								sender: '0x1',
+								eventType: '0x2::test::Event',
+								contents: {
+									value: 'BQYH',
+								},
+							},
+						],
+					},
+				},
+				commandOutputs: [
+					{
+						returnValues: [
+							{
+								value: {
+									value: 'CgsM',
+								},
+							},
+						],
+						mutatedByRef: [
+							{
+								value: {
+									value: 'DQ4P',
+								},
+							},
+						],
+					},
+				],
+				suggestedGasPrice: '1000',
+			}),
+		);
+
+		expect(response.suggestedGasPrice).toBe(1000n);
+		expect(response.transaction?.effects?.epoch).toBe(42n);
+		expectBytes(response.transaction?.transaction?.bcs?.value, [1, 2, 3, 4]);
+
+		const result = parseGrpcSimulateTransactionResponse(response, {
+			include: {
+				bcs: true,
+				commandResults: true,
+				events: true,
+				objectTypes: true,
+			},
+		});
+
+		expect(result.$kind).toBe('Transaction');
+		if (result.$kind !== 'Transaction') {
+			throw new Error('Expected Transaction result');
+		}
+
+		expect(result.Transaction.digest).toBe('transaction-digest');
+		expect(result.Transaction.epoch).toBe('42');
+		expectTypeOf(result.Transaction.bcs).toEqualTypeOf<Uint8Array>();
+		expectTypeOf(result.Transaction.events).toEqualTypeOf<SuiClientTypes.Event[]>();
+		expectTypeOf(result.Transaction.objectTypes).toEqualTypeOf<Record<string, string>>();
+		expectTypeOf(result.commandResults).toEqualTypeOf<SuiClientTypes.CommandResult[]>();
+		expect(result.Transaction.objectTypes).toEqual({
+			'0x2': '0x2::coin::Coin<0x2::sui::SUI>',
+		});
+		expectBytes(result.Transaction.bcs, [1, 2, 3, 4]);
+		expectBytes(result.Transaction.events?.[0]?.bcs, [5, 6, 7]);
+		expectBytes(result.commandResults?.[0]?.returnValues[0]?.bcs, [10, 11, 12]);
+		expectBytes(result.commandResults?.[0]?.mutatedReferences[0]?.bcs, [13, 14, 15]);
+
+		const defaultResult = parseGrpcSimulateTransactionResponse(response);
+		if (defaultResult.$kind === 'Transaction') {
+			expectTypeOf(defaultResult.Transaction.bcs).toEqualTypeOf<undefined>();
+			expectTypeOf(defaultResult.Transaction.events).toEqualTypeOf<undefined>();
+			expectTypeOf(defaultResult.commandResults).toEqualTypeOf<undefined>();
+		}
+
+		const transactionResult = parseGrpcTransactionResponse(response.transaction!, {
+			include: {
+				effects: true,
+			},
+		});
+		if (transactionResult.$kind === 'Transaction') {
+			expectTypeOf(
+				transactionResult.Transaction.effects,
+			).toEqualTypeOf<SuiClientTypes.TransactionEffects>();
+			expectTypeOf(transactionResult.Transaction.bcs).toEqualTypeOf<undefined>();
+		}
+	});
+
+	it('returns FailedTransaction for unsuccessful executed transactions', () => {
+		const response = GrpcTypes.ExecutedTransaction.create({
+			digest: 'failed-transaction-digest',
+			effects: {
+				status: {
+					success: false,
+				},
+			},
+		});
+
+		const result = parseGrpcTransactionResponse(response);
+
+		expect(result.$kind).toBe('FailedTransaction');
+		if (result.$kind !== 'FailedTransaction') {
+			throw new Error('Expected FailedTransaction result');
+		}
+
+		expect(result.FailedTransaction.digest).toBe('failed-transaction-digest');
+		expect(result.FailedTransaction.status).toEqual({
+			success: false,
+			error: {
+				$kind: 'Unknown',
+				message: 'Transaction failed',
+				Unknown: null,
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Description

Expose gRPC transaction response parsing helpers from `@mysten/sui/grpc`:

- `parseGrpcTransactionResponse` converts `GrpcTypes.ExecutedTransaction` into the SDK Core `TransactionResult` shape.
- `parseGrpcSimulateTransactionResponse` converts `GrpcTypes.SimulateTransactionResponse` into the SDK Core `SimulateTransactionResult` shape, including command output bytes when requested.
- `GrpcCoreClient` now uses the exported helpers internally so existing get/execute/simulate behavior stays on the same parser path.

This lets consumers parse canonical protobuf JSON with `GrpcTypes.SimulateTransactionResponse.fromJsonString(...)` and recover the strongly typed SDK transaction/simulation result.

## Test plan

- `pnpm install`
- `pnpm -F @mysten/utils build`
- `pnpm -F @mysten/bcs build`
- `pnpm -F @mysten/sui vitest run unit/grpc/parse-transaction-response.test.ts`
- `pnpm -F @mysten/sui test:typecheck`
- `pnpm -F @mysten/sui lint`
- `pnpm -F @mysten/sui build`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
