### PR TITLE
Add gRPC proto JSON transaction results

### DIFF
--- a/.changeset/grpc-client-proto-json.md
+++ b/.changeset/grpc-client-proto-json.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/sui': patch
+'@mysten/sui': minor
 ---
 
 Add gRPC client transaction results that include protobuf JSON with `include: { protoJson: true }`.

--- a/.changeset/grpc-client-proto-json.md
+++ b/.changeset/grpc-client-proto-json.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Add gRPC client transaction results that include protobuf JSON with `include: { protoJson: true }`.

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -57,6 +57,78 @@ export interface ListDynamicFieldsWithValueResponse<Include extends DynamicField
 	dynamicFields: DynamicFieldEntryWithValue<Include>[];
 }
 
+export interface GrpcTransactionInclude extends SuiClientTypes.TransactionInclude {
+	/** Include the parsed protobuf JSON value for the gRPC transaction response. */
+	protoJson?: boolean;
+}
+
+export interface GrpcSimulateTransactionInclude extends SuiClientTypes.SimulateTransactionInclude {
+	/** Include the parsed protobuf JSON value for the gRPC simulation response. */
+	protoJson?: boolean;
+}
+
+export type GrpcTransactionProtoJson = ReturnType<
+	typeof import('./proto/sui/rpc/v2/executed_transaction.js').ExecutedTransaction.toJson
+>;
+
+export type GrpcSimulateTransactionProtoJson = ReturnType<
+	typeof import('./proto/sui/rpc/v2/transaction_execution_service.js').SimulateTransactionResponse.toJson
+>;
+
+type ProtoJson<Include extends { protoJson?: boolean }, Json> = Include['protoJson'] extends true
+	? Json
+	: undefined;
+
+export type GrpcTransactionResult<Include extends GrpcTransactionInclude = {}> =
+	SuiClientTypes.TransactionResult<Include> & {
+		protoJson: ProtoJson<Include, GrpcTransactionProtoJson>;
+	};
+
+export type GrpcSimulateTransactionResult<Include extends GrpcSimulateTransactionInclude = {}> =
+	SuiClientTypes.SimulateTransactionResult<Include> & {
+		protoJson: ProtoJson<Include, GrpcSimulateTransactionProtoJson>;
+	};
+
+export interface GrpcGetTransactionOptions<
+	Include extends GrpcTransactionInclude = {},
+> extends SuiClientTypes.GetTransactionOptions<Include> {
+	include?: Include & GrpcTransactionInclude;
+}
+
+export interface GrpcWaitForTransactionByDigest<
+	Include extends GrpcTransactionInclude = {},
+> extends SuiClientTypes.WaitForTransactionByDigest<Include> {
+	include?: Include & GrpcTransactionInclude;
+}
+
+export interface GrpcWaitForTransactionByResult<
+	Include extends GrpcTransactionInclude = {},
+> extends SuiClientTypes.WaitForTransactionByResult<Include> {
+	include?: Include & GrpcTransactionInclude;
+}
+
+export type GrpcWaitForTransactionOptions<Include extends GrpcTransactionInclude = {}> =
+	| GrpcWaitForTransactionByDigest<Include>
+	| GrpcWaitForTransactionByResult<Include>;
+
+export interface GrpcExecuteTransactionOptions<
+	Include extends GrpcTransactionInclude = {},
+> extends SuiClientTypes.ExecuteTransactionOptions<Include> {
+	include?: Include & GrpcTransactionInclude;
+}
+
+export interface GrpcSignAndExecuteTransactionOptions<
+	Include extends GrpcTransactionInclude = {},
+> extends SuiClientTypes.SignAndExecuteTransactionOptions<Include> {
+	include?: Include & GrpcTransactionInclude;
+}
+
+export interface GrpcSimulateTransactionOptions<
+	Include extends GrpcSimulateTransactionInclude = {},
+> extends SuiClientTypes.SimulateTransactionOptions<Include> {
+	include?: Include & GrpcSimulateTransactionInclude;
+}
+
 export class SuiGrpcClient extends BaseClient implements SuiClientTypes.TransportMethods {
 	core: GrpcCoreClient;
 	get mvr(): SuiClientTypes.MvrMethods {
@@ -135,34 +207,34 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 		return this.core.getCoinMetadata(input);
 	}
 
-	getTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
-		input: SuiClientTypes.GetTransactionOptions<Include>,
-	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		return this.core.getTransaction(input);
+	getTransaction<Include extends GrpcTransactionInclude = {}>(
+		input: GrpcGetTransactionOptions<Include>,
+	): Promise<GrpcTransactionResult<Include>> {
+		return this.core.getTransaction(input) as Promise<GrpcTransactionResult<Include>>;
 	}
 
-	executeTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
-		input: SuiClientTypes.ExecuteTransactionOptions<Include>,
-	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		return this.core.executeTransaction(input);
+	executeTransaction<Include extends GrpcTransactionInclude = {}>(
+		input: GrpcExecuteTransactionOptions<Include>,
+	): Promise<GrpcTransactionResult<Include>> {
+		return this.core.executeTransaction(input) as Promise<GrpcTransactionResult<Include>>;
 	}
 
-	signAndExecuteTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
-		input: SuiClientTypes.SignAndExecuteTransactionOptions<Include>,
-	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		return this.core.signAndExecuteTransaction(input);
+	signAndExecuteTransaction<Include extends GrpcTransactionInclude = {}>(
+		input: GrpcSignAndExecuteTransactionOptions<Include>,
+	): Promise<GrpcTransactionResult<Include>> {
+		return this.core.signAndExecuteTransaction(input) as Promise<GrpcTransactionResult<Include>>;
 	}
 
-	waitForTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
-		input: SuiClientTypes.WaitForTransactionOptions<Include>,
-	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		return this.core.waitForTransaction(input);
+	waitForTransaction<Include extends GrpcTransactionInclude = {}>(
+		input: GrpcWaitForTransactionOptions<Include>,
+	): Promise<GrpcTransactionResult<Include>> {
+		return this.core.waitForTransaction(input) as Promise<GrpcTransactionResult<Include>>;
 	}
 
-	simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
-		input: SuiClientTypes.SimulateTransactionOptions<Include>,
-	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
-		return this.core.simulateTransaction(input);
+	simulateTransaction<Include extends GrpcSimulateTransactionInclude = {}>(
+		input: GrpcSimulateTransactionOptions<Include>,
+	): Promise<GrpcSimulateTransactionResult<Include>> {
+		return this.core.simulateTransaction(input) as Promise<GrpcSimulateTransactionResult<Include>>;
 	}
 
 	getReferenceGasPrice(): Promise<SuiClientTypes.GetReferenceGasPriceResponse> {

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -8,7 +8,6 @@ import type { SuiGrpcClient } from './client.js';
 import type { Owner } from './proto/sui/rpc/v2/owner.js';
 import { Owner_OwnerKind } from './proto/sui/rpc/v2/owner.js';
 import { chunk, fromBase64, toBase64 } from '@mysten/utils';
-import type { ExecutedTransaction } from './proto/sui/rpc/v2/executed_transaction.js';
 import type { TransactionEffects } from './proto/sui/rpc/v2/effects.js';
 import {
 	UnchangedConsensusObject_UnchangedConsensusObjectKind,
@@ -45,12 +44,16 @@ import {
 	grpcTransactionToTransactionData,
 } from '../client/transaction-resolver.js';
 import { Value } from './proto/google/protobuf/struct.js';
-import type { SimulateTransactionResponse } from './proto/sui/rpc/v2/transaction_execution_service.js';
-import { SimulateTransactionRequest_TransactionChecks } from './proto/sui/rpc/v2/transaction_execution_service.js';
+import { ExecutedTransaction } from './proto/sui/rpc/v2/executed_transaction.js';
+import {
+	SimulateTransactionRequest_TransactionChecks,
+	SimulateTransactionResponse,
+} from './proto/sui/rpc/v2/transaction_execution_service.js';
 
 export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
 }
+
 export class GrpcCoreClient extends CoreClient {
 	#client: SuiGrpcClient;
 	constructor({ client, ...options }: GrpcCoreClientOptions) {
@@ -331,37 +334,11 @@ export class GrpcCoreClient extends CoreClient {
 	async getTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.GetTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		const paths = ['digest', 'transaction.digest', 'signatures', 'effects.status'];
-		if (options.include?.transaction) {
-			paths.push(
-				'transaction.sender',
-				'transaction.gas_payment',
-				'transaction.expiration',
-				'transaction.kind',
-			);
-		}
-		if (options.include?.bcs) {
-			paths.push('transaction.bcs');
-		}
-		if (options.include?.balanceChanges) {
-			paths.push('balance_changes');
-		}
-		if (options.include?.effects) {
-			paths.push('effects');
-		}
-		if (options.include?.events) {
-			paths.push('events');
-		}
-		if (options.include?.objectTypes) {
-			paths.push('effects.changed_objects.object_type');
-			paths.push('effects.changed_objects.object_id');
-		}
-
 		const { response } = await this.#client.ledgerService.getTransaction(
 			{
 				digest: options.digest,
 				readMask: {
-					paths,
+					paths: transactionReadMaskPaths(options.include),
 				},
 			},
 			{ abort: options.signal },
@@ -371,37 +348,15 @@ export class GrpcCoreClient extends CoreClient {
 			throw new Error(`Transaction ${options.digest} not found`);
 		}
 
-		return parseGrpcTransactionResponse(response.transaction, { include: options.include });
+		return withProtoJson(
+			parseGrpcTransactionResponse(response.transaction, { include: options.include }),
+			options.include,
+			() => ExecutedTransaction.toJson(response.transaction!),
+		);
 	}
 	async executeTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.ExecuteTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		const paths = ['digest', 'transaction.digest', 'signatures', 'effects.status'];
-		if (options.include?.transaction) {
-			paths.push(
-				'transaction.sender',
-				'transaction.gas_payment',
-				'transaction.expiration',
-				'transaction.kind',
-			);
-		}
-		if (options.include?.bcs) {
-			paths.push('transaction.bcs');
-		}
-		if (options.include?.balanceChanges) {
-			paths.push('balance_changes');
-		}
-		if (options.include?.effects) {
-			paths.push('effects');
-		}
-		if (options.include?.events) {
-			paths.push('events');
-		}
-		if (options.include?.objectTypes) {
-			paths.push('effects.changed_objects.object_type');
-			paths.push('effects.changed_objects.object_id');
-		}
-
 		const { response } = await this.#client.transactionExecutionService.executeTransaction(
 			{
 				transaction: {
@@ -418,48 +373,22 @@ export class GrpcCoreClient extends CoreClient {
 					},
 				})),
 				readMask: {
-					paths,
+					paths: transactionReadMaskPaths(options.include),
 				},
 			},
 			{ abort: options.signal },
 		);
 
-		return parseGrpcTransactionResponse(response.transaction!, { include: options.include });
+		return withProtoJson(
+			parseGrpcTransactionResponse(response.transaction!, { include: options.include }),
+			options.include,
+			() => ExecutedTransaction.toJson(response.transaction!),
+		);
 	}
 	async simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
 		options: SuiClientTypes.SimulateTransactionOptions<Include>,
 	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
-		const paths = [
-			'transaction.digest',
-			'transaction.transaction.digest',
-			'transaction.signatures',
-			'transaction.effects.status',
-		];
-		if (options.include?.transaction) {
-			paths.push(
-				'transaction.transaction.sender',
-				'transaction.transaction.gas_payment',
-				'transaction.transaction.expiration',
-				'transaction.transaction.kind',
-			);
-		}
-		if (options.include?.bcs) {
-			paths.push('transaction.transaction.bcs');
-		}
-		if (options.include?.balanceChanges) {
-			paths.push('transaction.balance_changes');
-		}
-		if (options.include?.effects) {
-			paths.push('transaction.effects');
-		}
-		if (options.include?.events) {
-			paths.push('transaction.events');
-		}
-		if (options.include?.objectTypes) {
-			// Use effects.changed_objects to match JSON-RPC behavior (which uses objectChanges)
-			paths.push('transaction.effects.changed_objects.object_type');
-			paths.push('transaction.effects.changed_objects.object_id');
-		}
+		const paths = transactionReadMaskPaths(options.include, 'transaction.');
 		if (options.include?.commandResults) {
 			paths.push('command_outputs');
 		}
@@ -490,7 +419,11 @@ export class GrpcCoreClient extends CoreClient {
 			{ abort: options.signal },
 		);
 
-		return parseGrpcSimulateTransactionResponse(response, { include: options.include });
+		return withProtoJson(
+			parseGrpcSimulateTransactionResponse(response, { include: options.include }),
+			options.include,
+			() => SimulateTransactionResponse.toJson(response),
+		);
 	}
 	async getReferenceGasPrice(
 		options?: SuiClientTypes.GetReferenceGasPriceOptions,
@@ -841,6 +774,54 @@ export class GrpcCoreClient extends CoreClient {
 			return await next();
 		};
 	}
+}
+
+function transactionReadMaskPaths(
+	include: SuiClientTypes.TransactionInclude | undefined,
+	prefix = '',
+) {
+	const paths = ['digest', 'transaction.digest', 'signatures', 'effects.status'];
+	if (include?.transaction) {
+		paths.push(
+			'transaction.sender',
+			'transaction.gas_payment',
+			'transaction.expiration',
+			'transaction.kind',
+		);
+	}
+	if (include?.bcs) {
+		paths.push('transaction.bcs');
+	}
+	if (include?.balanceChanges) {
+		paths.push('balance_changes');
+	}
+	if (include?.effects) {
+		paths.push('effects');
+	}
+	if (include?.events) {
+		paths.push('events');
+	}
+	if (include?.objectTypes) {
+		paths.push('effects.changed_objects.object_type');
+		paths.push('effects.changed_objects.object_id');
+	}
+
+	return prefix ? paths.map((path) => prefix + path) : paths;
+}
+
+function withProtoJson<Result>(
+	result: Result,
+	include: ({ protoJson?: boolean } & object) | undefined,
+	getProtoJson: () => unknown,
+): Result {
+	if (!include?.protoJson) {
+		return result;
+	}
+
+	return {
+		...result,
+		protoJson: getProtoJson(),
+	};
 }
 
 function mapDisplayProto(

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -7,7 +7,20 @@ export {
 	parseGrpcSimulateTransactionResponse,
 	parseGrpcTransactionResponse,
 } from './core.js';
-export type { SuiGrpcClientOptions } from './client.js';
+export type {
+	GrpcExecuteTransactionOptions,
+	GrpcGetTransactionOptions,
+	GrpcSignAndExecuteTransactionOptions,
+	GrpcSimulateTransactionInclude,
+	GrpcSimulateTransactionOptions,
+	GrpcSimulateTransactionProtoJson,
+	GrpcSimulateTransactionResult,
+	GrpcTransactionInclude,
+	GrpcTransactionProtoJson,
+	GrpcTransactionResult,
+	GrpcWaitForTransactionOptions,
+	SuiGrpcClientOptions,
+} from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 
 // Re-export transports and types so users can configure custom transports

--- a/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
+++ b/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
@@ -8,6 +8,7 @@ import {
 	GrpcTypes,
 	parseGrpcSimulateTransactionResponse,
 	parseGrpcTransactionResponse,
+	SuiGrpcClient,
 } from '../../../src/grpc/index.js';
 
 function expectBytes(bytes: Uint8Array | undefined, expected: number[]) {
@@ -161,5 +162,121 @@ describe('gRPC transaction response parsers', () => {
 				Unknown: null,
 			},
 		});
+	});
+
+	it('includes protobuf JSON from top-level gRPC transaction methods', async () => {
+		const transaction = GrpcTypes.ExecutedTransaction.create({
+			digest: 'top-level-transaction-digest',
+			effects: {
+				status: {
+					success: true,
+				},
+			},
+		});
+		const simulation = GrpcTypes.SimulateTransactionResponse.create({
+			transaction,
+			suggestedGasPrice: 1000n,
+		});
+		const client = new SuiGrpcClient({
+			baseUrl: 'http://localhost',
+			network: 'testnet',
+		});
+
+		client.ledgerService.getTransaction = (async () => ({
+			response: {
+				transaction,
+			},
+		})) as never;
+		client.transactionExecutionService.executeTransaction = (async () => ({
+			response: {
+				transaction,
+			},
+		})) as never;
+		client.transactionExecutionService.simulateTransaction = (async () => ({
+			response: simulation,
+		})) as never;
+
+		const getResult = await client.getTransaction({
+			digest: 'top-level-transaction-digest',
+			include: {
+				protoJson: true,
+			},
+		});
+		expectTypeOf(getResult.protoJson).toEqualTypeOf<
+			ReturnType<typeof GrpcTypes.ExecutedTransaction.toJson>
+		>();
+		expect(GrpcTypes.ExecutedTransaction.fromJson(getResult.protoJson).digest).toBe(
+			'top-level-transaction-digest',
+		);
+
+		const defaultResult = await client.getTransaction({
+			digest: 'top-level-transaction-digest',
+		});
+		expectTypeOf(defaultResult.protoJson).toEqualTypeOf<undefined>();
+		expect(defaultResult.protoJson).toBeUndefined();
+
+		const executeResult = await client.executeTransaction({
+			transaction: new Uint8Array([1, 2, 3]),
+			signatures: ['AQID'],
+			include: {
+				protoJson: true,
+			},
+		});
+		expectTypeOf(executeResult.protoJson).toEqualTypeOf<
+			ReturnType<typeof GrpcTypes.ExecutedTransaction.toJson>
+		>();
+		expect(GrpcTypes.ExecutedTransaction.fromJson(executeResult.protoJson).digest).toBe(
+			'top-level-transaction-digest',
+		);
+
+		const signer = {
+			toSuiAddress: () => '0x1',
+			signTransaction: async () => ({
+				bytes: 'AQID',
+				signature: 'AQID',
+			}),
+		};
+		const signResult = await client.signAndExecuteTransaction({
+			transaction: new Uint8Array([1, 2, 3]),
+			signer: signer as never,
+			include: {
+				protoJson: true,
+			},
+		});
+		expectTypeOf(signResult.protoJson).toEqualTypeOf<
+			ReturnType<typeof GrpcTypes.ExecutedTransaction.toJson>
+		>();
+		expect(GrpcTypes.ExecutedTransaction.fromJson(signResult.protoJson).digest).toBe(
+			'top-level-transaction-digest',
+		);
+
+		const waitResult = await client.waitForTransaction({
+			digest: 'top-level-transaction-digest',
+			include: {
+				protoJson: true,
+			},
+			pollSchedule: [0],
+		});
+		expectTypeOf(waitResult.protoJson).toEqualTypeOf<
+			ReturnType<typeof GrpcTypes.ExecutedTransaction.toJson>
+		>();
+		expect(GrpcTypes.ExecutedTransaction.fromJson(waitResult.protoJson).digest).toBe(
+			'top-level-transaction-digest',
+		);
+
+		const simulateResult = await client.simulateTransaction({
+			transaction: new Uint8Array([1, 2, 3]),
+			include: {
+				protoJson: true,
+			},
+		});
+		expectTypeOf(simulateResult.protoJson).toEqualTypeOf<
+			ReturnType<typeof GrpcTypes.SimulateTransactionResponse.toJson>
+		>();
+		const parsedSimulation = GrpcTypes.SimulateTransactionResponse.fromJson(
+			simulateResult.protoJson,
+		);
+		expect(parsedSimulation.transaction?.digest).toBe('top-level-transaction-digest');
+		expect(parsedSimulation.suggestedGasPrice).toBe(1000n);
 	});
 });


### PR DESCRIPTION
## Description

- Add top-level `SuiGrpcClient` transaction include/result types for `include: { protoJson: true }`.
- Serialize executed transaction and simulation protobuf responses with generated protobuf JSON.
- Keep `GrpcCoreClient`'s public type surface on the shared core transaction result types while supporting the extra include at runtime.
- Align the transaction read-mask helper shape with PR #1137's `transactionReadMaskPaths(include, prefix?)`.

## Test plan

- `pnpm --filter @mysten/sui vitest run test/unit/grpc/parse-transaction-response.test.ts`
- `pnpm --filter @mysten/sui test:typecheck`
- `pnpm --filter @mysten/sui build`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.