### PR TITLE
[zklogin] support larger Poseidon inputs for v2

### DIFF
--- a/.changeset/flexible-rsa-poseidon.md
+++ b/.changeset/flexible-rsa-poseidon.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Extend zkLogin Poseidon hashing to support up to 64 inputs.

--- a/packages/sui/src/zklogin/poseidon.ts
+++ b/packages/sui/src/zklogin/poseidon.ts
@@ -54,10 +54,12 @@ export function poseidonHash(inputs: (number | bigint | string)[]): bigint {
 
 	if (hashFN) {
 		return hashFN(inputs);
-	} else if (inputs.length <= 32) {
-		const hash1 = poseidonHash(inputs.slice(0, 16));
-		const hash2 = poseidonHash(inputs.slice(16));
-		return poseidonHash([hash1, hash2]);
+	} else if (inputs.length > 16 && inputs.length <= 64) {
+		const chunkHashes = [];
+		for (let i = 0; i < inputs.length; i += 16) {
+			chunkHashes.push(poseidonHash(inputs.slice(i, i + 16)));
+		}
+		return poseidonHash(chunkHashes);
 	} else {
 		throw new Error(`Yet to implement: Unable to hash a vector of length ${inputs.length}`);
 	}

--- a/packages/sui/test/unit/zklogin/poseidon.test.ts
+++ b/packages/sui/test/unit/zklogin/poseidon.test.ts
@@ -15,6 +15,22 @@ test('can hash multiple inputs', () => {
 	expect(result).toBeTypeOf('bigint');
 });
 
+test.each([17, 32, 33, 48, 49, 64])('can hash %i inputs using 16-element chunks', (inputLength) => {
+	const inputs = Array.from({ length: inputLength }, (_, i) => BigInt(i));
+	const chunkHashes = [];
+	for (let i = 0; i < inputs.length; i += 16) {
+		chunkHashes.push(poseidonHash(inputs.slice(i, i + 16)));
+	}
+
+	expect(poseidonHash(inputs)).toBe(poseidonHash(chunkHashes));
+});
+
+test.each([0, 65])('throws error for unsupported input length %i', (inputLength) => {
+	expect(() => poseidonHash(Array(inputLength).fill(0))).toThrowError(
+		`Yet to implement: Unable to hash a vector of length ${inputLength}`,
+	);
+});
+
 test('throws error for invalid input', () => {
 	expect(() => poseidonHash([-1])).toThrowError('Element -1 not in the BN254 field');
 });


### PR DESCRIPTION
## Description

Extend `poseidonHash` to support 33–64 inputs using the same two-level, 16-input chunking scheme as the zkLogin v2 circuit. This supports packed commitments for RSA moduli up to 8192 bits while preserving the existing hashes for vectors of up to 32 inputs.

Linear: CRY-454
Circuit context: https://github.com/MystenLabs/zklogin-circuits/pull/227

## Test plan

- `corepack pnpm --filter @mysten/sui vitest run test/unit/zklogin/poseidon.test.ts`
- `corepack pnpm --filter @mysten/sui lint`
- Built `@mysten/utils`, `@mysten/bcs`, and `@mysten/sui` in dependency order

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.