### PR TITLE
Fix address balance gas expiration resolution

### DIFF
--- a/.changeset/address-balance-expiration.md
+++ b/.changeset/address-balance-expiration.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Set `ValidDuring` expiration when resolving transactions that explicitly use address-balance gas with an empty gas payment and preset gas budget.

--- a/packages/sui/src/client/address-balance-transaction-expiration.ts
+++ b/packages/sui/src/client/address-balance-transaction-expiration.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TransactionDataBuilder } from '../transactions/TransactionData.js';
+import type { TransactionData } from '../transactions/data/internal.js';
+import type { ClientWithCoreApi } from './core.js';
+
+export async function setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+	transactionData,
+	client,
+	epoch,
+	originalTransactionData,
+	isTransactionKindOnly,
+	doGasSelection,
+}: {
+	transactionData: TransactionDataBuilder;
+	client: ClientWithCoreApi;
+	epoch: string | number | bigint | null | undefined;
+	originalTransactionData: TransactionData;
+	isTransactionKindOnly: boolean;
+	doGasSelection: boolean;
+}) {
+	if (
+		isTransactionKindOnly ||
+		doGasSelection ||
+		originalTransactionData.expiration ||
+		originalTransactionData.gasData.payment?.length !== 0
+	) {
+		return;
+	}
+
+	if (transactionData.expiration && transactionData.expiration.$kind !== 'None') {
+		return;
+	}
+
+	const [{ chainIdentifier }, systemStateResult] = await Promise.all([
+		client.core.getChainIdentifier(),
+		epoch == null ? client.core.getCurrentSystemState() : null,
+	]);
+	const currentEpoch = BigInt(epoch ?? systemStateResult!.systemState.epoch);
+
+	transactionData.expiration = {
+		$kind: 'ValidDuring',
+		ValidDuring: {
+			minEpoch: String(currentEpoch),
+			maxEpoch: String(currentEpoch + 1n),
+			minTimestamp: null,
+			maxTimestamp: null,
+			chain: chainIdentifier,
+			nonce: (Math.random() * 0x100000000) >>> 0,
+		},
+	};
+}

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -44,6 +44,7 @@ import {
 	transactionToGrpcJson,
 	grpcTransactionToTransactionData,
 } from '../client/transaction-resolver.js';
+import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../client/address-balance-transaction-expiration.js';
 import { BalanceChange as BalanceChangeType } from '../grpc/proto/sui/rpc/v2/balance_change.js';
 import { TransactionEffects as TransactionEffectsType } from '../grpc/proto/sui/rpc/v2/effects.js';
 import { Transaction as GrpcTransactionType } from '../grpc/proto/sui/rpc/v2/transaction.js';
@@ -732,14 +733,15 @@ export class GraphQLCoreClient extends CoreClient {
 			}
 			const grpcTransaction = transactionDataToGrpcTransaction(snapshot);
 			const transactionJson = GrpcTransactionType.toJson(grpcTransaction);
+			const doGasSelection =
+				!options.onlyTransactionKind &&
+				(snapshot.gasData.budget == null || snapshot.gasData.payment == null);
 
 			const { data, errors } = await graphqlClient.query({
 				query: ResolveTransactionDocument,
 				variables: {
 					transaction: transactionJson,
-					doGasSelection:
-						!options.onlyTransactionKind &&
-						(snapshot.gasData.budget == null || snapshot.gasData.payment == null),
+					doGasSelection,
 					checksEnabled: !options.onlyTransactionKind,
 				},
 			});
@@ -780,6 +782,14 @@ export class GraphQLCoreClient extends CoreClient {
 			} else {
 				transactionData.applyResolvedData(resolved);
 			}
+			await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+				transactionData,
+				client: graphqlClient,
+				epoch: transactionEffects?.epoch?.epochId,
+				originalTransactionData: snapshot,
+				isTransactionKindOnly: !!options.onlyTransactionKind,
+				doGasSelection,
+			});
 
 			return await next();
 		};

--- a/packages/sui/src/graphql/generated/queries.ts
+++ b/packages/sui/src/graphql/generated/queries.ts
@@ -338,7 +338,7 @@ export type ResolveTransactionQueryVariables = Exact<{
 }>;
 
 
-export type ResolveTransactionQuery = { simulateTransaction: { effects: { transaction: { transactionBcs: string | null, effects: { status: ExecutionStatus | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null } | null } | null } | null } };
+export type ResolveTransactionQuery = { simulateTransaction: { effects: { transaction: { transactionBcs: string | null, effects: { status: ExecutionStatus | null, epoch: { epochId: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null } | null } | null } | null } };
 
 export type VerifyZkLoginSignatureQueryVariables = Exact<{
   bytes: string;
@@ -1153,6 +1153,9 @@ export const ResolveTransactionDocument = new TypedDocumentString(`
       transaction {
         transactionBcs
         effects {
+          epoch {
+            epochId
+          }
           status
           executionError {
             message

--- a/packages/sui/src/graphql/queries/transactions.graphql
+++ b/packages/sui/src/graphql/queries/transactions.graphql
@@ -157,6 +157,9 @@ query resolveTransaction(
 			transaction {
 				transactionBcs
 				effects {
+					epoch {
+						epochId
+					}
 					status
 					executionError {
 						message

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -43,6 +43,7 @@ import {
 	transactionToGrpcTransaction,
 	grpcTransactionToTransactionData,
 } from '../client/transaction-resolver.js';
+import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../client/address-balance-transaction-expiration.js';
 import { Value } from './proto/google/protobuf/struct.js';
 import { ExecutedTransaction } from './proto/sui/rpc/v2/executed_transaction.js';
 import {
@@ -720,14 +721,15 @@ export class GrpcCoreClient extends CoreClient {
 				snapshot.sender = '0x0000000000000000000000000000000000000000000000000000000000000000';
 			}
 			const grpcTransaction = transactionDataToGrpcTransaction(snapshot);
+			const doGasSelection =
+				!options.onlyTransactionKind &&
+				(snapshot.gasData.budget == null || snapshot.gasData.payment == null);
 
 			let response;
 			try {
 				const result = await client.transactionExecutionService.simulateTransaction({
 					transaction: grpcTransaction,
-					doGasSelection:
-						!options.onlyTransactionKind &&
-						(snapshot.gasData.budget == null || snapshot.gasData.payment == null),
+					doGasSelection,
 					// Kind-only txns are never executed directly and do not have sender, so skip validation checks.
 					checks: options.onlyTransactionKind
 						? SimulateTransactionRequest_TransactionChecks.DISABLED
@@ -739,6 +741,7 @@ export class GrpcCoreClient extends CoreClient {
 							'transaction.transaction.expiration',
 							'transaction.transaction.kind',
 							'transaction.effects.status',
+							'transaction.effects.epoch',
 						],
 					},
 				});
@@ -770,6 +773,14 @@ export class GrpcCoreClient extends CoreClient {
 			}
 
 			applyGrpcResolvedTransaction(transactionData, response.transaction.transaction, options);
+			await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+				transactionData,
+				client,
+				epoch: response.transaction.effects?.epoch,
+				originalTransactionData: snapshot,
+				isTransactionKindOnly: !!options.onlyTransactionKind,
+				doGasSelection,
+			});
 
 			return await next();
 		};

--- a/packages/sui/test/e2e/clients/core/transaction-resolution.test.ts
+++ b/packages/sui/test/e2e/clients/core/transaction-resolution.test.ts
@@ -2,10 +2,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { setup, TestToolbox, createTestWithAllClients } from '../../utils/setup.js';
+import {
+	setup,
+	TestToolbox,
+	createTestWithAllClients,
+	getRandomAddresses,
+} from '../../utils/setup.js';
 import { Transaction } from '../../../../src/transactions/index.js';
 import { SUI_TYPE_ARG } from '../../../../src/utils/index.js';
 import { bcs } from '../../../../src/bcs/index.js';
+
+const CLOCK_OBJECT_ID = '0x6';
+
+function addClockRead(tx: Transaction) {
+	tx.moveCall({
+		target: '0x2::clock::timestamp_ms',
+		arguments: [
+			tx.sharedObjectRef({
+				objectId: CLOCK_OBJECT_ID,
+				initialSharedVersion: '1',
+				mutable: false,
+			}),
+		],
+	});
+}
+
+function expectAddressBalanceTransactionExpiration(bytes: Uint8Array, budget: bigint) {
+	const parsed = bcs.TransactionData.parse(bytes);
+	const validDuring = parsed.V1?.expiration.ValidDuring;
+
+	expect(parsed.V1?.gasData.payment).toEqual([]);
+	expect(String(parsed.V1?.gasData.budget)).toBe(String(budget));
+	expect(Number(parsed.V1?.gasData.price)).toBeGreaterThan(0);
+	expect(validDuring).toBeDefined();
+	expect(validDuring?.chain).toEqual(expect.any(String));
+	expect(validDuring?.chain.length).toBeGreaterThan(0);
+	expect(validDuring?.nonce).toEqual(expect.any(Number));
+	expect(validDuring?.minEpoch).toEqual(expect.any(String));
+	expect(validDuring?.maxEpoch).toEqual(expect.any(String));
+	expect(BigInt(validDuring!.maxEpoch!)).toBe(BigInt(validDuring!.minEpoch!) + 1n);
+
+	return validDuring!;
+}
 
 /**
  * Transaction Resolution Test Suite
@@ -218,6 +256,136 @@ describe('Core API - Transaction Resolution', () => {
 			const parsed = bcs.TransactionData.parse(bytes);
 			expect(parsed.V1?.gasData.payment?.[0].objectId).toBe(explicitGasCoin.objectId);
 		});
+
+		testWithAllClients(
+			'should set ValidDuring expiration for address balance gas without selecting coins',
+			async (client) => {
+				const [sender, gasOwner] = getRandomAddresses(2);
+				const budget = 50_000_000n;
+
+				const tx = new Transaction();
+				addClockRead(tx);
+				tx.setSender(sender);
+				tx.setGasOwner(gasOwner);
+				tx.setGasPayment([]);
+				tx.setGasBudget(budget);
+
+				const bytes = await tx.build({ client });
+				expectAddressBalanceTransactionExpiration(bytes, budget);
+			},
+		);
+
+		testWithAllClients(
+			'should preserve explicit None expiration for address balance gas',
+			async (client) => {
+				const [sender, gasOwner] = getRandomAddresses(2);
+				const budget = 50_000_000n;
+
+				const tx = new Transaction();
+				addClockRead(tx);
+				tx.setSender(sender);
+				tx.setGasOwner(gasOwner);
+				tx.setGasPayment([]);
+				tx.setGasBudget(budget);
+				tx.setExpiration({ None: true });
+
+				const bytes = await tx.build({ client });
+				const parsed = bcs.TransactionData.parse(bytes);
+
+				expect(parsed.V1?.gasData.payment).toEqual([]);
+				expect(String(parsed.V1?.gasData.budget)).toBe(String(budget));
+				expect(Number(parsed.V1?.gasData.price)).toBeGreaterThan(0);
+				expect(parsed.V1?.expiration.None).toBe(true);
+				expect(tx.getData().expiration?.$kind).toBe('None');
+			},
+		);
+
+		testWithAllClients(
+			'should not synthesize ValidDuring when address balance gas request uses backend gas selection',
+			async (client) => {
+				const { address } = await toolbox.getSigner({ coins: [200_000_000n] });
+
+				const tx = new Transaction();
+				addClockRead(tx);
+				tx.setSender(address);
+				tx.setGasPayment([]);
+
+				const bytes = await tx.build({ client });
+				const parsed = bcs.TransactionData.parse(bytes);
+
+				expect(Number(parsed.V1?.gasData.budget)).toBeGreaterThan(0);
+				expect(Number(parsed.V1?.gasData.price)).toBeGreaterThan(0);
+				expect(parsed.V1?.expiration.ValidDuring).toBeUndefined();
+			},
+			{ skip: ['jsonrpc'] },
+		);
+
+		testWithAllClients(
+			'should execute resolved address balance gas transactions without gas coins',
+			async (client) => {
+				const { keypair, address } = await toolbox.getSigner({ addressBalance: 200_000_000n });
+				const budget = 50_000_000n;
+
+				const tx = new Transaction();
+				addClockRead(tx);
+				tx.setSender(address);
+				tx.setGasPayment([]);
+				tx.setGasBudget(budget);
+
+				const bytes = await tx.build({ client });
+				const validDuring = expectAddressBalanceTransactionExpiration(bytes, budget);
+
+				const simulation = await client.core.simulateTransaction({
+					transaction: bytes,
+					include: { effects: true, transaction: true },
+				});
+
+				if (simulation.$kind !== 'Transaction') {
+					throw new Error(
+						`Expected transaction simulation to succeed: ${
+							simulation.FailedTransaction.status.error?.message ?? 'unknown error'
+						}`,
+					);
+				}
+
+				expect(simulation.Transaction.effects?.status.success).toBe(true);
+				expect(
+					simulation.Transaction.transaction?.expiration &&
+						'ValidDuring' in simulation.Transaction.transaction.expiration,
+				).toBe(true);
+				if (simulation.Transaction.epoch != null) {
+					expect(BigInt(simulation.Transaction.epoch)).toBeGreaterThanOrEqual(
+						BigInt(validDuring.minEpoch!),
+					);
+					expect(BigInt(simulation.Transaction.epoch)).toBeLessThan(BigInt(validDuring.maxEpoch!));
+				}
+
+				const result = await client.core.signAndExecuteTransaction({
+					transaction: bytes,
+					signer: keypair,
+					include: { effects: true, transaction: true },
+				});
+
+				if (result.$kind !== 'Transaction') {
+					throw new Error(
+						`Expected transaction execution to succeed: ${
+							result.FailedTransaction.status.error?.message ?? 'unknown error'
+						}`,
+					);
+				}
+
+				expect(result.Transaction.effects?.status.success).toBe(true);
+				expect(
+					result.Transaction.transaction?.expiration &&
+						'ValidDuring' in result.Transaction.transaction.expiration,
+				).toBe(true);
+				expect(BigInt(result.Transaction.epoch!)).toBeGreaterThanOrEqual(
+					BigInt(validDuring.minEpoch!),
+				);
+				expect(BigInt(result.Transaction.epoch!)).toBeLessThan(BigInt(validDuring.maxEpoch!));
+				await toolbox.waitForTransaction({ result });
+			},
+		);
 	});
 
 	describe('Transaction Execution', () => {

--- a/packages/sui/test/unit/client/address-balance-transaction-expiration.test.ts
+++ b/packages/sui/test/unit/client/address-balance-transaction-expiration.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toBase58 } from '@mysten/bcs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../../../src/client/address-balance-transaction-expiration.js';
+import { TransactionDataBuilder } from '../../../src/transactions/TransactionData.js';
+import type { TransactionData } from '../../../src/transactions/data/internal.js';
+
+const MOCK_CHAIN_IDENTIFIER = toBase58(new Uint8Array(32).fill(1));
+
+function createClient() {
+	return {
+		core: {
+			getChainIdentifier: vi.fn().mockResolvedValue({
+				chainIdentifier: MOCK_CHAIN_IDENTIFIER,
+			}),
+			getCurrentSystemState: vi.fn().mockResolvedValue({
+				systemState: {
+					epoch: '20',
+					referenceGasPrice: '1000',
+				},
+			}),
+		},
+	};
+}
+
+function createTransactionData({
+	expiration = null,
+	payment = [],
+}: {
+	expiration?: TransactionData['expiration'];
+	payment?: TransactionData['gasData']['payment'];
+} = {}) {
+	return TransactionDataBuilder.restore({
+		version: 2,
+		sender: '0x' + '1'.repeat(64),
+		expiration,
+		gasData: {
+			budget: '1000000',
+			price: '1000',
+			owner: null,
+			payment,
+		},
+		inputs: [],
+		commands: [],
+	});
+}
+
+describe('setAddressBalanceTransactionExpirationFromSimulatedEpoch', () => {
+	it('sets ValidDuring when gas selection was disabled and the original transaction had no expiration', async () => {
+		const transactionData = createTransactionData({ expiration: { $kind: 'None', None: true } });
+		const originalTransactionData = createTransactionData({ expiration: null }).snapshot();
+		const client = createClient();
+
+		await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+			transactionData,
+			client: client as any,
+			epoch: '12',
+			originalTransactionData,
+			isTransactionKindOnly: false,
+			doGasSelection: false,
+		});
+
+		expect(transactionData.expiration?.$kind).toBe('ValidDuring');
+		expect(transactionData.expiration?.ValidDuring).toMatchObject({
+			minEpoch: '12',
+			maxEpoch: '13',
+			chain: MOCK_CHAIN_IDENTIFIER,
+		});
+		expect(client.core.getChainIdentifier).toHaveBeenCalledTimes(1);
+		expect(client.core.getCurrentSystemState).not.toHaveBeenCalled();
+	});
+
+	it('does not set ValidDuring when gas selection was enabled', async () => {
+		const transactionData = createTransactionData({ expiration: { $kind: 'None', None: true } });
+		const originalTransactionData = createTransactionData({ expiration: null }).snapshot();
+		const client = createClient();
+
+		await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+			transactionData,
+			client: client as any,
+			epoch: '12',
+			originalTransactionData,
+			isTransactionKindOnly: false,
+			doGasSelection: true,
+		});
+
+		expect(transactionData.expiration?.$kind).toBe('None');
+		expect(client.core.getChainIdentifier).not.toHaveBeenCalled();
+	});
+
+	it('does not set ValidDuring for transaction-kind-only resolution', async () => {
+		const transactionData = createTransactionData({ expiration: { $kind: 'None', None: true } });
+		const originalTransactionData = createTransactionData({ expiration: null }).snapshot();
+		const client = createClient();
+
+		await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+			transactionData,
+			client: client as any,
+			epoch: '12',
+			originalTransactionData,
+			isTransactionKindOnly: true,
+			doGasSelection: false,
+		});
+
+		expect(transactionData.expiration?.$kind).toBe('None');
+		expect(client.core.getChainIdentifier).not.toHaveBeenCalled();
+	});
+
+	it('falls back to current system state when simulation did not return an epoch', async () => {
+		const transactionData = createTransactionData({ expiration: { $kind: 'None', None: true } });
+		const originalTransactionData = createTransactionData({ expiration: null }).snapshot();
+		const client = createClient();
+
+		await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+			transactionData,
+			client: client as any,
+			epoch: null,
+			originalTransactionData,
+			isTransactionKindOnly: false,
+			doGasSelection: false,
+		});
+
+		expect(transactionData.expiration?.$kind).toBe('ValidDuring');
+		expect(transactionData.expiration?.ValidDuring).toMatchObject({
+			minEpoch: '20',
+			maxEpoch: '21',
+			chain: MOCK_CHAIN_IDENTIFIER,
+		});
+		expect(client.core.getChainIdentifier).toHaveBeenCalledTimes(1);
+		expect(client.core.getCurrentSystemState).toHaveBeenCalledTimes(1);
+	});
+
+	it('preserves explicit None expiration from the original transaction', async () => {
+		const transactionData = createTransactionData({ expiration: { $kind: 'None', None: true } });
+		const originalTransactionData = createTransactionData({
+			expiration: { $kind: 'None', None: true },
+		}).snapshot();
+		const client = createClient();
+
+		await setAddressBalanceTransactionExpirationFromSimulatedEpoch({
+			transactionData,
+			client: client as any,
+			epoch: '12',
+			originalTransactionData,
+			isTransactionKindOnly: false,
+			doGasSelection: false,
+		});
+
+		expect(transactionData.expiration?.$kind).toBe('None');
+		expect(client.core.getChainIdentifier).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Description

Addresses #1147 by setting `ValidDuring` transaction expiration when gRPC or GraphQL transaction resolution starts from an unset expiration, an explicit empty gas payment for address-balance gas, and a full-transaction simulate request that disabled backend gas selection.

The transport-specific resolvers request the simulation effects epoch and use it to set the same `ValidDuring` shape the backend uses for this transaction-expiration path. Explicit user-provided expiration values, including `{ None: true }`, are preserved, and the SDK does not synthesize expiration when resolving transaction kind bytes or when backend gas selection was enabled. If an older or partial simulate response omits the effects epoch, the helper falls back to `getCurrentSystemState()` only for this address-balance expiration path.

## Test plan

- `pnpm --filter @mysten/sui codegen:graphql`
- `pnpm --filter @mysten/sui test:typecheck`
- `pnpm --filter @mysten/sui oxlint:check`
- `pnpm --filter @mysten/sui test:unit`
- `pnpm --filter @mysten/sui vitest run --config test/e2e/vitest.config.mts test/e2e/clients/core/transaction-resolution.test.ts -t "address balance gas"`
- `pnpm prettier --check packages/sui/src/client/address-balance-transaction-expiration.ts packages/sui/src/grpc/core.ts packages/sui/src/graphql/core.ts packages/sui/src/graphql/generated/queries.ts packages/sui/src/graphql/queries/transactions.graphql packages/sui/test/unit/client/address-balance-transaction-expiration.test.ts packages/sui/test/e2e/clients/core/transaction-resolution.test.ts .changeset/address-balance-expiration.md`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.