### PR TITLE
feat(deepbook-v3): migrate margin builders to codegen named-args

### DIFF
--- a/.changeset/margin-codegen-migration.md
+++ b/.changeset/margin-codegen-migration.md
@@ -1,0 +1,14 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Internal refactor: the margin transaction builders now delegate to generated codegen bindings with
+named arguments instead of positional `moveCall` argument arrays, removing the risk of transposing
+same-typed arguments (base/quote oracles, base/quote margin pools). `deepbook_margin` and
+`margin_liquidation` were added to `sui-codegen.config.ts`; human-unit conversion and coin plumbing
+stay in the facade, so this is a pure construction-layer change.
+
+No API or behavior change: every migrated builder emits a byte-identical transaction, verified by a
+new PTB snapshot test (`test/unit/transactions/margin-ptb-snapshot.test.ts`). Two builders whose
+command/input interleaving does not reduce cleanly (`marginPool.supplyToMarginPool`,
+`marginAdmin.revokeMaintainerCap`) are intentionally left as positional `moveCall`s.

--- a/packages/deepbook-v3/CLAUDE.md
+++ b/packages/deepbook-v3/CLAUDE.md
@@ -178,11 +178,16 @@ pnpm --filter @mysten/deepbook-v3 codegen
    `Command "sui-ts-codegen" not found` or `ERR_MODULE_NOT_FOUND` on `@mysten/sui/dist/utils`. Fix:
    `pnpm turbo build --filter @mysten/codegen --filter @mysten/sui`, then **re-run `pnpm install`**
    — pnpm only links a workspace bin when its target file exists at install time, so the first
-   install silently skipped it. Both `@deepbook/core` and `@deepbook/margin` are generated
-   (path-based entries pointing at the `../deepbookv3` sibling); the hand-written builders delegate
-   to the generated named-argument functions (e.g. `poolProxy.placeMarketOrderAndRepayLoan` →
+   install silently skipped it. `@deepbook/core`, `@deepbook/margin`, and
+   `@deepbook/margin-liquidation` are all generated (path-based entries pointing at the
+   `../deepbookv3` sibling); the hand-written builders delegate to the generated named-argument
+   functions (e.g. `poolProxy.placeMarketOrderAndRepayLoan` →
    `contracts/deepbook_margin/pool_proxy`) so positional-arg transposition can't happen. Unit
-   conversion stays in the facade.
+   conversion stays in the facade. The full margin surface is migrated; a PTB byte-identity snapshot
+   test (`test/unit/transactions/margin-ptb-snapshot.test.ts`) guards that migrating a builder never
+   changes its emitted transaction. Two builders that don't reduce cleanly are kept as positional
+   moveCalls (documented in-code): `marginPool.supplyToMarginPool` and
+   `marginAdmin.revokeMaintainerCap`.
 2. **The pyth entry in `sui-codegen.config.ts` currently fails.** Its on-chain package `0xabf837e9…`
    resolves to `Object not found`, which aborts the CLI _after_ the `deepbook` package has been
    written. The deepbook output is complete and correct; only the trailing `pnpm lint:fix` is

--- a/packages/deepbook-v3/src/contracts/margin_liquidation/deps/sui/bag.ts
+++ b/packages/deepbook-v3/src/contracts/margin_liquidation/deps/sui/bag.ts
@@ -1,0 +1,41 @@
+/**************************************************************
+ * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+ **************************************************************/
+
+/**
+ * A bag is a heterogeneous map-like collection. The collection is similar to
+ * `sui::table` in that its keys and values are not stored within the `Bag` value,
+ * but instead are stored using Sui's object system. The `Bag` struct acts only as
+ * a handle into the object system to retrieve those keys and values. Note that
+ * this means that `Bag` values with exactly the same key-value mapping will not be
+ * equal, with `==`, at runtime. For example
+ *
+ * ```
+ * let bag1 = bag::new();
+ * let bag2 = bag::new();
+ * bag::add(&mut bag1, 0, false);
+ * bag::add(&mut bag1, 1, true);
+ * bag::add(&mut bag2, 0, false);
+ * bag::add(&mut bag2, 1, true);
+ * // bag1 does not equal bag2, despite having the same entries
+ * assert!(&bag1 != &bag2);
+ * ```
+ *
+ * At it's core, `sui::bag` is a wrapper around `UID` that allows for access to
+ * `sui::dynamic_field` while preventing accidentally stranding field values. A
+ * `UID` can be deleted, even if it has dynamic fields associated with it, but a
+ * bag, on the other hand, must be empty to be destroyed.
+ */
+
+import { MoveStruct } from '../../../utils/index.js';
+import { bcs } from '@mysten/sui/bcs';
+const $moduleName = '0x2::bag';
+export const Bag = new MoveStruct({
+	name: `${$moduleName}::Bag`,
+	fields: {
+		/** the ID of this bag */
+		id: bcs.Address,
+		/** the number of key-value pairs in the bag */
+		size: bcs.u64(),
+	},
+});

--- a/packages/deepbook-v3/src/contracts/margin_liquidation/liquidation_vault.ts
+++ b/packages/deepbook-v3/src/contracts/margin_liquidation/liquidation_vault.ts
@@ -1,0 +1,401 @@
+/**************************************************************
+ * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+ **************************************************************/
+import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
+import { bcs } from '@mysten/sui/bcs';
+import { type Transaction } from '@mysten/sui/transactions';
+import * as bag from './deps/sui/bag.js';
+const $moduleName = '@deepbook/margin-liquidation::liquidation_vault';
+export const LIQUIDATION_VAULT = new MoveStruct({
+	name: `${$moduleName}::LIQUIDATION_VAULT`,
+	fields: {
+		dummy_field: bcs.bool(),
+	},
+});
+export const LiquidationVault = new MoveStruct({
+	name: `${$moduleName}::LiquidationVault`,
+	fields: {
+		id: bcs.Address,
+		vault: bag.Bag,
+	},
+});
+export const BalanceKey = new MoveStruct({
+	name: `${$moduleName}::BalanceKey<phantom T>`,
+	fields: {
+		dummy_field: bcs.bool(),
+	},
+});
+export const AuthorizedTradersKey = new MoveStruct({
+	name: `${$moduleName}::AuthorizedTradersKey`,
+	fields: {
+		dummy_field: bcs.bool(),
+	},
+});
+export const LiquidationAdminCap = new MoveStruct({
+	name: `${$moduleName}::LiquidationAdminCap`,
+	fields: {
+		id: bcs.Address,
+	},
+});
+export const LiquidationByVault = new MoveStruct({
+	name: `${$moduleName}::LiquidationByVault`,
+	fields: {
+		vault_id: bcs.Address,
+		margin_manager_id: bcs.Address,
+		margin_pool_id: bcs.Address,
+		base_in: bcs.u64(),
+		base_out: bcs.u64(),
+		quote_in: bcs.u64(),
+		quote_out: bcs.u64(),
+		repay_balance_remaining: bcs.u64(),
+		base_liquidation: bcs.bool(),
+	},
+});
+export interface DepositArguments {
+	self: RawTransactionArgument<string>;
+	LiquidationCap: RawTransactionArgument<string>;
+	coin: RawTransactionArgument<string>;
+}
+export interface DepositOptions {
+	package?: string;
+	arguments:
+		| DepositArguments
+		| [
+				self: RawTransactionArgument<string>,
+				LiquidationCap: RawTransactionArgument<string>,
+				coin: RawTransactionArgument<string>,
+		  ];
+	typeArguments: [string];
+}
+export function deposit(options: DepositOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, null] satisfies (string | null)[];
+	const parameterNames = ['self', 'LiquidationCap', 'coin'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'deposit',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface WithdrawArguments {
+	self: RawTransactionArgument<string>;
+	LiquidationCap: RawTransactionArgument<string>;
+	amount: RawTransactionArgument<number | bigint>;
+}
+export interface WithdrawOptions {
+	package?: string;
+	arguments:
+		| WithdrawArguments
+		| [
+				self: RawTransactionArgument<string>,
+				LiquidationCap: RawTransactionArgument<string>,
+				amount: RawTransactionArgument<number | bigint>,
+		  ];
+	typeArguments: [string];
+}
+export function withdraw(options: WithdrawOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, 'u64'] satisfies (string | null)[];
+	const parameterNames = ['self', 'LiquidationCap', 'amount'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'withdraw',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface CreateLiquidationVaultArguments {
+	LiquidationCap: RawTransactionArgument<string>;
+}
+export interface CreateLiquidationVaultOptions {
+	package?: string;
+	arguments: CreateLiquidationVaultArguments | [LiquidationCap: RawTransactionArgument<string>];
+}
+export function createLiquidationVault(options: CreateLiquidationVaultOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null] satisfies (string | null)[];
+	const parameterNames = ['LiquidationCap'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'create_liquidation_vault',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface AuthorizeTraderArguments {
+	self: RawTransactionArgument<string>;
+	LiquidationCap: RawTransactionArgument<string>;
+	authorizedAddress: RawTransactionArgument<string>;
+}
+export interface AuthorizeTraderOptions {
+	package?: string;
+	arguments:
+		| AuthorizeTraderArguments
+		| [
+				self: RawTransactionArgument<string>,
+				LiquidationCap: RawTransactionArgument<string>,
+				authorizedAddress: RawTransactionArgument<string>,
+		  ];
+}
+export function authorizeTrader(options: AuthorizeTraderOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, 'address'] satisfies (string | null)[];
+	const parameterNames = ['self', 'LiquidationCap', 'authorizedAddress'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'authorize_trader',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface DeauthorizeTraderArguments {
+	self: RawTransactionArgument<string>;
+	LiquidationCap: RawTransactionArgument<string>;
+	authorizedAddress: RawTransactionArgument<string>;
+}
+export interface DeauthorizeTraderOptions {
+	package?: string;
+	arguments:
+		| DeauthorizeTraderArguments
+		| [
+				self: RawTransactionArgument<string>,
+				LiquidationCap: RawTransactionArgument<string>,
+				authorizedAddress: RawTransactionArgument<string>,
+		  ];
+}
+export function deauthorizeTrader(options: DeauthorizeTraderOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, 'address'] satisfies (string | null)[];
+	const parameterNames = ['self', 'LiquidationCap', 'authorizedAddress'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'deauthorize_trader',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface SwapBaseToQuoteArguments {
+	self: RawTransactionArgument<string>;
+	pool: RawTransactionArgument<string>;
+	baseIn: RawTransactionArgument<number | bigint>;
+	deepIn: RawTransactionArgument<number | bigint>;
+	minQuoteOut: RawTransactionArgument<number | bigint>;
+}
+export interface SwapBaseToQuoteOptions {
+	package?: string;
+	arguments:
+		| SwapBaseToQuoteArguments
+		| [
+				self: RawTransactionArgument<string>,
+				pool: RawTransactionArgument<string>,
+				baseIn: RawTransactionArgument<number | bigint>,
+				deepIn: RawTransactionArgument<number | bigint>,
+				minQuoteOut: RawTransactionArgument<number | bigint>,
+		  ];
+	typeArguments: [string, string];
+}
+export function swapBaseToQuote(options: SwapBaseToQuoteOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, 'u64', 'u64', 'u64', '0x2::clock::Clock'] satisfies (
+		| string
+		| null
+	)[];
+	const parameterNames = ['self', 'pool', 'baseIn', 'deepIn', 'minQuoteOut'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'swap_base_to_quote',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface SwapQuoteToBaseArguments {
+	self: RawTransactionArgument<string>;
+	pool: RawTransactionArgument<string>;
+	quoteIn: RawTransactionArgument<number | bigint>;
+	deepIn: RawTransactionArgument<number | bigint>;
+	minBaseOut: RawTransactionArgument<number | bigint>;
+}
+export interface SwapQuoteToBaseOptions {
+	package?: string;
+	arguments:
+		| SwapQuoteToBaseArguments
+		| [
+				self: RawTransactionArgument<string>,
+				pool: RawTransactionArgument<string>,
+				quoteIn: RawTransactionArgument<number | bigint>,
+				deepIn: RawTransactionArgument<number | bigint>,
+				minBaseOut: RawTransactionArgument<number | bigint>,
+		  ];
+	typeArguments: [string, string];
+}
+export function swapQuoteToBase(options: SwapQuoteToBaseOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null, null, 'u64', 'u64', 'u64', '0x2::clock::Clock'] satisfies (
+		| string
+		| null
+	)[];
+	const parameterNames = ['self', 'pool', 'quoteIn', 'deepIn', 'minBaseOut'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'swap_quote_to_base',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface LiquidateBaseArguments {
+	self: RawTransactionArgument<string>;
+	marginManager: RawTransactionArgument<string>;
+	registry: RawTransactionArgument<string>;
+	baseOracle: RawTransactionArgument<string>;
+	quoteOracle: RawTransactionArgument<string>;
+	baseMarginPool: RawTransactionArgument<string>;
+	quoteMarginPool: RawTransactionArgument<string>;
+	pool: RawTransactionArgument<string>;
+	repayAmount: RawTransactionArgument<number | bigint | null>;
+}
+export interface LiquidateBaseOptions {
+	package?: string;
+	arguments:
+		| LiquidateBaseArguments
+		| [
+				self: RawTransactionArgument<string>,
+				marginManager: RawTransactionArgument<string>,
+				registry: RawTransactionArgument<string>,
+				baseOracle: RawTransactionArgument<string>,
+				quoteOracle: RawTransactionArgument<string>,
+				baseMarginPool: RawTransactionArgument<string>,
+				quoteMarginPool: RawTransactionArgument<string>,
+				pool: RawTransactionArgument<string>,
+				repayAmount: RawTransactionArgument<number | bigint | null>,
+		  ];
+	typeArguments: [string, string];
+}
+export function liquidateBase(options: LiquidateBaseOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		'0x1::option::Option<u64>',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = [
+		'self',
+		'marginManager',
+		'registry',
+		'baseOracle',
+		'quoteOracle',
+		'baseMarginPool',
+		'quoteMarginPool',
+		'pool',
+		'repayAmount',
+	];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'liquidate_base',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface LiquidateQuoteArguments {
+	self: RawTransactionArgument<string>;
+	marginManager: RawTransactionArgument<string>;
+	registry: RawTransactionArgument<string>;
+	baseOracle: RawTransactionArgument<string>;
+	quoteOracle: RawTransactionArgument<string>;
+	baseMarginPool: RawTransactionArgument<string>;
+	quoteMarginPool: RawTransactionArgument<string>;
+	pool: RawTransactionArgument<string>;
+	repayAmount: RawTransactionArgument<number | bigint | null>;
+}
+export interface LiquidateQuoteOptions {
+	package?: string;
+	arguments:
+		| LiquidateQuoteArguments
+		| [
+				self: RawTransactionArgument<string>,
+				marginManager: RawTransactionArgument<string>,
+				registry: RawTransactionArgument<string>,
+				baseOracle: RawTransactionArgument<string>,
+				quoteOracle: RawTransactionArgument<string>,
+				baseMarginPool: RawTransactionArgument<string>,
+				quoteMarginPool: RawTransactionArgument<string>,
+				pool: RawTransactionArgument<string>,
+				repayAmount: RawTransactionArgument<number | bigint | null>,
+		  ];
+	typeArguments: [string, string];
+}
+export function liquidateQuote(options: LiquidateQuoteOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		null,
+		'0x1::option::Option<u64>',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = [
+		'self',
+		'marginManager',
+		'registry',
+		'baseOracle',
+		'quoteOracle',
+		'baseMarginPool',
+		'quoteMarginPool',
+		'pool',
+		'repayAmount',
+	];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'liquidate_quote',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}
+export interface BalanceArguments {
+	self: RawTransactionArgument<string>;
+}
+export interface BalanceOptions {
+	package?: string;
+	arguments: BalanceArguments | [self: RawTransactionArgument<string>];
+	typeArguments: [string];
+}
+export function balance(options: BalanceOptions) {
+	const packageAddress = options.package ?? '@deepbook/margin-liquidation';
+	const argumentsTypes = [null] satisfies (string | null)[];
+	const parameterNames = ['self'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'liquidation_vault',
+			function: 'balance',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			typeArguments: options.typeArguments,
+		});
+}

--- a/packages/deepbook-v3/src/transactions/marginAdmin.ts
+++ b/packages/deepbook-v3/src/transactions/marginAdmin.ts
@@ -10,6 +10,8 @@ import { FLOAT_SCALAR } from '../utils/config.js';
 import { convertRate } from '../utils/conversion.js';
 import { hexToBytes } from '@noble/hashes/utils.js';
 import * as marginRegistryMoveCalls from '../contracts/deepbook_margin/margin_registry.js';
+import * as marginPoolMoveCalls from '../contracts/deepbook_margin/margin_pool.js';
+import * as oracleMoveCalls from '../contracts/deepbook_margin/oracle.js';
 
 /**
  * MarginAdminContract class for managing admin actions.
@@ -41,14 +43,12 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	mintMaintainerCap = () => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::mint_maintainer_cap`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object.clock(),
-			],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.mintMaintainerCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, AdminCap: this.#marginAdminCap() },
+			}),
+		);
 	};
 
 	/**
@@ -56,6 +56,10 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	revokeMaintainerCap = (maintainerCapId: string) => (tx: Transaction) => {
+		// NOTE: left as a positional moveCall (not codegen). The original passes
+		// `maintainerCapId` as an object reference (`tx.object`), whereas the
+		// generated binding encodes it as a pure `ID` value — migrating would change
+		// the emitted PTB. Kept verbatim to stay byte-identical.
 		tx.moveCall({
 			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::revoke_maintainer_cap`,
 			arguments: [
@@ -78,17 +82,18 @@ export class MarginAdminContract {
 			const pool = this.#config.getPool(poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::register_deepbook_pool`,
-				arguments: [
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(this.#marginAdminCap()),
-					tx.object(pool.address),
-					poolConfig,
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				marginRegistryMoveCalls.registerDeepbookPool({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: this.#config.MARGIN_REGISTRY_ID,
+						AdminCap: this.#marginAdminCap(),
+						pool: pool.address,
+						poolConfig,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -100,16 +105,17 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::enable_deepbook_pool`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.enableDeepbookPool({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -121,16 +127,17 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::disable_deepbook_pool`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.disableDeepbookPool({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -143,17 +150,18 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::update_risk_params`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				poolConfig,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.updateRiskParams({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+					poolConfig,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -170,17 +178,18 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::set_price_tolerance`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				tx.pure.u64(convertRate(tolerance, FLOAT_SCALAR)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.setPriceTolerance({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+					tolerance: convertRate(tolerance, FLOAT_SCALAR),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -195,17 +204,18 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::set_max_price_age`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				tx.pure.u64(maxAgeMs),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.setMaxPriceAge({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+					maxAgeMs,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -222,17 +232,18 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::set_max_order_ttl`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object(pool.address),
-				tx.pure.u64(maxOrderTtlMs),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.setMaxOrderTtl({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pool: pool.address,
+					maxOrderTtlMs,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -270,15 +281,17 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	addConfig = (config: TransactionArgument) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::add_config`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				config,
-			],
-			typeArguments: [`${this.#config.MARGIN_PACKAGE_ID}::oracle::PythConfig`],
-		});
+		tx.add(
+			marginRegistryMoveCalls.addConfig({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					config,
+				},
+				typeArguments: [`${this.#config.MARGIN_PACKAGE_ID}::oracle::PythConfig`],
+			}),
+		);
 	};
 
 	/**
@@ -287,11 +300,13 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	removeConfig = () => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::remove_config`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.object(this.#marginAdminCap())],
-			typeArguments: [`${this.#config.MARGIN_PACKAGE_ID}::oracle::PythConfig`],
-		});
+		tx.add(
+			marginRegistryMoveCalls.removeConfig({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, AdminCap: this.#marginAdminCap() },
+				typeArguments: [`${this.#config.MARGIN_PACKAGE_ID}::oracle::PythConfig`],
+			}),
+		);
 	};
 
 	/**
@@ -300,14 +315,16 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	enableVersion = (version: number) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::enable_version`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(version),
-				tx.object(this.#marginAdminCap()),
-			],
-		});
+		tx.add(
+			marginRegistryMoveCalls.enableVersion({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					version,
+					AdminCap: this.#marginAdminCap(),
+				},
+			}),
+		);
 	};
 
 	/**
@@ -316,14 +333,16 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	disableVersion = (version: number) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::disable_version`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(version),
-				tx.object(this.#marginAdminCap()),
-			],
-		});
+		tx.add(
+			marginRegistryMoveCalls.disableVersion({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					version,
+					AdminCap: this.#marginAdminCap(),
+				},
+			}),
+		);
 	};
 
 	/**
@@ -344,19 +363,21 @@ export class MarginAdminContract {
 			userLiquidationReward,
 			poolLiquidationReward,
 		} = poolConfigParams;
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::new_pool_config`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(convertRate(minWithdrawRiskRatio, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(minBorrowRiskRatio, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(liquidationRiskRatio, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(targetLiquidationRiskRatio, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(userLiquidationReward, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(poolLiquidationReward, FLOAT_SCALAR)),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.newPoolConfig({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					minWithdrawRiskRatio: convertRate(minWithdrawRiskRatio, FLOAT_SCALAR),
+					minBorrowRiskRatio: convertRate(minBorrowRiskRatio, FLOAT_SCALAR),
+					liquidationRiskRatio: convertRate(liquidationRiskRatio, FLOAT_SCALAR),
+					targetLiquidationRiskRatio: convertRate(targetLiquidationRiskRatio, FLOAT_SCALAR),
+					userLiquidationReward: convertRate(userLiquidationReward, FLOAT_SCALAR),
+					poolLiquidationReward: convertRate(poolLiquidationReward, FLOAT_SCALAR),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -369,14 +390,16 @@ export class MarginAdminContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::new_pool_config_with_leverage`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(convertRate(leverage, FLOAT_SCALAR)),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginRegistryMoveCalls.newPoolConfigWithLeverage({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					leverage: convertRate(leverage, FLOAT_SCALAR),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -395,16 +418,18 @@ export class MarginAdminContract {
 			const priceFeedInput = new Uint8Array(
 				hexToBytes(coin['feed']!.startsWith('0x') ? coin.feed!.slice(2) : coin['feed']),
 			);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::oracle::new_coin_type_data_from_currency`,
-				arguments: [
-					tx.object(coin.currencyId!),
-					tx.pure.vector('u8', priceFeedInput),
-					tx.pure.u64(maxConfBps),
-					tx.pure.u64(maxEwmaDifferenceBps),
-				],
-				typeArguments: [coin.type],
-			});
+			return tx.add(
+				oracleMoveCalls.newCoinTypeDataFromCurrency({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						currency: coin.currencyId!,
+						priceFeedId: Array.from(priceFeedInput),
+						maxConfBps,
+						maxEwmaDifferenceBps,
+					},
+					typeArguments: [coin.type],
+				}),
+			);
 		};
 
 	/**
@@ -425,16 +450,18 @@ export class MarginAdminContract {
 					this.newCoinTypeData(setup.coinKey, setup.maxConfBps, setup.maxEwmaDifferenceBps)(tx),
 				);
 			}
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::oracle::new_pyth_config`,
-				arguments: [
-					tx.makeMoveVec({
-						elements: coinTypeDataList,
-						type: `${this.#config.MARGIN_PACKAGE_ID}::oracle::CoinTypeData`,
-					}),
-					tx.pure.u64(maxAgeSeconds),
-				],
-			});
+			return tx.add(
+				oracleMoveCalls.newPythConfig({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						setups: tx.makeMoveVec({
+							elements: coinTypeDataList,
+							type: `${this.#config.MARGIN_PACKAGE_ID}::oracle::CoinTypeData`,
+						}),
+						maxAgeSecs: maxAgeSeconds,
+					},
+				}),
+			);
 		};
 
 	/**
@@ -442,14 +469,12 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	mintPauseCap = () => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::mint_pause_cap`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object.clock(),
-			],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.mintPauseCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, AdminCap: this.#marginAdminCap() },
+			}),
+		);
 	};
 
 	/**
@@ -458,15 +483,16 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	revokePauseCap = (pauseCapId: string) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::revoke_pause_cap`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-				tx.object.clock(),
-				tx.pure.id(pauseCapId),
-			],
-		});
+		tx.add(
+			marginRegistryMoveCalls.revokePauseCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+					pauseCapId,
+				},
+			}),
+		);
 	};
 
 	/**
@@ -476,14 +502,16 @@ export class MarginAdminContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	disableVersionPauseCap = (version: number, pauseCapId: string) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::disable_version_pause_cap`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(version),
-				tx.object(pauseCapId),
-			],
-		});
+		tx.add(
+			marginRegistryMoveCalls.disableVersionPauseCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: this.#config.MARGIN_REGISTRY_ID,
+					version,
+					pauseCap: pauseCapId,
+				},
+			}),
+		);
 	};
 
 	/**
@@ -495,14 +523,16 @@ export class MarginAdminContract {
 	adminWithdrawDefaultReferralFees = (coinKey: string) => (tx: Transaction) => {
 		const coin = this.#config.getCoin(coinKey);
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::admin_withdraw_default_referral_fees`,
-			arguments: [
-				tx.object(marginPool.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(this.#marginAdminCap()),
-			],
-			typeArguments: [coin.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.adminWithdrawDefaultReferralFees({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: marginPool.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					AdminCap: this.#marginAdminCap(),
+				},
+				typeArguments: [coin.type],
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/src/transactions/marginLiquidations.ts
+++ b/packages/deepbook-v3/src/transactions/marginLiquidations.ts
@@ -5,6 +5,7 @@ import { coinWithBalance } from '@mysten/sui/transactions';
 
 import type { DeepBookConfig } from '../utils/config.js';
 import { convertQuantity } from '../utils/conversion.js';
+import * as liquidationVaultMoveCalls from '../contracts/margin_liquidation/liquidation_vault.js';
 
 /**
  * MarginLiquidationsContract class for managing LiquidationVault operations.
@@ -25,10 +26,12 @@ export class MarginLiquidationsContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	createLiquidationVault = (liquidationAdminCap: string) => (tx: Transaction) => {
-		tx.moveCall({
-			target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::create_liquidation_vault`,
-			arguments: [tx.object(liquidationAdminCap)],
-		});
+		tx.add(
+			liquidationVaultMoveCalls.createLiquidationVault({
+				package: this.#config.LIQUIDATION_PACKAGE_ID,
+				arguments: { LiquidationCap: liquidationAdminCap },
+			}),
+		);
 	};
 
 	/**
@@ -47,11 +50,13 @@ export class MarginLiquidationsContract {
 				type: coin.type,
 				balance: convertQuantity(amount, coin.scalar),
 			});
-			tx.moveCall({
-				target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::deposit`,
-				arguments: [tx.object(vaultId), tx.object(liquidationAdminCap), depositCoin],
-				typeArguments: [coin.type],
-			});
+			tx.add(
+				liquidationVaultMoveCalls.deposit({
+					package: this.#config.LIQUIDATION_PACKAGE_ID,
+					arguments: { self: vaultId, LiquidationCap: liquidationAdminCap, coin: depositCoin },
+					typeArguments: [coin.type],
+				}),
+			);
 		};
 
 	/**
@@ -66,15 +71,17 @@ export class MarginLiquidationsContract {
 		(vaultId: string, liquidationAdminCap: string, coinKey: string, amount: number) =>
 		(tx: Transaction) => {
 			const coin = this.#config.getCoin(coinKey);
-			return tx.moveCall({
-				target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::withdraw`,
-				arguments: [
-					tx.object(vaultId),
-					tx.object(liquidationAdminCap),
-					tx.pure.u64(convertQuantity(amount, coin.scalar)),
-				],
-				typeArguments: [coin.type],
-			});
+			return tx.add(
+				liquidationVaultMoveCalls.withdraw({
+					package: this.#config.LIQUIDATION_PACKAGE_ID,
+					arguments: {
+						self: vaultId,
+						LiquidationCap: liquidationAdminCap,
+						amount: convertQuantity(amount, coin.scalar),
+					},
+					typeArguments: [coin.type],
+				}),
+			);
 		};
 
 	/**
@@ -94,27 +101,30 @@ export class MarginLiquidationsContract {
 			const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 			const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 
+			// Build the Option arg first so its pure input registers ahead of the
+			// object inputs (matches the original positional ordering — byte-identical).
 			const repayAmountArg =
 				repayAmount !== undefined
 					? tx.pure.option('u64', convertQuantity(repayAmount, baseCoin.scalar))
 					: tx.pure.option('u64', null);
 
-			tx.moveCall({
-				target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::liquidate_base`,
-				arguments: [
-					tx.object(vaultId),
-					tx.object(managerAddress),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(baseCoin.priceInfoObjectId!),
-					tx.object(quoteCoin.priceInfoObjectId!),
-					tx.object(baseMarginPool.address),
-					tx.object(quoteMarginPool.address),
-					tx.object(pool.address),
-					repayAmountArg,
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				liquidationVaultMoveCalls.liquidateBase({
+					package: this.#config.LIQUIDATION_PACKAGE_ID,
+					arguments: {
+						self: vaultId,
+						marginManager: managerAddress,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						baseOracle: baseCoin.priceInfoObjectId!,
+						quoteOracle: quoteCoin.priceInfoObjectId!,
+						baseMarginPool: baseMarginPool.address,
+						quoteMarginPool: quoteMarginPool.address,
+						pool: pool.address,
+						repayAmount: repayAmountArg,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -134,27 +144,30 @@ export class MarginLiquidationsContract {
 			const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 			const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 
+			// Build the Option arg first so its pure input registers ahead of the
+			// object inputs (matches the original positional ordering — byte-identical).
 			const repayAmountArg =
 				repayAmount !== undefined
 					? tx.pure.option('u64', convertQuantity(repayAmount, quoteCoin.scalar))
 					: tx.pure.option('u64', null);
 
-			tx.moveCall({
-				target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::liquidate_quote`,
-				arguments: [
-					tx.object(vaultId),
-					tx.object(managerAddress),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(baseCoin.priceInfoObjectId!),
-					tx.object(quoteCoin.priceInfoObjectId!),
-					tx.object(baseMarginPool.address),
-					tx.object(quoteMarginPool.address),
-					tx.object(pool.address),
-					repayAmountArg,
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				liquidationVaultMoveCalls.liquidateQuote({
+					package: this.#config.LIQUIDATION_PACKAGE_ID,
+					arguments: {
+						self: vaultId,
+						marginManager: managerAddress,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						baseOracle: baseCoin.priceInfoObjectId!,
+						quoteOracle: quoteCoin.priceInfoObjectId!,
+						baseMarginPool: baseMarginPool.address,
+						quoteMarginPool: quoteMarginPool.address,
+						pool: pool.address,
+						repayAmount: repayAmountArg,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	// === Read-Only Functions ===
@@ -167,10 +180,12 @@ export class MarginLiquidationsContract {
 	 */
 	balance = (vaultId: string, coinKey: string) => (tx: Transaction) => {
 		const coin = this.#config.getCoin(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.LIQUIDATION_PACKAGE_ID}::liquidation_vault::balance`,
-			arguments: [tx.object(vaultId)],
-			typeArguments: [coin.type],
-		});
+		return tx.add(
+			liquidationVaultMoveCalls.balance({
+				package: this.#config.LIQUIDATION_PACKAGE_ID,
+				arguments: { self: vaultId },
+				typeArguments: [coin.type],
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/src/transactions/marginMaintainer.ts
+++ b/packages/deepbook-v3/src/transactions/marginMaintainer.ts
@@ -11,6 +11,8 @@ import type { DeepBookConfig } from '../utils/config.js';
 import type { MarginPoolConfigParams, InterestConfigParams } from '../types/index.js';
 import { FLOAT_SCALAR } from '../utils/config.js';
 import { convertQuantity, convertRate } from '../utils/conversion.js';
+import * as marginPoolMoveCalls from '../contracts/deepbook_margin/margin_pool.js';
+import * as protocolConfigMoveCalls from '../contracts/deepbook_margin/protocol_config.js';
 
 /**
  * DeepBookMaintainerContract class for managing maintainer actions.
@@ -45,16 +47,17 @@ export class MarginMaintainerContract {
 	 */
 	createMarginPool = (coinKey: string, poolConfig: TransactionArgument) => (tx: Transaction) => {
 		const coin = this.#config.getCoin(coinKey);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::create_margin_pool`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				poolConfig,
-				tx.object(this.#marginMaintainerCap()),
-				tx.object.clock(),
-			],
-			typeArguments: [coin.type],
-		});
+		tx.add(
+			marginPoolMoveCalls.createMarginPool({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					config: poolConfig,
+					maintainerCap: this.#marginMaintainerCap(),
+				},
+				typeArguments: [coin.type],
+			}),
+		);
 	};
 
 	/**
@@ -84,10 +87,15 @@ export class MarginMaintainerContract {
 					})(tx)
 				: this.newMarginPoolConfig(coinKey, marginPoolConfig)(tx);
 			const interestConfigObject = this.newInterestConfig(interestConfig)(tx);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::protocol_config::new_protocol_config`,
-				arguments: [marginPoolConfigObject, interestConfigObject],
-			});
+			return tx.add(
+				protocolConfigMoveCalls.newProtocolConfig({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						marginPoolConfig: marginPoolConfigObject,
+						interestConfig: interestConfigObject,
+					},
+				}),
+			);
 		};
 
 	/**
@@ -100,15 +108,17 @@ export class MarginMaintainerContract {
 		(coinKey: string, marginPoolConfig: MarginPoolConfigParams) => (tx: Transaction) => {
 			const coin = this.#config.getCoin(coinKey);
 			const { supplyCap, maxUtilizationRate, protocolSpread, minBorrow } = marginPoolConfig;
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::protocol_config::new_margin_pool_config`,
-				arguments: [
-					tx.pure.u64(convertQuantity(supplyCap, coin.scalar)),
-					tx.pure.u64(convertRate(maxUtilizationRate, FLOAT_SCALAR)),
-					tx.pure.u64(convertRate(protocolSpread, FLOAT_SCALAR)),
-					tx.pure.u64(convertQuantity(minBorrow, coin.scalar)),
-				],
-			});
+			return tx.add(
+				protocolConfigMoveCalls.newMarginPoolConfig({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						supplyCap: convertQuantity(supplyCap, coin.scalar),
+						maxUtilizationRate: convertRate(maxUtilizationRate, FLOAT_SCALAR),
+						protocolSpread: convertRate(protocolSpread, FLOAT_SCALAR),
+						minBorrow: convertQuantity(minBorrow, coin.scalar),
+					},
+				}),
+			);
 		};
 
 	/**
@@ -139,18 +149,20 @@ export class MarginMaintainerContract {
 				rateLimitRefillRatePerMs,
 				rateLimitEnabled,
 			} = marginPoolConfig;
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::protocol_config::new_margin_pool_config_with_rate_limit`,
-				arguments: [
-					tx.pure.u64(convertQuantity(supplyCap, coin.scalar)),
-					tx.pure.u64(convertRate(maxUtilizationRate, FLOAT_SCALAR)),
-					tx.pure.u64(convertRate(protocolSpread, FLOAT_SCALAR)),
-					tx.pure.u64(convertQuantity(minBorrow, coin.scalar)),
-					tx.pure.u64(convertQuantity(rateLimitCapacity, coin.scalar)),
-					tx.pure.u64(convertQuantity(rateLimitRefillRatePerMs, coin.scalar)),
-					tx.pure.bool(rateLimitEnabled),
-				],
-			});
+			return tx.add(
+				protocolConfigMoveCalls.newMarginPoolConfigWithRateLimit({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						supplyCap: convertQuantity(supplyCap, coin.scalar),
+						maxUtilizationRate: convertRate(maxUtilizationRate, FLOAT_SCALAR),
+						protocolSpread: convertRate(protocolSpread, FLOAT_SCALAR),
+						minBorrow: convertQuantity(minBorrow, coin.scalar),
+						rateLimitCapacity: convertQuantity(rateLimitCapacity, coin.scalar),
+						rateLimitRefillRatePerMs: convertQuantity(rateLimitRefillRatePerMs, coin.scalar),
+						rateLimitEnabled,
+					},
+				}),
+			);
 		};
 
 	/**
@@ -160,15 +172,17 @@ export class MarginMaintainerContract {
 	 */
 	newInterestConfig = (interestConfig: InterestConfigParams) => (tx: Transaction) => {
 		const { baseRate, baseSlope, optimalUtilization, excessSlope } = interestConfig;
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::protocol_config::new_interest_config`,
-			arguments: [
-				tx.pure.u64(convertRate(baseRate, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(baseSlope, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(optimalUtilization, FLOAT_SCALAR)),
-				tx.pure.u64(convertRate(excessSlope, FLOAT_SCALAR)),
-			],
-		});
+		return tx.add(
+			protocolConfigMoveCalls.newInterestConfig({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					baseRate: convertRate(baseRate, FLOAT_SCALAR),
+					baseSlope: convertRate(baseSlope, FLOAT_SCALAR),
+					optimalUtilization: convertRate(optimalUtilization, FLOAT_SCALAR),
+					excessSlope: convertRate(excessSlope, FLOAT_SCALAR),
+				},
+			}),
+		);
 	};
 
 	/**
@@ -183,17 +197,18 @@ export class MarginMaintainerContract {
 		(tx: Transaction) => {
 			const deepbookPool = this.#config.getPool(deepbookPoolKey);
 			const marginPool = this.#config.getMarginPool(coinKey);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::enable_deepbook_pool_for_loan`,
-				arguments: [
-					tx.object(marginPool.address),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.pure.id(deepbookPool.address),
-					tx.object(marginPoolCap),
-					tx.object.clock(),
-				],
-				typeArguments: [marginPool.type],
-			});
+			tx.add(
+				marginPoolMoveCalls.enableDeepbookPoolForLoan({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginPool.address,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						deepbookPoolId: deepbookPool.address,
+						marginPoolCap,
+					},
+					typeArguments: [marginPool.type],
+				}),
+			);
 		};
 
 	/**
@@ -208,17 +223,18 @@ export class MarginMaintainerContract {
 		(tx: Transaction) => {
 			const deepbookPool = this.#config.getPool(deepbookPoolKey);
 			const marginPool = this.#config.getMarginPool(coinKey);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::disable_deepbook_pool_for_loan`,
-				arguments: [
-					tx.object(marginPool.address),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.pure.id(deepbookPool.address),
-					tx.object(marginPoolCap),
-					tx.object.clock(),
-				],
-				typeArguments: [marginPool.type],
-			});
+			tx.add(
+				marginPoolMoveCalls.disableDeepbookPoolForLoan({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginPool.address,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						deepbookPoolId: deepbookPool.address,
+						marginPoolCap,
+					},
+					typeArguments: [marginPool.type],
+				}),
+			);
 		};
 
 	/**
@@ -237,17 +253,18 @@ export class MarginMaintainerContract {
 		(tx: Transaction) => {
 			const marginPool = this.#config.getMarginPool(coinKey);
 			const interestConfigObject = this.newInterestConfig(interestConfig)(tx);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::update_interest_params`,
-				arguments: [
-					tx.object(marginPool.address),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					interestConfigObject,
-					tx.object(marginPoolCap),
-					tx.object.clock(),
-				],
-				typeArguments: [marginPool.type],
-			});
+			tx.add(
+				marginPoolMoveCalls.updateInterestParams({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginPool.address,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						interestConfig: interestConfigObject,
+						marginPoolCap,
+					},
+					typeArguments: [marginPool.type],
+				}),
+			);
 		};
 
 	/**
@@ -277,16 +294,17 @@ export class MarginMaintainerContract {
 						rateLimitEnabled: marginPoolConfig.rateLimitEnabled!,
 					})(tx)
 				: this.newMarginPoolConfig(coinKey, marginPoolConfig)(tx);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::update_margin_pool_config`,
-				arguments: [
-					tx.object(marginPool.address),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					marginPoolConfigObject,
-					tx.object(marginPoolCap),
-					tx.object.clock(),
-				],
-				typeArguments: [marginPool.type],
-			});
+			tx.add(
+				marginPoolMoveCalls.updateMarginPoolConfig({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginPool.address,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						marginPoolConfig: marginPoolConfigObject,
+						marginPoolCap,
+					},
+					typeArguments: [marginPool.type],
+				}),
+			);
 		};
 }

--- a/packages/deepbook-v3/src/transactions/marginManager.ts
+++ b/packages/deepbook-v3/src/transactions/marginManager.ts
@@ -7,6 +7,7 @@ import type { DeepBookConfig } from '../utils/config.js';
 import type { DepositParams, DepositDuringInitParams } from '../types/index.js';
 import { FLOAT_SCALAR } from '../utils/config.js';
 import { convertPrice, convertQuantity } from '../utils/conversion.js';
+import * as marginManagerMoveCalls from '../contracts/deepbook_margin/margin_manager.js';
 
 /**
  * MarginManagerContract class for managing MarginManager operations.
@@ -30,16 +31,17 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::new`,
-			arguments: [
-				tx.object(pool.address),
-				tx.object(this.#config.REGISTRY_ID),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls._new({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					pool: pool.address,
+					deepbookRegistry: this.#config.REGISTRY_ID,
+					marginRegistry: this.#config.MARGIN_REGISTRY_ID,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -51,16 +53,17 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		const [manager, initializer] = tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::new_with_initializer`,
-			arguments: [
-				tx.object(pool.address),
-				tx.object(this.#config.REGISTRY_ID),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		const [manager, initializer] = tx.add(
+			marginManagerMoveCalls.newWithInitializer({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					pool: pool.address,
+					deepbookRegistry: this.#config.REGISTRY_ID,
+					marginRegistry: this.#config.MARGIN_REGISTRY_ID,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 		return { manager, initializer };
 	};
 
@@ -77,11 +80,13 @@ export class MarginManagerContract {
 			const pool = this.#config.getPool(poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::share`,
-				arguments: [manager, initializer],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				marginManagerMoveCalls.share({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: { manager, initializer },
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -96,11 +101,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(manager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::register_margin_manager`,
-			arguments: [tx.object(manager.address), tx.object(this.#config.MARGIN_REGISTRY_ID)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.registerMarginManager({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: manager.address, marginRegistry: this.#config.MARGIN_REGISTRY_ID },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -114,11 +121,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(manager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::unregister_margin_manager`,
-			arguments: [tx.object(manager.address), tx.object(this.#config.MARGIN_REGISTRY_ID)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.unregisterMarginManager({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: manager.address, marginRegistry: this.#config.MARGIN_REGISTRY_ID },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -145,18 +154,19 @@ export class MarginManagerContract {
 					})
 				: params.coin;
 
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deposit`,
-			arguments: [
-				manager,
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				coin,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, depositCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.deposit({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					coin,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, depositCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -177,18 +187,19 @@ export class MarginManagerContract {
 						balance: convertQuantity(params.amount, baseCoin.scalar),
 					})
 				: params.coin;
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deposit`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				coin,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, baseCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.deposit({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					coin,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, baseCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -209,18 +220,19 @@ export class MarginManagerContract {
 						balance: convertQuantity(params.amount, quoteCoin.scalar),
 					})
 				: params.coin;
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deposit`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				coin,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.deposit({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					coin,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -242,18 +254,19 @@ export class MarginManagerContract {
 						balance: convertQuantity(params.amount, deepCoin.scalar),
 					})
 				: params.coin;
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deposit`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				coin,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, deepCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.deposit({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					coin,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, deepCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -269,21 +282,22 @@ export class MarginManagerContract {
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::withdraw`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.pure.u64(convertQuantity(amount, baseCoin.scalar)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, baseCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.withdraw({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					withdrawAmount: convertQuantity(amount, baseCoin.scalar),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, baseCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -299,21 +313,22 @@ export class MarginManagerContract {
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::withdraw`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.pure.u64(convertQuantity(amount, quoteCoin.scalar)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.withdraw({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					withdrawAmount: convertQuantity(amount, quoteCoin.scalar),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -330,21 +345,22 @@ export class MarginManagerContract {
 		const deepCoin = this.#config.getCoin('DEEP');
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::withdraw`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.pure.u64(convertQuantity(amount, deepCoin.scalar)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type, deepCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.withdraw({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					withdrawAmount: convertQuantity(amount, deepCoin.scalar),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type, deepCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -359,20 +375,21 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::borrow_base`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.pure.u64(convertQuantity(amount, baseCoin.scalar)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.borrowBase({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseMarginPool: baseMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					loanAmount: convertQuantity(amount, baseCoin.scalar),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -387,20 +404,21 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::borrow_quote`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.pure.u64(convertQuantity(amount, quoteCoin.scalar)),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.borrowQuote({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					loanAmount: convertQuantity(amount, quoteCoin.scalar),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -415,20 +433,18 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::repay_base`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseMarginPool.address),
-				tx.pure.option(
-					'u64',
-					amount !== undefined ? convertQuantity(amount, baseCoin.scalar) : null,
-				),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.repayBase({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginPool: baseMarginPool.address,
+					amount: amount !== undefined ? convertQuantity(amount, baseCoin.scalar) : null,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -443,20 +459,18 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::repay_quote`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(quoteMarginPool.address),
-				tx.pure.option(
-					'u64',
-					amount !== undefined ? convertQuantity(amount, quoteCoin.scalar) : null,
-				),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.repayQuote({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginPool: quoteMarginPool.address,
+					amount: amount !== undefined ? convertQuantity(amount, quoteCoin.scalar) : null,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -481,20 +495,21 @@ export class MarginManagerContract {
 			const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 			const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 			const marginPool = debtIsBase ? baseMarginPool : quoteMarginPool;
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::liquidate`,
-				arguments: [
-					tx.object(managerAddress),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(baseCoin.priceInfoObjectId!),
-					tx.object(quoteCoin.priceInfoObjectId!),
-					tx.object(marginPool.address),
-					tx.object(pool.address),
-					repayCoin,
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type, debtIsBase ? baseCoin.type : quoteCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.liquidate({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: managerAddress,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						baseOracle: baseCoin.priceInfoObjectId!,
+						quoteOracle: quoteCoin.priceInfoObjectId!,
+						marginPool: marginPool.address,
+						pool: pool.address,
+						repayCoin,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type, debtIsBase ? baseCoin.type : quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -509,11 +524,13 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::set_margin_manager_referral`,
-			arguments: [tx.object(manager.address), tx.object(referral)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.setMarginManagerReferral({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: manager.address, referralCap: referral },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -528,11 +545,13 @@ export class MarginManagerContract {
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::unset_margin_manager_referral`,
-			arguments: [tx.object(manager.address), tx.pure.id(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.unsetMarginManagerReferral({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: manager.address, poolId: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	// === Read-Only Functions ===
@@ -547,11 +566,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::owner`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.owner({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -564,11 +585,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deepbook_pool`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.deepbookPool({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -581,11 +604,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::margin_pool_id`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.marginPoolId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -598,11 +623,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::borrowed_shares`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.borrowedShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -615,11 +642,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::borrowed_base_shares`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.borrowedBaseShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -632,11 +661,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::borrowed_quote_shares`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.borrowedQuoteShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -649,11 +680,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::has_base_debt`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.hasBaseDebt({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -666,11 +699,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::balance_manager`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.balanceManager({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -683,11 +718,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::calculate_assets`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.calculateAssets({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -704,11 +741,13 @@ export class MarginManagerContract {
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const debtCoin = this.#config.getCoin(coinKey);
 			const marginPool = this.#config.getMarginPool(coinKey);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::calculate_debts`,
-				arguments: [tx.object(marginManagerId), tx.object(marginPool.address), tx.object.clock()],
-				typeArguments: [baseCoin.type, quoteCoin.type, debtCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.calculateDebts({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: { self: marginManagerId, marginPool: marginPool.address },
+					typeArguments: [baseCoin.type, quoteCoin.type, debtCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -726,20 +765,21 @@ export class MarginManagerContract {
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::manager_state`,
-			arguments: [
-				tx.object(marginManagerId),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(pool.address),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.managerState({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: marginManagerId,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					pool: pool.address,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -752,11 +792,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::base_balance`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.baseBalance({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -769,11 +811,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::quote_balance`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.quoteBalance({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -786,11 +830,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::deep_balance`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.deepBalance({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -805,11 +851,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::balance_manager_id`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.balanceManagerId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -822,11 +870,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::get_balance_manager_referral_id`,
-			arguments: [tx.object(marginManagerId), tx.pure.id(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.getBalanceManagerReferralId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, poolId: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -839,11 +889,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::account_exists`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.accountExists({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -856,11 +908,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::account`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.account({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -874,11 +928,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::account_open_orders`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.accountOpenOrders({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -892,11 +948,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::get_account_order_details`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.getAccountOrderDetails({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -910,11 +968,13 @@ export class MarginManagerContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::locked_balance`,
-			arguments: [tx.object(marginManagerId), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.lockedBalance({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -945,20 +1005,21 @@ export class MarginManagerContract {
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const inputPrice = convertPrice(price, FLOAT_SCALAR, quoteCoin.scalar, baseCoin.scalar);
 			const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::can_place_limit_order`,
-				arguments: [
-					tx.object(marginManagerId),
-					tx.object(pool.address),
-					tx.pure.u64(inputPrice),
-					tx.pure.u64(inputQuantity),
-					tx.pure.bool(isBid),
-					tx.pure.bool(payWithDeep),
-					tx.pure.u64(expireTimestamp),
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.canPlaceLimitOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginManagerId,
+						pool: pool.address,
+						price: inputPrice,
+						quantity: inputQuantity,
+						isBid,
+						payWithDeep,
+						expireTimestamp,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -984,17 +1045,18 @@ export class MarginManagerContract {
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::can_place_market_order`,
-				arguments: [
-					tx.object(marginManagerId),
-					tx.object(pool.address),
-					tx.pure.u64(inputQuantity),
-					tx.pure.bool(isBid),
-					tx.pure.bool(payWithDeep),
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.canPlaceMarketOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginManagerId,
+						pool: pool.address,
+						quantity: inputQuantity,
+						isBid,
+						payWithDeep,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 }

--- a/packages/deepbook-v3/src/transactions/marginManager.ts
+++ b/packages/deepbook-v3/src/transactions/marginManager.ts
@@ -507,7 +507,11 @@ export class MarginManagerContract {
 						pool: pool.address,
 						repayCoin,
 					},
-					typeArguments: [baseCoin.type, quoteCoin.type, debtIsBase ? baseCoin.type : quoteCoin.type],
+					typeArguments: [
+						baseCoin.type,
+						quoteCoin.type,
+						debtIsBase ? baseCoin.type : quoteCoin.type,
+					],
 				}),
 			);
 		};

--- a/packages/deepbook-v3/src/transactions/marginPool.ts
+++ b/packages/deepbook-v3/src/transactions/marginPool.ts
@@ -5,6 +5,7 @@ import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transac
 
 import type { DeepBookConfig } from '../utils/config.js';
 import { convertQuantity } from '../utils/conversion.js';
+import * as marginPoolMoveCalls from '../contracts/deepbook_margin/margin_pool.js';
 
 /**
  * MarginPoolContract class for managing MarginPool operations.
@@ -24,10 +25,12 @@ export class MarginPoolContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	mintSupplierCap = () => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::mint_supplier_cap`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.object.clock()],
-		});
+		return tx.add(
+			marginPoolMoveCalls.mintSupplierCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { registry: this.#config.MARGIN_REGISTRY_ID },
+			}),
+		);
 	};
 
 	/**
@@ -55,6 +58,11 @@ export class MarginPoolContract {
 				balance: depositInput,
 			});
 
+			// NOTE: left as a positional moveCall (not codegen). This builder's
+			// coinWithBalance + `tx.object.option` (an on-chain option::none MoveCall
+			// for the Option<ID> referral) interleave commands in a way that a
+			// generated named-arg call reorders — so migrating it would change the
+			// emitted PTB. Kept verbatim to stay byte-identical.
 			tx.moveCall({
 				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::supply`,
 				arguments: [
@@ -86,17 +94,18 @@ export class MarginPoolContract {
 			const coin = this.#config.getCoin(coinKey);
 			const withdrawInput =
 				amountToWithdraw !== undefined ? convertQuantity(amountToWithdraw, coin.scalar) : null;
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::withdraw`,
-				arguments: [
-					tx.object(marginPool.address),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					supplierCap,
-					tx.pure.option('u64', withdrawInput),
-					tx.object.clock(),
-				],
-				typeArguments: [marginPool.type],
-			});
+			return tx.add(
+				marginPoolMoveCalls.withdraw({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: marginPool.address,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						supplierCap,
+						amount: withdrawInput,
+					},
+					typeArguments: [marginPool.type],
+				}),
+			);
 		};
 
 	/**
@@ -106,15 +115,13 @@ export class MarginPoolContract {
 	 */
 	mintSupplyReferral = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::mint_supply_referral`,
-			arguments: [
-				tx.object(marginPool.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object.clock(),
-			],
-			typeArguments: [marginPool.type],
-		});
+		tx.add(
+			marginPoolMoveCalls.mintSupplyReferral({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address, registry: this.#config.MARGIN_REGISTRY_ID },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -125,15 +132,17 @@ export class MarginPoolContract {
 	 */
 	withdrawReferralFees = (coinKey: string, referralId: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::withdraw_referral_fees`,
-			arguments: [
-				tx.object(marginPool.address),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(referralId),
-			],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.withdrawReferralFees({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: marginPool.address,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					referral: referralId,
+				},
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	// === Read-only/View Functions ===
@@ -145,11 +154,13 @@ export class MarginPoolContract {
 	 */
 	getId = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::id`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.id({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -160,11 +171,13 @@ export class MarginPoolContract {
 	 */
 	deepbookPoolAllowed = (coinKey: string, deepbookPoolId: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::deepbook_pool_allowed`,
-			arguments: [tx.object(marginPool.address), tx.pure.id(deepbookPoolId)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.deepbookPoolAllowed({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address, deepbookPoolId },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -174,11 +187,13 @@ export class MarginPoolContract {
 	 */
 	totalSupply = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::total_supply`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.totalSupply({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -188,11 +203,13 @@ export class MarginPoolContract {
 	 */
 	supplyShares = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::supply_shares`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.supplyShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -202,11 +219,13 @@ export class MarginPoolContract {
 	 */
 	totalBorrow = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::total_borrow`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.totalBorrow({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -216,11 +235,13 @@ export class MarginPoolContract {
 	 */
 	borrowShares = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::borrow_shares`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.borrowShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -230,11 +251,13 @@ export class MarginPoolContract {
 	 */
 	lastUpdateTimestamp = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::last_update_timestamp`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.lastUpdateTimestamp({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -244,11 +267,13 @@ export class MarginPoolContract {
 	 */
 	supplyCap = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::supply_cap`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.supplyCap({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -258,11 +283,13 @@ export class MarginPoolContract {
 	 */
 	maxUtilizationRate = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::max_utilization_rate`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.maxUtilizationRate({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -272,11 +299,13 @@ export class MarginPoolContract {
 	 */
 	protocolSpread = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::protocol_spread`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.protocolSpread({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -286,11 +315,13 @@ export class MarginPoolContract {
 	 */
 	minBorrow = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::min_borrow`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.minBorrow({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -300,11 +331,13 @@ export class MarginPoolContract {
 	 */
 	interestRate = (coinKey: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::interest_rate`,
-			arguments: [tx.object(marginPool.address)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.interestRate({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -315,11 +348,13 @@ export class MarginPoolContract {
 	 */
 	userSupplyShares = (coinKey: string, supplierCapId: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::user_supply_shares`,
-			arguments: [tx.object(marginPool.address), tx.pure.id(supplierCapId)],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.userSupplyShares({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address, supplierCapId },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 
 	/**
@@ -330,10 +365,12 @@ export class MarginPoolContract {
 	 */
 	userSupplyAmount = (coinKey: string, supplierCapId: string) => (tx: Transaction) => {
 		const marginPool = this.#config.getMarginPool(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_pool::user_supply_amount`,
-			arguments: [tx.object(marginPool.address), tx.pure.id(supplierCapId), tx.object.clock()],
-			typeArguments: [marginPool.type],
-		});
+		return tx.add(
+			marginPoolMoveCalls.userSupplyAmount({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginPool.address, supplierCapId },
+				typeArguments: [marginPool.type],
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/src/transactions/marginRegistry.ts
+++ b/packages/deepbook-v3/src/transactions/marginRegistry.ts
@@ -27,11 +27,13 @@ export class MarginRegistryContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::pool_enabled`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.object(pool.address)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.poolEnabled({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, pool: pool.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -41,11 +43,13 @@ export class MarginRegistryContract {
 	 */
 	getMarginPoolId = (coinKey: string) => (tx: Transaction) => {
 		const coin = this.#config.getCoin(coinKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::get_margin_pool_id`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID)],
-			typeArguments: [coin.type],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.getMarginPoolId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID },
+				typeArguments: [coin.type],
+			}),
+		);
 	};
 
 	/**
@@ -55,11 +59,12 @@ export class MarginRegistryContract {
 	 */
 	getDeepbookPoolMarginPoolIds = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::get_deepbook_pool_margin_pool_ids`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.getDeepbookPoolMarginPoolIds({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -68,11 +73,12 @@ export class MarginRegistryContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	getMarginManagerIds = (owner: string) => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::get_margin_manager_ids`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.address(owner)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.getMarginManagerIds({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, owner },
+			}),
+		);
 	};
 
 	/**
@@ -82,11 +88,12 @@ export class MarginRegistryContract {
 	 */
 	baseMarginPoolId = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::base_margin_pool_id`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.baseMarginPoolId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -96,11 +103,12 @@ export class MarginRegistryContract {
 	 */
 	quoteMarginPoolId = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::quote_margin_pool_id`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.quoteMarginPoolId({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -110,11 +118,12 @@ export class MarginRegistryContract {
 	 */
 	minWithdrawRiskRatio = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::min_withdraw_risk_ratio`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.minWithdrawRiskRatio({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -124,11 +133,12 @@ export class MarginRegistryContract {
 	 */
 	minBorrowRiskRatio = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::min_borrow_risk_ratio`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.minBorrowRiskRatio({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -142,10 +152,7 @@ export class MarginRegistryContract {
 		return tx.add(
 			marginRegistryMoveCalls.minOpenRiskRatio({
 				package: this.#config.MARGIN_PACKAGE_ID,
-				arguments: {
-					self: this.#config.MARGIN_REGISTRY_ID,
-					deepbookPoolId: pool.address,
-				},
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
 			}),
 		);
 	};
@@ -157,11 +164,12 @@ export class MarginRegistryContract {
 	 */
 	liquidationRiskRatio = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::liquidation_risk_ratio`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.liquidationRiskRatio({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -171,11 +179,12 @@ export class MarginRegistryContract {
 	 */
 	targetLiquidationRiskRatio = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::target_liquidation_risk_ratio`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.targetLiquidationRiskRatio({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -185,11 +194,12 @@ export class MarginRegistryContract {
 	 */
 	userLiquidationReward = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::user_liquidation_reward`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.userLiquidationReward({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -199,11 +209,12 @@ export class MarginRegistryContract {
 	 */
 	poolLiquidationReward = (poolKey: string) => (tx: Transaction) => {
 		const pool = this.#config.getPool(poolKey);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::pool_liquidation_reward`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID), tx.pure.id(pool.address)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.poolLiquidationReward({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID, deepbookPoolId: pool.address },
+			}),
+		);
 	};
 
 	/**
@@ -211,11 +222,12 @@ export class MarginRegistryContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	allowedMaintainers = () => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::allowed_maintainers`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.allowedMaintainers({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID },
+			}),
+		);
 	};
 
 	/**
@@ -223,10 +235,11 @@ export class MarginRegistryContract {
 	 * @returns A function that takes a Transaction object
 	 */
 	allowedPauseCaps = () => (tx: Transaction) => {
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_registry::allowed_pause_caps`,
-			arguments: [tx.object(this.#config.MARGIN_REGISTRY_ID)],
-			typeArguments: [],
-		});
+		return tx.add(
+			marginRegistryMoveCalls.allowedPauseCaps({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: this.#config.MARGIN_REGISTRY_ID },
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/src/transactions/marginTPSL.ts
+++ b/packages/deepbook-v3/src/transactions/marginTPSL.ts
@@ -12,6 +12,7 @@ import { OrderType, SelfMatchingOptions } from '../types/index.js';
 import { MAX_TIMESTAMP, FLOAT_SCALAR } from '../utils/config.js';
 import { convertQuantity, convertPrice } from '../utils/conversion.js';
 import * as marginManagerMoveCalls from '../contracts/deepbook_margin/margin_manager.js';
+import * as tpslMoveCalls from '../contracts/deepbook_margin/tpsl.js';
 
 /**
  * MarginTPSLContract class for managing Take Profit / Stop Loss operations.
@@ -47,10 +48,12 @@ export class MarginTPSLContract {
 				quoteCoin.scalar,
 				baseCoin.scalar,
 			);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::tpsl::new_condition`,
-				arguments: [tx.pure.bool(triggerBelowPrice), tx.pure.u64(inputPrice)],
-			});
+			return tx.add(
+				tpslMoveCalls.newCondition({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: { triggerBelowPrice, triggerPrice: inputPrice },
+				}),
+			);
 		};
 
 	/**
@@ -76,19 +79,21 @@ export class MarginTPSLContract {
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const inputPrice = convertPrice(price, FLOAT_SCALAR, quoteCoin.scalar, baseCoin.scalar);
 			const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::tpsl::new_pending_limit_order`,
-				arguments: [
-					tx.pure.u64(clientOrderId),
-					tx.pure.u8(orderType),
-					tx.pure.u8(selfMatchingOption),
-					tx.pure.u64(inputPrice),
-					tx.pure.u64(inputQuantity),
-					tx.pure.bool(isBid),
-					tx.pure.bool(payWithDeep),
-					tx.pure.u64(expireTimestamp),
-				],
-			});
+			return tx.add(
+				tpslMoveCalls.newPendingLimitOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						clientOrderId: BigInt(clientOrderId),
+						orderType,
+						selfMatchingOption,
+						price: inputPrice,
+						quantity: inputQuantity,
+						isBid,
+						payWithDeep,
+						expireTimestamp,
+					},
+				}),
+			);
 		};
 
 	/**
@@ -109,16 +114,18 @@ export class MarginTPSLContract {
 			const pool = this.#config.getPool(poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::tpsl::new_pending_market_order`,
-				arguments: [
-					tx.pure.u64(clientOrderId),
-					tx.pure.u8(selfMatchingOption),
-					tx.pure.u64(inputQuantity),
-					tx.pure.bool(isBid),
-					tx.pure.bool(payWithDeep),
-				],
-			});
+			return tx.add(
+				tpslMoveCalls.newPendingMarketOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						clientOrderId: BigInt(clientOrderId),
+						selfMatchingOption,
+						quantity: inputQuantity,
+						isBid,
+						payWithDeep,
+					},
+				}),
+			);
 		};
 
 	// === Public Functions ===
@@ -145,21 +152,22 @@ export class MarginTPSLContract {
 			? this.newPendingLimitOrder(manager.poolKey, pendingOrder as PendingLimitOrderParams)(tx)
 			: this.newPendingMarketOrder(manager.poolKey, pendingOrder as PendingMarketOrderParams)(tx);
 
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::add_conditional_order`,
-			arguments: [
-				tx.object(manager.address),
-				tx.object(pool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.pure.u64(conditionalOrderId),
-				condition,
-				pending,
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.addConditionalOrder({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					self: manager.address,
+					pool: pool.address,
+					basePriceInfoObject: baseCoin.priceInfoObjectId!,
+					quotePriceInfoObject: quoteCoin.priceInfoObjectId!,
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					conditionalOrderId: BigInt(conditionalOrderId),
+					condition,
+					pendingOrder: pending,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -172,11 +180,13 @@ export class MarginTPSLContract {
 		const pool = this.#config.getPool(manager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::cancel_all_conditional_orders`,
-			arguments: [tx.object(manager.address), tx.object.clock()],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			marginManagerMoveCalls.cancelAllConditionalOrders({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: manager.address },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -191,11 +201,13 @@ export class MarginTPSLContract {
 			const pool = this.#config.getPool(manager.poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::cancel_conditional_order`,
-				arguments: [tx.object(manager.address), tx.pure.u64(conditionalOrderId), tx.object.clock()],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				marginManagerMoveCalls.cancelConditionalOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: { self: manager.address, conditionalOrderId: BigInt(conditionalOrderId) },
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -216,21 +228,22 @@ export class MarginTPSLContract {
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 			const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::execute_conditional_orders_v2`,
-				arguments: [
-					tx.object(managerAddress),
-					tx.object(pool.address),
-					tx.object(baseMarginPool.address),
-					tx.object(quoteMarginPool.address),
-					tx.object(baseCoin.priceInfoObjectId!),
-					tx.object(quoteCoin.priceInfoObjectId!),
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.pure.u64(maxOrdersToExecute),
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.executeConditionalOrdersV2({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						self: managerAddress,
+						pool: pool.address,
+						baseMarginPool: baseMarginPool.address,
+						quoteMarginPool: quoteMarginPool.address,
+						basePriceInfoObject: baseCoin.priceInfoObjectId!,
+						quotePriceInfoObject: quoteCoin.priceInfoObjectId!,
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						maxOrdersToExecute,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -287,11 +300,13 @@ export class MarginTPSLContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::conditional_order_ids`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.conditionalOrderIds({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -306,11 +321,13 @@ export class MarginTPSLContract {
 			const pool = this.#config.getPool(poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-			return tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::conditional_order`,
-				arguments: [tx.object(marginManagerId), tx.pure.u64(conditionalOrderId)],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			return tx.add(
+				marginManagerMoveCalls.conditionalOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: { self: marginManagerId, conditionalOrderId: BigInt(conditionalOrderId) },
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -324,11 +341,13 @@ export class MarginTPSLContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::lowest_trigger_above_price`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.lowestTriggerAbovePrice({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -342,10 +361,12 @@ export class MarginTPSLContract {
 		const pool = this.#config.getPool(poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::margin_manager::highest_trigger_below_price`,
-			arguments: [tx.object(marginManagerId)],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			marginManagerMoveCalls.highestTriggerBelowPrice({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: { self: marginManagerId },
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/src/transactions/poolProxy.ts
+++ b/packages/deepbook-v3/src/transactions/poolProxy.ts
@@ -54,28 +54,29 @@ export class PoolProxyContract {
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 		const inputPrice = convertPrice(price, FLOAT_SCALAR, quoteCoin.scalar, baseCoin.scalar);
 		const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::place_limit_order_v2`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(manager.address),
-				tx.object(pool.address),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.pure.u64(clientOrderId),
-				tx.pure.u8(orderType),
-				tx.pure.u8(selfMatchingOption),
-				tx.pure.u64(inputPrice),
-				tx.pure.u64(inputQuantity),
-				tx.pure.bool(isBid),
-				tx.pure.bool(payWithDeep),
-				tx.pure.u64(expiration),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			poolProxyMoveCalls.placeLimitOrderV2({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: manager.address,
+					pool: pool.address,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					clientOrderId: BigInt(clientOrderId),
+					orderType,
+					selfMatchingOption,
+					price: inputPrice,
+					quantity: inputQuantity,
+					isBid,
+					payWithDeep,
+					expireTimestamp: expiration,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -102,25 +103,26 @@ export class PoolProxyContract {
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 		const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::place_market_order_v2`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(manager.address),
-				tx.object(pool.address),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.pure.u64(clientOrderId),
-				tx.pure.u8(selfMatchingOption),
-				tx.pure.u64(inputQuantity),
-				tx.pure.bool(isBid),
-				tx.pure.bool(payWithDeep),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			poolProxyMoveCalls.placeMarketOrderV2({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: manager.address,
+					pool: pool.address,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					clientOrderId: BigInt(clientOrderId),
+					selfMatchingOption,
+					quantity: inputQuantity,
+					isBid,
+					payWithDeep,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -152,28 +154,29 @@ export class PoolProxyContract {
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 		const inputPrice = convertPrice(price, FLOAT_SCALAR, quoteCoin.scalar, baseCoin.scalar);
 		const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::place_reduce_only_limit_order_v2`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(manager.address),
-				tx.object(pool.address),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.pure.u64(clientOrderId),
-				tx.pure.u8(orderType),
-				tx.pure.u8(selfMatchingOption),
-				tx.pure.u64(inputPrice),
-				tx.pure.u64(inputQuantity),
-				tx.pure.bool(isBid),
-				tx.pure.bool(payWithDeep),
-				tx.pure.u64(expiration),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			poolProxyMoveCalls.placeReduceOnlyLimitOrderV2({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: manager.address,
+					pool: pool.address,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					clientOrderId: BigInt(clientOrderId),
+					orderType,
+					selfMatchingOption,
+					price: inputPrice,
+					quantity: inputQuantity,
+					isBid,
+					payWithDeep,
+					expireTimestamp: expiration,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -201,25 +204,26 @@ export class PoolProxyContract {
 		const baseMarginPool = this.#config.getMarginPool(pool.baseCoin);
 		const quoteMarginPool = this.#config.getMarginPool(pool.quoteCoin);
 		const inputQuantity = convertQuantity(quantity, baseCoin.scalar);
-		return tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::place_reduce_only_market_order_v2`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(manager.address),
-				tx.object(pool.address),
-				tx.object(baseMarginPool.address),
-				tx.object(quoteMarginPool.address),
-				tx.object(baseCoin.priceInfoObjectId!),
-				tx.object(quoteCoin.priceInfoObjectId!),
-				tx.pure.u64(clientOrderId),
-				tx.pure.u8(selfMatchingOption),
-				tx.pure.u64(inputQuantity),
-				tx.pure.bool(isBid),
-				tx.pure.bool(payWithDeep),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		return tx.add(
+			poolProxyMoveCalls.placeReduceOnlyMarketOrderV2({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: manager.address,
+					pool: pool.address,
+					baseMarginPool: baseMarginPool.address,
+					quoteMarginPool: quoteMarginPool.address,
+					baseOracle: baseCoin.priceInfoObjectId!,
+					quoteOracle: quoteCoin.priceInfoObjectId!,
+					clientOrderId: BigInt(clientOrderId),
+					selfMatchingOption,
+					quantity: inputQuantity,
+					isBid,
+					payWithDeep,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -392,18 +396,19 @@ export class PoolProxyContract {
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 			const inputQuantity = convertQuantity(newQuantity, baseCoin.scalar);
 
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::modify_order`,
-				arguments: [
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(marginManager.address),
-					tx.object(pool.address),
-					tx.pure.u128(orderId),
-					tx.pure.u64(inputQuantity),
-					tx.object.clock(),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				poolProxyMoveCalls.modifyOrder({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						marginManager: marginManager.address,
+						pool: pool.address,
+						orderId: BigInt(orderId),
+						newQuantity: inputQuantity,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -417,17 +422,18 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::cancel_order`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-				tx.pure.u128(orderId),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.cancelOrder({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+					orderId: BigInt(orderId),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -441,17 +447,18 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::cancel_orders`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-				tx.pure.vector('u128', orderIds),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.cancelOrders({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+					orderIds: orderIds.map(BigInt),
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -464,16 +471,17 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::cancel_all_orders`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.cancelAllOrders({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -486,15 +494,17 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::withdraw_settled_amounts`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.withdrawSettledAmounts({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -510,16 +520,18 @@ export class PoolProxyContract {
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
 		const deepCoin = this.#config.getCoin('DEEP');
 		const stakeInput = convertQuantity(stakeAmount, deepCoin.scalar);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::stake`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-				tx.pure.u64(stakeInput),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.stake({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+					amount: stakeInput,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -532,15 +544,17 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::unstake`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.unstake({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -559,18 +573,20 @@ export class PoolProxyContract {
 			const stakeInput = convertRate(stakeRequired, FLOAT_SCALAR);
 			const takerFeeInput = convertRate(takerFee, FLOAT_SCALAR);
 			const makerFeeInput = convertRate(makerFee, FLOAT_SCALAR);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::submit_proposal`,
-				arguments: [
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(marginManager.address),
-					tx.object(pool.address),
-					tx.pure.u64(takerFeeInput),
-					tx.pure.u64(makerFeeInput),
-					tx.pure.u64(stakeInput),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				poolProxyMoveCalls.submitProposal({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						marginManager: marginManager.address,
+						pool: pool.address,
+						takerFee: takerFeeInput,
+						makerFee: makerFeeInput,
+						stakeRequired: stakeInput,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -584,16 +600,18 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::vote`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-				tx.pure.id(proposalId),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.vote({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+					proposalId,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -606,15 +624,17 @@ export class PoolProxyContract {
 		const pool = this.#config.getPool(marginManager.poolKey);
 		const baseCoin = this.#config.getCoin(pool.baseCoin);
 		const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::claim_rebates`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(marginManager.address),
-				tx.object(pool.address),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.claimRebates({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					marginManager: marginManager.address,
+					pool: pool.address,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 
 	/**
@@ -628,15 +648,17 @@ export class PoolProxyContract {
 			const pool = this.#config.getPool(poolKey);
 			const baseCoin = this.#config.getCoin(pool.baseCoin);
 			const quoteCoin = this.#config.getCoin(pool.quoteCoin);
-			tx.moveCall({
-				target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::withdraw_settled_amounts_permissionless`,
-				arguments: [
-					tx.object(this.#config.MARGIN_REGISTRY_ID),
-					tx.object(marginManagerId),
-					tx.object(pool.address),
-				],
-				typeArguments: [baseCoin.type, quoteCoin.type],
-			});
+			tx.add(
+				poolProxyMoveCalls.withdrawSettledAmountsPermissionless({
+					package: this.#config.MARGIN_PACKAGE_ID,
+					arguments: {
+						registry: this.#config.MARGIN_REGISTRY_ID,
+						marginManager: marginManagerId,
+						pool: pool.address,
+					},
+					typeArguments: [baseCoin.type, quoteCoin.type],
+				}),
+			);
 		};
 
 	/**
@@ -654,16 +676,17 @@ export class PoolProxyContract {
 		if (!quoteCoin.priceInfoObjectId) {
 			throw new Error(`Missing priceInfoObjectId for ${pool.quoteCoin}`);
 		}
-		tx.moveCall({
-			target: `${this.#config.MARGIN_PACKAGE_ID}::pool_proxy::update_current_price`,
-			arguments: [
-				tx.object(this.#config.MARGIN_REGISTRY_ID),
-				tx.object(pool.address),
-				tx.object(baseCoin.priceInfoObjectId),
-				tx.object(quoteCoin.priceInfoObjectId),
-				tx.object.clock(),
-			],
-			typeArguments: [baseCoin.type, quoteCoin.type],
-		});
+		tx.add(
+			poolProxyMoveCalls.updateCurrentPrice({
+				package: this.#config.MARGIN_PACKAGE_ID,
+				arguments: {
+					registry: this.#config.MARGIN_REGISTRY_ID,
+					pool: pool.address,
+					basePriceInfoObject: baseCoin.priceInfoObjectId,
+					quotePriceInfoObject: quoteCoin.priceInfoObjectId,
+				},
+				typeArguments: [baseCoin.type, quoteCoin.type],
+			}),
+		);
 	};
 }

--- a/packages/deepbook-v3/sui-codegen.config.ts
+++ b/packages/deepbook-v3/sui-codegen.config.ts
@@ -15,6 +15,10 @@ const config: SuiCodegenConfig = {
 			path: '../../../deepbookv3/packages/deepbook_margin',
 		},
 		{
+			package: '@deepbook/margin-liquidation',
+			path: '../../../deepbookv3/packages/margin_liquidation',
+		},
+		{
 			package: '0xabf837e98c26087cba0883c0a7a28326b1fa3c5e1e2c5abdb486f9e8f594c837',
 			packageName: 'pyth',
 			network: 'testnet',

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -1550,3 +1550,2161 @@ exports[`marginTPSL PTB snapshots > newPendingMarketOrder 1`] = `
   ],
 }
 `;
+
+exports[`poolProxy PTB snapshots > cancelAllOrders 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "cancel_all_orders",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > cancelOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "cancel_order",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ewAAAAAAAAAAAAAAAAAAAA==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > cancelOrders 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "cancel_orders",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AnsAAAAAAAAAAAAAAAAAAADIAQAAAAAAAAAAAAAAAAAA",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > claimRebate 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "claim_rebates",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > modifyOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+        ],
+        "function": "modify_order",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ewAAAAAAAAAAAAAAAAAAAA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeLimitOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 13,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 14,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 15,
+            "type": "object",
+          },
+        ],
+        "function": "place_limit_order_v2",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "mZmZmZmZmRk=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeMarketOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "object",
+          },
+        ],
+        "function": "place_market_order_v2",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeMarketOrderAndRepayLoan 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "object",
+          },
+        ],
+        "function": "place_market_order_and_repay_loan",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeReduceOnlyLimitOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 13,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 14,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 15,
+            "type": "object",
+          },
+        ],
+        "function": "place_reduce_only_limit_order_v2",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "mZmZmZmZmRk=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeReduceOnlyLimitOrderAndRepayLoan 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 13,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 14,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 15,
+            "type": "object",
+          },
+        ],
+        "function": "place_reduce_only_limit_order_and_repay_loan",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "mZmZmZmZmRk=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeReduceOnlyMarketOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "object",
+          },
+        ],
+        "function": "place_reduce_only_market_order_v2",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > placeReduceOnlyMarketOrderAndRepayLoan 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "object",
+          },
+        ],
+        "function": "place_reduce_only_market_order_and_repay_loan",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > stake 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "stake",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > submitProposal 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+        ],
+        "function": "submit_proposal",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOh2SBcAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > unstake 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "unstake",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > updateCurrentPrice 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "update_current_price",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > vote 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "vote",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > withdrawMarginSettledAmounts 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw_settled_amounts_permissionless",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`poolProxy PTB snapshots > withdrawSettledAmounts 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw_settled_amounts",
+        "module": "pool_proxy",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -980,6 +980,864 @@ exports[`marginMaintainer PTB snapshots > updateMarginPoolConfig 1`] = `
 }
 `;
 
+exports[`marginPool PTB snapshots > borrowShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "borrow_shares",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > deepbookPoolAllowed 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "deepbook_pool_allowed",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7u4=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > getId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "id",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > interestRate 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "interest_rate",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > lastUpdateTimestamp 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "last_update_timestamp",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > maxUtilizationRate 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "max_utilization_rate",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > minBorrow 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "min_borrow",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > mintSupplierCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "mint_supplier_cap",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > mintSupplyReferral 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "mint_supply_referral",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > protocolSpread 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "protocol_spread",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > supplyCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "supply_cap",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > supplyShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "supply_shares",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > supplyToMarginPool 1`] = `
+{
+  "commands": [
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000000n,
+          "outputKind": "coin",
+          "type": "gas",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [],
+        "function": "none",
+        "module": "option",
+        "package": "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "typeArguments": [
+          "0x2::object::ID",
+        ],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "supply",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000dddd",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > totalBorrow 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "total_borrow",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > totalSupply 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "total_supply",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > userSupplyAmount 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "user_supply_amount",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7u4=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > userSupplyShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "user_supply_shares",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7u4=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > withdrawFromMarginPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000dddd",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQDKmjsAAAAA",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginPool PTB snapshots > withdrawReferralFees 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw_referral_fees",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000eeee",
+      },
+    },
+  ],
+}
+`;
+
 exports[`marginRegistry PTB snapshots > allowedMaintainers 1`] = `
 {
   "commands": [

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -1524,6 +1524,599 @@ exports[`marginAdmin PTB snapshots > updateRiskParams 1`] = `
 }
 `;
 
+exports[`marginLiquidations PTB snapshots > balance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "balance",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > createLiquidationVault 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "create_liquidation_vault",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000008888",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > deposit 1`] = `
+{
+  "commands": [
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000000n,
+          "outputKind": "coin",
+          "type": "gas",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+        ],
+        "function": "deposit",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000008888",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > liquidateBase 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "object",
+          },
+        ],
+        "function": "liquidate_base",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQDKmjsAAAAA",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > liquidateBaseAll 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "object",
+          },
+        ],
+        "function": "liquidate_base",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > liquidateQuote 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "object",
+          },
+        ],
+        "function": "liquidate_quote",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AUBCDwAAAAAA",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginLiquidations PTB snapshots > withdraw 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+        ],
+        "function": "withdraw",
+        "module": "liquidation_vault",
+        "package": "0x8d69c3ef3ef580e5bf87b933ce28de19a5d0323588d1a44b9c60b4001741aa24",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000009999",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000008888",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
 exports[`marginMaintainer PTB snapshots > createMarginPool 1`] = `
 {
   "commands": [

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -1,5 +1,1529 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`marginAdmin PTB snapshots > addConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "add_config",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580::oracle::PythConfig",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > adminWithdrawDefaultReferralFees 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "admin_withdraw_default_referral_fees",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > disableDeepbookPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "disable_deepbook_pool",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > disableVersion 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "disable_version",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AwAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > disableVersionPauseCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "disable_version_pause_cap",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AwAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > enableDeepbookPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "enable_deepbook_pool",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > enableVersion 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "enable_version",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AwAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > mintMaintainerCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "mint_maintainer_cap",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > mintPauseCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "mint_pause_cap",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > newCoinTypeData 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_coin_type_data_from_currency",
+        "module": "oracle",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf256d3fb6a50eaa748d94335b34f2982fbc3b63ceec78cafaa29ebc9ebaf2bbc",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "IFDGez/SJduJEqQk3Uuu1g/93mJe0v6q8oNyT5YI/qJm",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ZAAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ZAAAAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > newPoolConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pool_config",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AJQ1dwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AC9oWQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AKuQQQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AIyGRwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gPD6AgAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gJaYAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > newPoolConfigWithLeverage 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pool_config_with_leverage",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "APIFKgEAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > newPythConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_coin_type_data_from_currency",
+        "module": "oracle",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+    {
+      "$kind": "MakeMoveVec",
+      "MakeMoveVec": {
+        "elements": [
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+        ],
+        "type": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580::oracle::CoinTypeData",
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pyth_config",
+        "module": "oracle",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf256d3fb6a50eaa748d94335b34f2982fbc3b63ceec78cafaa29ebc9ebaf2bbc",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "IFDGez/SJduJEqQk3Uuu1g/93mJe0v6q8oNyT5YI/qJm",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ZAAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ZAAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "PAAAAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > registerDeepbookPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "register_deepbook_pool",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > removeConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "remove_config",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580::oracle::PythConfig",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > revokeMaintainerCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "revoke_maintainer_cap",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > revokePauseCap 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "revoke_pause_cap",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAq80=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > setMaxOrderTtl 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "set_max_order_ttl",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "YOoAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > setMaxPriceAge 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "set_max_price_age",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "YOoAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > setMinOpenRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "set_min_open_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gHyBSgAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > setPriceTolerance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "set_price_tolerance",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginAdmin PTB snapshots > updateRiskParams 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "update_risk_params",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000abcd",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000aaaa",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`marginMaintainer PTB snapshots > createMarginPool 1`] = `
 {
   "commands": [

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -601,3 +601,952 @@ exports[`marginRegistry PTB snapshots > userLiquidationReward 1`] = `
   ],
 }
 `;
+
+exports[`marginTPSL PTB snapshots > addConditionalOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "new_condition",
+        "module": "tpsl",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pending_market_order",
+        "module": "tpsl",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 11,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 12,
+            "type": "pure",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+          {
+            "$kind": "Input",
+            "Input": 13,
+            "type": "object",
+          },
+        ],
+        "function": "add_conditional_order",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > cancelAllConditionalOrders 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "cancel_all_conditional_orders",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > cancelConditionalOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "cancel_conditional_order",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > conditionalOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "conditional_order",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > conditionalOrderIds 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "conditional_order_ids",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > executeConditionalOrders 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+        ],
+        "function": "execute_conditional_orders_v2",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > executeConditionalOrdersV3 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+        ],
+        "function": "execute_conditional_orders_v3",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > highestTriggerBelowPrice 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "highest_trigger_below_price",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > lowestTriggerAbovePrice 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "lowest_trigger_above_price",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > newCondition 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "new_condition",
+        "module": "tpsl",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > newPendingLimitOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pending_limit_order",
+        "module": "tpsl",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "mZmZmZmZmRk=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginTPSL PTB snapshots > newPendingMarketOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+        ],
+        "function": "new_pending_market_order",
+        "module": "tpsl",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQAAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+  ],
+}
+`;

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -1,0 +1,603 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`marginRegistry PTB snapshots > allowedMaintainers 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "allowed_maintainers",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > allowedPauseCaps 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "allowed_pause_caps",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > baseMarginPoolId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "base_margin_pool_id",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > getDeepbookPoolMarginPoolIds 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "get_deepbook_pool_margin_pool_ids",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > getMarginManagerIds 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "get_margin_manager_ids",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3q0=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > getMarginPoolId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "get_margin_pool_id",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > liquidationRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "liquidation_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > minBorrowRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "min_borrow_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > minOpenRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "min_open_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > minWithdrawRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "min_withdraw_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > poolEnabled 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "pool_enabled",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > poolLiquidationReward 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "pool_liquidation_reward",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > quoteMarginPoolId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "quote_margin_pool_id",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > targetLiquidationRiskRatio 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "target_liquidation_risk_ratio",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginRegistry PTB snapshots > userLiquidationReward 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "user_liquidation_reward",
+        "module": "margin_registry",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -2504,6 +2504,2965 @@ exports[`marginMaintainer PTB snapshots > updateMarginPoolConfig 1`] = `
 }
 `;
 
+exports[`marginManager PTB snapshots > account 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "account",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > accountExists 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "account_exists",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > accountOpenOrders 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "account_open_orders",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > balanceManager 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "balance_manager",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > balanceManagerId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "balance_manager_id",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > baseBalance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "base_balance",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > borrowBase 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "borrow_base",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > borrowQuote 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "borrow_quote",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > borrowedBaseShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "borrowed_base_shares",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > borrowedQuoteShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "borrowed_quote_shares",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > borrowedShares 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "borrowed_shares",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > calculateAssets 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "calculate_assets",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > calculateDebts 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+        ],
+        "function": "calculate_debts",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > canPlaceLimitOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "can_place_limit_order",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "6AMAAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > canPlaceMarketOrder 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+        ],
+        "function": "can_place_market_order",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > deepBalance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "deep_balance",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > deepbookPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "deepbook_pool",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > depositBase 1`] = `
+{
+  "commands": [
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000000n,
+          "outputKind": "coin",
+          "type": "gas",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "deposit",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > depositDeep 1`] = `
+{
+  "commands": [
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000n,
+          "outputKind": "coin",
+          "type": "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "deposit",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > depositDuringInitialization 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "new_with_initializer",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000000n,
+          "outputKind": "coin",
+          "type": "gas",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "NestedResult",
+            "NestedResult": [
+              0,
+              0,
+            ],
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "deposit",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > depositQuote 1`] = `
+{
+  "commands": [
+    {
+      "$Intent": {
+        "data": {
+          "balance": 1000000n,
+          "outputKind": "coin",
+          "type": "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        },
+        "inputs": {},
+        "name": "CoinWithBalance",
+      },
+      "$kind": "$Intent",
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "deposit",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > getAccountOrderDetails 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "get_account_order_details",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > getBalanceManagerReferralId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "get_balance_manager_referral_id",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > hasBaseDebt 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "has_base_debt",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > liquidate 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "liquidate",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000fff",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > lockedBalance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "locked_balance",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > managerState 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "manager_state",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > marginPoolId 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "margin_pool_id",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > newMarginManager 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "new",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > newMarginManagerWithInitializer 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "new_with_initializer",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > ownerByPoolKey 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "owner",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > quoteBalance 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+        ],
+        "function": "quote_balance",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > registerMarginManager 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "register_margin_manager",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > repayBase 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "repay_base",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQDKmjsAAAAA",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > repayBaseAll 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "repay_base",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AA==",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > repayQuote 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "repay_quote",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AUBCDwAAAAAA",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > setMarginManagerReferral 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "set_margin_manager_referral",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x0000000000000000000000000000000000000000000000000000000000000fff",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > shareMarginManager 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+        ],
+        "function": "new_with_initializer",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "NestedResult",
+            "NestedResult": [
+              0,
+              0,
+            ],
+          },
+          {
+            "$kind": "NestedResult",
+            "NestedResult": [
+              0,
+              1,
+            ],
+          },
+        ],
+        "function": "share",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > unregisterMarginManager 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+        ],
+        "function": "unregister_margin_manager",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > unsetMarginManagerReferral 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+        ],
+        "function": "unset_margin_manager_referral",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > withdrawBase 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > withdrawDeep 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginManager PTB snapshots > withdrawQuote 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+        ],
+        "function": "withdraw",
+        "module": "margin_manager",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+          "0xf7152c05930480cd740d7311b5b8b45c6f488e3a53a11c3f74a6fac36a52e0d7::DBUSDC::DBUSDC",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xf08568da93834e1ee04f09902ac7b1e78d3fdf113ab4d2106c7265e95318b14d",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1ebb295c789cc42b3b2a1606482cd1c7124076a0f5676718501fda8c7fd075a0",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x9c4dd4008297ffa5e480684b8100ec21cc934405ed9a25d4e4d7b6259aad9c81",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x1c19362ca52b8ffd7a33cee805a67d40f31e6ba303753fd3a4cfdfacea7163a5",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "QEIPAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`marginPool PTB snapshots > borrowShares 1`] = `
 {
   "commands": [

--- a/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
+++ b/packages/deepbook-v3/test/unit/transactions/__snapshots__/margin-ptb-snapshot.test.ts.snap
@@ -1,5 +1,985 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`marginMaintainer PTB snapshots > createMarginPool 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_margin_pool_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+        ],
+        "function": "new_interest_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+        ],
+        "function": "new_protocol_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 8,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 2,
+          },
+          {
+            "$kind": "Input",
+            "Input": 9,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 10,
+            "type": "object",
+          },
+        ],
+        "function": "create_margin_pool",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ABCl1OgAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOmkNQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gJaYAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAivLwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AGXNHQAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000bbbb",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > disableDeepbookPoolForLoan 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "disable_deepbook_pool_for_loan",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000cccc",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > enableDeepbookPoolForLoan 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "object",
+          },
+        ],
+        "function": "enable_deepbook_pool_for_loan",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000cccc",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "HBk2LKUrj/16M87oBaZ9QPMea6MDdT/TpM/frOpxY6U=",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > newInterestConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_interest_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gJaYAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAivLwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AGXNHQAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > newMarginPoolConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_margin_pool_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ABCl1OgAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOmkNQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > newMarginPoolConfigWithRateLimit 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+        ],
+        "function": "new_margin_pool_config_with_rate_limit",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ABCl1OgAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOmkNQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOh2SBcAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AQ==",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > newProtocolConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+        ],
+        "function": "new_margin_pool_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "pure",
+          },
+        ],
+        "function": "new_interest_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Result",
+            "Result": 1,
+          },
+        ],
+        "function": "new_protocol_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ABCl1OgAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOmkNQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gJaYAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAivLwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AGXNHQAAAAA=",
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > updateInterestParams 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+        ],
+        "function": "new_interest_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "update_interest_params",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000cccc",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "gJaYAAAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AAivLwAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AGXNHQAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`marginMaintainer PTB snapshots > updateMarginPoolConfig 1`] = `
+{
+  "commands": [
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 1,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 2,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 3,
+            "type": "pure",
+          },
+          {
+            "$kind": "Input",
+            "Input": 4,
+            "type": "pure",
+          },
+        ],
+        "function": "new_margin_pool_config",
+        "module": "protocol_config",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [],
+      },
+    },
+    {
+      "$kind": "MoveCall",
+      "MoveCall": {
+        "arguments": [
+          {
+            "$kind": "Input",
+            "Input": 5,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 6,
+            "type": "object",
+          },
+          {
+            "$kind": "Result",
+            "Result": 0,
+          },
+          {
+            "$kind": "Input",
+            "Input": 0,
+            "type": "object",
+          },
+          {
+            "$kind": "Input",
+            "Input": 7,
+            "type": "object",
+          },
+        ],
+        "function": "update_margin_pool_config",
+        "module": "margin_pool",
+        "package": "0xe52c1dece2bb5d5645689d6da8b8debe8347e3446011704a4fcb386746876580",
+        "typeArguments": [
+          "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        ],
+      },
+    },
+  ],
+  "inputs": [
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x000000000000000000000000000000000000000000000000000000000000cccc",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "ABCl1OgAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOmkNQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AOH1BQAAAAA=",
+      },
+    },
+    {
+      "$kind": "Pure",
+      "Pure": {
+        "bytes": "AMqaOwAAAAA=",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0xcdbbe6a72e639b647296788e2e4b1cac5cea4246028ba388ba1332ff9a382eea",
+      },
+    },
+    {
+      "$kind": "UnresolvedObject",
+      "UnresolvedObject": {
+        "objectId": "0x48d7640dfae2c6e9ceeada197a7a1643984b5a24c55a0c6c023dac77e0339f75",
+      },
+    },
+    {
+      "$kind": "Object",
+      "Object": {
+        "$kind": "SharedObject",
+        "SharedObject": {
+          "initialSharedVersion": 1,
+          "mutable": false,
+          "objectId": "0x0000000000000000000000000000000000000000000000000000000000000006",
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`marginRegistry PTB snapshots > allowedMaintainers 1`] = `
 {
   "commands": [

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// PTB byte-identity guard for the margin codegen migration.
+// Each builder's emitted PTB (tx.getData: inputs + commands) is snapshotted.
+// Migrating a builder from positional moveCall to a generated named-arg call
+// must NOT change the snapshot — that is the proof the migration is non-breaking.
+import { Transaction } from '@mysten/sui/transactions';
+import { describe, expect, it } from 'vitest';
+
+import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
+import { DeepBookConfig } from '../../../src/utils/config.js';
+
+const POOL_KEY = 'SUI_DBUSDC';
+const COIN_KEY = 'SUI';
+const OWNER = '0x000000000000000000000000000000000000000000000000000000000000dead';
+
+function config() {
+	return new DeepBookConfig({
+		network: 'testnet',
+		address: '0x1',
+		marginManagers: {
+			TEST_MGR: {
+				address: '0x2222222222222222222222222222222222222222222222222222222222222222',
+				poolKey: POOL_KEY,
+			},
+		},
+		marginAdminCap: '0x000000000000000000000000000000000000000000000000000000000000aaaa',
+		marginMaintainerCap: '0x000000000000000000000000000000000000000000000000000000000000bbbb',
+	});
+}
+
+// Serialize the parts of a PTB that define what executes: inputs (values) and
+// commands (targets, arg references, type args). Byte-identical => same tx.
+function ptb(build: (tx: Transaction) => unknown) {
+	const tx = new Transaction();
+	tx.setSender('0x1');
+	build(tx);
+	const { inputs, commands } = tx.getData();
+	return { inputs, commands };
+}
+
+describe('marginRegistry PTB snapshots', () => {
+	const c = () => new MarginRegistryContract(config());
+	const cases: Array<[string, (m: MarginRegistryContract) => (tx: Transaction) => unknown]> = [
+		['poolEnabled', (m) => m.poolEnabled(POOL_KEY)],
+		['getMarginPoolId', (m) => m.getMarginPoolId(COIN_KEY)],
+		['getDeepbookPoolMarginPoolIds', (m) => m.getDeepbookPoolMarginPoolIds(POOL_KEY)],
+		['getMarginManagerIds', (m) => m.getMarginManagerIds(OWNER)],
+		['baseMarginPoolId', (m) => m.baseMarginPoolId(POOL_KEY)],
+		['quoteMarginPoolId', (m) => m.quoteMarginPoolId(POOL_KEY)],
+		['minWithdrawRiskRatio', (m) => m.minWithdrawRiskRatio(POOL_KEY)],
+		['minBorrowRiskRatio', (m) => m.minBorrowRiskRatio(POOL_KEY)],
+		['minOpenRiskRatio', (m) => m.minOpenRiskRatio(POOL_KEY)],
+		['liquidationRiskRatio', (m) => m.liquidationRiskRatio(POOL_KEY)],
+		['targetLiquidationRiskRatio', (m) => m.targetLiquidationRiskRatio(POOL_KEY)],
+		['userLiquidationReward', (m) => m.userLiquidationReward(POOL_KEY)],
+		['poolLiquidationReward', (m) => m.poolLiquidationReward(POOL_KEY)],
+		['allowedMaintainers', (m) => m.allowedMaintainers()],
+		['allowedPauseCaps', (m) => m.allowedPauseCaps()],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -9,6 +9,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { describe, expect, it } from 'vitest';
 
 import { MarginAdminContract } from '../../../src/transactions/marginAdmin.js';
+import { MarginLiquidationsContract } from '../../../src/transactions/marginLiquidations.js';
 import { MarginMaintainerContract } from '../../../src/transactions/marginMaintainer.js';
 import { MarginManagerContract } from '../../../src/transactions/marginManager.js';
 import { MarginPoolContract } from '../../../src/transactions/marginPool.js';
@@ -74,16 +75,35 @@ describe('marginRegistry PTB snapshots', () => {
 
 describe('poolProxy PTB snapshots', () => {
 	const c = () => new PoolProxyContract(config());
-	const limit = { poolKey: POOL_KEY, marginManagerKey: MGR_KEY, clientOrderId: '1', price: 1, quantity: 1, isBid: true };
-	const market = { poolKey: POOL_KEY, marginManagerKey: MGR_KEY, clientOrderId: '1', quantity: 1, isBid: true };
+	const limit = {
+		poolKey: POOL_KEY,
+		marginManagerKey: MGR_KEY,
+		clientOrderId: '1',
+		price: 1,
+		quantity: 1,
+		isBid: true,
+	};
+	const market = {
+		poolKey: POOL_KEY,
+		marginManagerKey: MGR_KEY,
+		clientOrderId: '1',
+		quantity: 1,
+		isBid: true,
+	};
 	const cases: Array<[string, (m: PoolProxyContract) => (tx: Transaction) => unknown]> = [
 		['placeLimitOrder', (m) => m.placeLimitOrder(limit)],
 		['placeMarketOrder', (m) => m.placeMarketOrder(market)],
 		['placeReduceOnlyLimitOrder', (m) => m.placeReduceOnlyLimitOrder(limit)],
 		['placeReduceOnlyMarketOrder', (m) => m.placeReduceOnlyMarketOrder(market)],
 		['placeMarketOrderAndRepayLoan', (m) => m.placeMarketOrderAndRepayLoan(market)],
-		['placeReduceOnlyLimitOrderAndRepayLoan', (m) => m.placeReduceOnlyLimitOrderAndRepayLoan(limit)],
-		['placeReduceOnlyMarketOrderAndRepayLoan', (m) => m.placeReduceOnlyMarketOrderAndRepayLoan(market)],
+		[
+			'placeReduceOnlyLimitOrderAndRepayLoan',
+			(m) => m.placeReduceOnlyLimitOrderAndRepayLoan(limit),
+		],
+		[
+			'placeReduceOnlyMarketOrderAndRepayLoan',
+			(m) => m.placeReduceOnlyMarketOrderAndRepayLoan(market),
+		],
 		['modifyOrder', (m) => m.modifyOrder(MGR_KEY, '123', 1)],
 		['cancelOrder', (m) => m.cancelOrder(MGR_KEY, '123')],
 		['cancelOrders', (m) => m.cancelOrders(MGR_KEY, ['123', '456'])],
@@ -91,11 +111,32 @@ describe('poolProxy PTB snapshots', () => {
 		['withdrawSettledAmounts', (m) => m.withdrawSettledAmounts(MGR_KEY)],
 		['stake', (m) => m.stake(MGR_KEY, 1)],
 		['unstake', (m) => m.unstake(MGR_KEY)],
-		['submitProposal', (m) => m.submitProposal(MGR_KEY, { takerFee: 0.001, makerFee: 0.001, stakeRequired: 100 })],
+		[
+			'submitProposal',
+			(m) => m.submitProposal(MGR_KEY, { takerFee: 0.001, makerFee: 0.001, stakeRequired: 100 }),
+		],
 		['vote', (m) => m.vote(MGR_KEY, MGR_ADDR)],
 		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
 		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
 		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginLiquidations PTB snapshots', () => {
+	const c = () => new MarginLiquidationsContract(config());
+	const VAULT = '0x0000000000000000000000000000000000000000000000000000000000009999';
+	const CAP = '0x0000000000000000000000000000000000000000000000000000000000008888';
+	const cases: Array<[string, (m: MarginLiquidationsContract) => (tx: Transaction) => unknown]> = [
+		['createLiquidationVault', (m) => m.createLiquidationVault(CAP)],
+		['deposit', (m) => m.deposit(VAULT, CAP, COIN_KEY, 1)],
+		['withdraw', (m) => m.withdraw(VAULT, CAP, COIN_KEY, 1)],
+		['liquidateBase', (m) => m.liquidateBase(VAULT, MGR_ADDR, POOL_KEY, 1)],
+		['liquidateBaseAll', (m) => m.liquidateBase(VAULT, MGR_ADDR, POOL_KEY)],
+		['liquidateQuote', (m) => m.liquidateQuote(VAULT, MGR_ADDR, POOL_KEY, 1)],
+		['balance', (m) => m.balance(VAULT, COIN_KEY)],
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();
@@ -144,9 +185,12 @@ describe('marginManager PTB snapshots', () => {
 			'depositDuringInitialization',
 			(m) => (tx: Transaction) => {
 				const { manager } = m.newMarginManagerWithInitializer(POOL_KEY)(tx);
-				m.depositDuringInitialization({ manager, poolKey: POOL_KEY, coinType: COIN_KEY, amount: 1 })(
-					tx,
-				);
+				m.depositDuringInitialization({
+					manager,
+					poolKey: POOL_KEY,
+					coinType: COIN_KEY,
+					amount: 1,
+				})(tx);
 			},
 		],
 		['depositBase', (m) => m.depositBase({ managerKey: MGR_KEY, amount: 1 })],
@@ -160,14 +204,14 @@ describe('marginManager PTB snapshots', () => {
 		['repayBase', (m) => m.repayBase(MGR_KEY, 1)],
 		['repayBaseAll', (m) => m.repayBase(MGR_KEY)],
 		['repayQuote', (m) => m.repayQuote(MGR_KEY, 1)],
-		['liquidate', (m) => (tx: Transaction) => m.liquidate(MGR_ADDR, POOL_KEY, true, tx.object(COIN))(tx)],
+		[
+			'liquidate',
+			(m) => (tx: Transaction) => m.liquidate(MGR_ADDR, POOL_KEY, true, tx.object(COIN))(tx),
+		],
 		['setMarginManagerReferral', (m) => m.setMarginManagerReferral(MGR_KEY, COIN)],
 		['unsetMarginManagerReferral', (m) => m.unsetMarginManagerReferral(MGR_KEY, POOL_KEY)],
 		['calculateDebts', (m) => m.calculateDebts(POOL_KEY, COIN_KEY, MGR_ADDR)],
-		[
-			'canPlaceLimitOrder',
-			(m) => m.canPlaceLimitOrder(POOL_KEY, MGR_ADDR, 1, 1, true, true, 1000),
-		],
+		['canPlaceLimitOrder', (m) => m.canPlaceLimitOrder(POOL_KEY, MGR_ADDR, 1, 1, true, true, 1000)],
 		['canPlaceMarketOrder', (m) => m.canPlaceMarketOrder(POOL_KEY, MGR_ADDR, 1, true, true)],
 		...twoArgReads.map(
 			(fn): [string, (m: MarginManagerContract) => (tx: Transaction) => unknown] => [
@@ -195,10 +239,16 @@ describe('marginAdmin PTB snapshots', () => {
 	const cases: Array<[string, (m: MarginAdminContract) => (tx: Transaction) => unknown]> = [
 		['mintMaintainerCap', (m) => m.mintMaintainerCap()],
 		['revokeMaintainerCap', (m) => m.revokeMaintainerCap(ID)],
-		['registerDeepbookPool', (m) => (tx: Transaction) => m.registerDeepbookPool(POOL_KEY, tx.object(ID))(tx)],
+		[
+			'registerDeepbookPool',
+			(m) => (tx: Transaction) => m.registerDeepbookPool(POOL_KEY, tx.object(ID))(tx),
+		],
 		['enableDeepbookPool', (m) => m.enableDeepbookPool(POOL_KEY)],
 		['disableDeepbookPool', (m) => m.disableDeepbookPool(POOL_KEY)],
-		['updateRiskParams', (m) => (tx: Transaction) => m.updateRiskParams(POOL_KEY, tx.object(ID))(tx)],
+		[
+			'updateRiskParams',
+			(m) => (tx: Transaction) => m.updateRiskParams(POOL_KEY, tx.object(ID))(tx),
+		],
 		['setPriceTolerance', (m) => m.setPriceTolerance(POOL_KEY, 0.1)],
 		['setMaxPriceAge', (m) => m.setMaxPriceAge(POOL_KEY, 60000)],
 		['setMaxOrderTtl', (m) => m.setMaxOrderTtl(POOL_KEY, 60000)],
@@ -212,7 +262,8 @@ describe('marginAdmin PTB snapshots', () => {
 		['newCoinTypeData', (m) => m.newCoinTypeData(COIN_KEY, 100, 100)],
 		[
 			'newPythConfig',
-			(m) => m.newPythConfig([{ coinKey: COIN_KEY, maxConfBps: 100, maxEwmaDifferenceBps: 100 }], 60),
+			(m) =>
+				m.newPythConfig([{ coinKey: COIN_KEY, maxConfBps: 100, maxEwmaDifferenceBps: 100 }], 60),
 		],
 		['mintPauseCap', (m) => m.mintPauseCap()],
 		['revokePauseCap', (m) => m.revokePauseCap(ID)],
@@ -256,12 +307,10 @@ describe('marginPool PTB snapshots', () => {
 		['deepbookPoolAllowed', (m) => m.deepbookPoolAllowed(COIN_KEY, ID)],
 		['userSupplyShares', (m) => m.userSupplyShares(COIN_KEY, ID)],
 		['userSupplyAmount', (m) => m.userSupplyAmount(COIN_KEY, ID)],
-		...reads.map(
-			(fn): [string, (m: MarginPoolContract) => (tx: Transaction) => unknown] => [
-				fn,
-				(m) => m[fn](COIN_KEY),
-			],
-		),
+		...reads.map((fn): [string, (m: MarginPoolContract) => (tx: Transaction) => unknown] => [
+			fn,
+			(m) => m[fn](COIN_KEY),
+		]),
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();
@@ -282,7 +331,10 @@ describe('marginMaintainer PTB snapshots', () => {
 	const cases: Array<[string, (m: MarginMaintainerContract) => (tx: Transaction) => unknown]> = [
 		['newInterestConfig', (m) => m.newInterestConfig(IC)],
 		['newMarginPoolConfig', (m) => m.newMarginPoolConfig(COIN_KEY, MPC)],
-		['newMarginPoolConfigWithRateLimit', (m) => m.newMarginPoolConfigWithRateLimit(COIN_KEY, MPC_RL)],
+		[
+			'newMarginPoolConfigWithRateLimit',
+			(m) => m.newMarginPoolConfigWithRateLimit(COIN_KEY, MPC_RL),
+		],
 		['newProtocolConfig', (m) => m.newProtocolConfig(COIN_KEY, MPC, IC)],
 		[
 			'createMarginPool',
@@ -293,11 +345,13 @@ describe('marginMaintainer PTB snapshots', () => {
 		],
 		[
 			'enableDeepbookPoolForLoan',
-			(m) => (tx: Transaction) => m.enableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
+			(m) => (tx: Transaction) =>
+				m.enableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
 		],
 		[
 			'disableDeepbookPoolForLoan',
-			(m) => (tx: Transaction) => m.disableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
+			(m) => (tx: Transaction) =>
+				m.disableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
 		],
 		[
 			'updateInterestParams',
@@ -319,7 +373,13 @@ describe('marginTPSL PTB snapshots', () => {
 		['newCondition', (m) => m.newCondition(POOL_KEY, true, 1)],
 		[
 			'newPendingLimitOrder',
-			(m) => m.newPendingLimitOrder(POOL_KEY, { clientOrderId: '1', price: 1, quantity: 1, isBid: true }),
+			(m) =>
+				m.newPendingLimitOrder(POOL_KEY, {
+					clientOrderId: '1',
+					price: 1,
+					quantity: 1,
+					isBid: true,
+				}),
 		],
 		[
 			'newPendingMarketOrder',

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -9,6 +9,7 @@ import { Transaction } from '@mysten/sui/transactions';
 import { describe, expect, it } from 'vitest';
 
 import { MarginMaintainerContract } from '../../../src/transactions/marginMaintainer.js';
+import { MarginPoolContract } from '../../../src/transactions/marginPool.js';
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
 import { MarginTPSLContract } from '../../../src/transactions/marginTPSL.js';
 import { PoolProxyContract } from '../../../src/transactions/poolProxy.js';
@@ -93,6 +94,50 @@ describe('poolProxy PTB snapshots', () => {
 		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
 		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
 		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginPool PTB snapshots', () => {
+	const c = () => new MarginPoolContract(config());
+	const CAP = '0x000000000000000000000000000000000000000000000000000000000000dddd';
+	const ID = '0x000000000000000000000000000000000000000000000000000000000000eeee';
+	const reads = [
+		'getId',
+		'totalSupply',
+		'supplyShares',
+		'totalBorrow',
+		'borrowShares',
+		'lastUpdateTimestamp',
+		'supplyCap',
+		'maxUtilizationRate',
+		'protocolSpread',
+		'minBorrow',
+		'interestRate',
+	] as const;
+	const cases: Array<[string, (m: MarginPoolContract) => (tx: Transaction) => unknown]> = [
+		['mintSupplierCap', (m) => m.mintSupplierCap()],
+		[
+			'supplyToMarginPool',
+			(m) => (tx: Transaction) => m.supplyToMarginPool(COIN_KEY, tx.object(CAP), 1)(tx),
+		],
+		[
+			'withdrawFromMarginPool',
+			(m) => (tx: Transaction) => m.withdrawFromMarginPool(COIN_KEY, tx.object(CAP), 1)(tx),
+		],
+		['mintSupplyReferral', (m) => m.mintSupplyReferral(COIN_KEY)],
+		['withdrawReferralFees', (m) => m.withdrawReferralFees(COIN_KEY, ID)],
+		['deepbookPoolAllowed', (m) => m.deepbookPoolAllowed(COIN_KEY, ID)],
+		['userSupplyShares', (m) => m.userSupplyShares(COIN_KEY, ID)],
+		['userSupplyAmount', (m) => m.userSupplyAmount(COIN_KEY, ID)],
+		...reads.map(
+			(fn): [string, (m: MarginPoolContract) => (tx: Transaction) => unknown] => [
+				fn,
+				(m) => m[fn](COIN_KEY),
+			],
+		),
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 
 import { MarginAdminContract } from '../../../src/transactions/marginAdmin.js';
 import { MarginMaintainerContract } from '../../../src/transactions/marginMaintainer.js';
+import { MarginManagerContract } from '../../../src/transactions/marginManager.js';
 import { MarginPoolContract } from '../../../src/transactions/marginPool.js';
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
 import { MarginTPSLContract } from '../../../src/transactions/marginTPSL.js';
@@ -95,6 +96,85 @@ describe('poolProxy PTB snapshots', () => {
 		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
 		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
 		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginManager PTB snapshots', () => {
+	const c = () => new MarginManagerContract(config());
+	const COIN = '0x0000000000000000000000000000000000000000000000000000000000000fff';
+	// reads taking (poolKey, marginManagerId)
+	const twoArgReads = [
+		'ownerByPoolKey',
+		'deepbookPool',
+		'marginPoolId',
+		'borrowedShares',
+		'borrowedBaseShares',
+		'borrowedQuoteShares',
+		'hasBaseDebt',
+		'balanceManager',
+		'calculateAssets',
+		'managerState',
+		'baseBalance',
+		'quoteBalance',
+		'deepBalance',
+		'balanceManagerId',
+		'getBalanceManagerReferralId',
+		'accountExists',
+		'account',
+		'accountOpenOrders',
+		'getAccountOrderDetails',
+		'lockedBalance',
+	] as const;
+	const cases: Array<[string, (m: MarginManagerContract) => (tx: Transaction) => unknown]> = [
+		['newMarginManager', (m) => m.newMarginManager(POOL_KEY)],
+		['newMarginManagerWithInitializer', (m) => m.newMarginManagerWithInitializer(POOL_KEY)],
+		[
+			'shareMarginManager',
+			(m) => (tx: Transaction) => {
+				const { manager, initializer } = m.newMarginManagerWithInitializer(POOL_KEY)(tx);
+				m.shareMarginManager(POOL_KEY, manager, initializer)(tx);
+			},
+		],
+		['registerMarginManager', (m) => m.registerMarginManager(MGR_KEY)],
+		['unregisterMarginManager', (m) => m.unregisterMarginManager(MGR_KEY)],
+		[
+			'depositDuringInitialization',
+			(m) => (tx: Transaction) => {
+				const { manager } = m.newMarginManagerWithInitializer(POOL_KEY)(tx);
+				m.depositDuringInitialization({ manager, poolKey: POOL_KEY, coinType: COIN_KEY, amount: 1 })(
+					tx,
+				);
+			},
+		],
+		['depositBase', (m) => m.depositBase({ managerKey: MGR_KEY, amount: 1 })],
+		['depositQuote', (m) => m.depositQuote({ managerKey: MGR_KEY, amount: 1 })],
+		['depositDeep', (m) => m.depositDeep({ managerKey: MGR_KEY, amount: 1 })],
+		['withdrawBase', (m) => m.withdrawBase(MGR_KEY, 1)],
+		['withdrawQuote', (m) => m.withdrawQuote(MGR_KEY, 1)],
+		['withdrawDeep', (m) => m.withdrawDeep(MGR_KEY, 1)],
+		['borrowBase', (m) => m.borrowBase(MGR_KEY, 1)],
+		['borrowQuote', (m) => m.borrowQuote(MGR_KEY, 1)],
+		['repayBase', (m) => m.repayBase(MGR_KEY, 1)],
+		['repayBaseAll', (m) => m.repayBase(MGR_KEY)],
+		['repayQuote', (m) => m.repayQuote(MGR_KEY, 1)],
+		['liquidate', (m) => (tx: Transaction) => m.liquidate(MGR_ADDR, POOL_KEY, true, tx.object(COIN))(tx)],
+		['setMarginManagerReferral', (m) => m.setMarginManagerReferral(MGR_KEY, COIN)],
+		['unsetMarginManagerReferral', (m) => m.unsetMarginManagerReferral(MGR_KEY, POOL_KEY)],
+		['calculateDebts', (m) => m.calculateDebts(POOL_KEY, COIN_KEY, MGR_ADDR)],
+		[
+			'canPlaceLimitOrder',
+			(m) => m.canPlaceLimitOrder(POOL_KEY, MGR_ADDR, 1, 1, true, true, 1000),
+		],
+		['canPlaceMarketOrder', (m) => m.canPlaceMarketOrder(POOL_KEY, MGR_ADDR, 1, true, true)],
+		...twoArgReads.map(
+			(fn): [string, (m: MarginManagerContract) => (tx: Transaction) => unknown] => [
+				fn,
+				(m) => m[fn](POOL_KEY, MGR_ADDR),
+			],
+		),
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -9,11 +9,14 @@ import { Transaction } from '@mysten/sui/transactions';
 import { describe, expect, it } from 'vitest';
 
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
+import { MarginTPSLContract } from '../../../src/transactions/marginTPSL.js';
 import { DeepBookConfig } from '../../../src/utils/config.js';
 
 const POOL_KEY = 'SUI_DBUSDC';
 const COIN_KEY = 'SUI';
 const OWNER = '0x000000000000000000000000000000000000000000000000000000000000dead';
+const MGR_KEY = 'TEST_MGR';
+const MGR_ADDR = '0x2222222222222222222222222222222222222222222222222222222222222222';
 
 function config() {
 	return new DeepBookConfig({
@@ -58,6 +61,43 @@ describe('marginRegistry PTB snapshots', () => {
 		['poolLiquidationReward', (m) => m.poolLiquidationReward(POOL_KEY)],
 		['allowedMaintainers', (m) => m.allowedMaintainers()],
 		['allowedPauseCaps', (m) => m.allowedPauseCaps()],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginTPSL PTB snapshots', () => {
+	const c = () => new MarginTPSLContract(config());
+	const cases: Array<[string, (m: MarginTPSLContract) => (tx: Transaction) => unknown]> = [
+		['newCondition', (m) => m.newCondition(POOL_KEY, true, 1)],
+		[
+			'newPendingLimitOrder',
+			(m) => m.newPendingLimitOrder(POOL_KEY, { clientOrderId: '1', price: 1, quantity: 1, isBid: true }),
+		],
+		[
+			'newPendingMarketOrder',
+			(m) => m.newPendingMarketOrder(POOL_KEY, { clientOrderId: '1', quantity: 1, isBid: true }),
+		],
+		[
+			'addConditionalOrder',
+			(m) =>
+				m.addConditionalOrder({
+					marginManagerKey: MGR_KEY,
+					conditionalOrderId: '1',
+					triggerBelowPrice: true,
+					triggerPrice: 1,
+					pendingOrder: { clientOrderId: '1', quantity: 1, isBid: true },
+				}),
+		],
+		['cancelAllConditionalOrders', (m) => m.cancelAllConditionalOrders(MGR_KEY)],
+		['cancelConditionalOrder', (m) => m.cancelConditionalOrder(MGR_KEY, '1')],
+		['executeConditionalOrders', (m) => m.executeConditionalOrders(MGR_ADDR, POOL_KEY, 1)],
+		['executeConditionalOrdersV3', (m) => m.executeConditionalOrdersV3(MGR_ADDR, POOL_KEY, 1)],
+		['conditionalOrderIds', (m) => m.conditionalOrderIds(POOL_KEY, MGR_ADDR)],
+		['conditionalOrder', (m) => m.conditionalOrder(POOL_KEY, MGR_ADDR, '1')],
+		['lowestTriggerAbovePrice', (m) => m.lowestTriggerAbovePrice(POOL_KEY, MGR_ADDR)],
+		['highestTriggerBelowPrice', (m) => m.highestTriggerBelowPrice(POOL_KEY, MGR_ADDR)],
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
 import { MarginTPSLContract } from '../../../src/transactions/marginTPSL.js';
+import { PoolProxyContract } from '../../../src/transactions/poolProxy.js';
 import { DeepBookConfig } from '../../../src/utils/config.js';
 
 const POOL_KEY = 'SUI_DBUSDC';
@@ -61,6 +62,36 @@ describe('marginRegistry PTB snapshots', () => {
 		['poolLiquidationReward', (m) => m.poolLiquidationReward(POOL_KEY)],
 		['allowedMaintainers', (m) => m.allowedMaintainers()],
 		['allowedPauseCaps', (m) => m.allowedPauseCaps()],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('poolProxy PTB snapshots', () => {
+	const c = () => new PoolProxyContract(config());
+	const limit = { poolKey: POOL_KEY, marginManagerKey: MGR_KEY, clientOrderId: '1', price: 1, quantity: 1, isBid: true };
+	const market = { poolKey: POOL_KEY, marginManagerKey: MGR_KEY, clientOrderId: '1', quantity: 1, isBid: true };
+	const cases: Array<[string, (m: PoolProxyContract) => (tx: Transaction) => unknown]> = [
+		['placeLimitOrder', (m) => m.placeLimitOrder(limit)],
+		['placeMarketOrder', (m) => m.placeMarketOrder(market)],
+		['placeReduceOnlyLimitOrder', (m) => m.placeReduceOnlyLimitOrder(limit)],
+		['placeReduceOnlyMarketOrder', (m) => m.placeReduceOnlyMarketOrder(market)],
+		['placeMarketOrderAndRepayLoan', (m) => m.placeMarketOrderAndRepayLoan(market)],
+		['placeReduceOnlyLimitOrderAndRepayLoan', (m) => m.placeReduceOnlyLimitOrderAndRepayLoan(limit)],
+		['placeReduceOnlyMarketOrderAndRepayLoan', (m) => m.placeReduceOnlyMarketOrderAndRepayLoan(market)],
+		['modifyOrder', (m) => m.modifyOrder(MGR_KEY, '123', 1)],
+		['cancelOrder', (m) => m.cancelOrder(MGR_KEY, '123')],
+		['cancelOrders', (m) => m.cancelOrders(MGR_KEY, ['123', '456'])],
+		['cancelAllOrders', (m) => m.cancelAllOrders(MGR_KEY)],
+		['withdrawSettledAmounts', (m) => m.withdrawSettledAmounts(MGR_KEY)],
+		['stake', (m) => m.stake(MGR_KEY, 1)],
+		['unstake', (m) => m.unstake(MGR_KEY)],
+		['submitProposal', (m) => m.submitProposal(MGR_KEY, { takerFee: 0.001, makerFee: 0.001, stakeRequired: 100 })],
+		['vote', (m) => m.vote(MGR_KEY, MGR_ADDR)],
+		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
+		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
+		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -8,6 +8,7 @@
 import { Transaction } from '@mysten/sui/transactions';
 import { describe, expect, it } from 'vitest';
 
+import { MarginMaintainerContract } from '../../../src/transactions/marginMaintainer.js';
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
 import { MarginTPSLContract } from '../../../src/transactions/marginTPSL.js';
 import { PoolProxyContract } from '../../../src/transactions/poolProxy.js';
@@ -92,6 +93,51 @@ describe('poolProxy PTB snapshots', () => {
 		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
 		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
 		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginMaintainer PTB snapshots', () => {
+	const c = () => new MarginMaintainerContract(config());
+	const CAP = '0x000000000000000000000000000000000000000000000000000000000000cccc';
+	const IC = { baseRate: 0.01, baseSlope: 0.1, optimalUtilization: 0.8, excessSlope: 0.5 };
+	const MPC = { supplyCap: 1000, maxUtilizationRate: 0.9, protocolSpread: 0.1, minBorrow: 1 };
+	const MPC_RL = {
+		...MPC,
+		rateLimitCapacity: 100,
+		rateLimitRefillRatePerMs: 1,
+		rateLimitEnabled: true,
+	};
+	const cases: Array<[string, (m: MarginMaintainerContract) => (tx: Transaction) => unknown]> = [
+		['newInterestConfig', (m) => m.newInterestConfig(IC)],
+		['newMarginPoolConfig', (m) => m.newMarginPoolConfig(COIN_KEY, MPC)],
+		['newMarginPoolConfigWithRateLimit', (m) => m.newMarginPoolConfigWithRateLimit(COIN_KEY, MPC_RL)],
+		['newProtocolConfig', (m) => m.newProtocolConfig(COIN_KEY, MPC, IC)],
+		[
+			'createMarginPool',
+			(m) => (tx: Transaction) => {
+				const cfg = m.newProtocolConfig(COIN_KEY, MPC, IC)(tx);
+				m.createMarginPool(COIN_KEY, cfg)(tx);
+			},
+		],
+		[
+			'enableDeepbookPoolForLoan',
+			(m) => (tx: Transaction) => m.enableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
+		],
+		[
+			'disableDeepbookPoolForLoan',
+			(m) => (tx: Transaction) => m.disableDeepbookPoolForLoan(POOL_KEY, COIN_KEY, tx.object(CAP))(tx),
+		],
+		[
+			'updateInterestParams',
+			(m) => (tx: Transaction) => m.updateInterestParams(COIN_KEY, tx.object(CAP), IC)(tx),
+		],
+		[
+			'updateMarginPoolConfig',
+			(m) => (tx: Transaction) => m.updateMarginPoolConfig(COIN_KEY, tx.object(CAP), MPC)(tx),
+		],
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();

--- a/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
+++ b/packages/deepbook-v3/test/unit/transactions/margin-ptb-snapshot.test.ts
@@ -8,6 +8,7 @@
 import { Transaction } from '@mysten/sui/transactions';
 import { describe, expect, it } from 'vitest';
 
+import { MarginAdminContract } from '../../../src/transactions/marginAdmin.js';
 import { MarginMaintainerContract } from '../../../src/transactions/marginMaintainer.js';
 import { MarginPoolContract } from '../../../src/transactions/marginPool.js';
 import { MarginRegistryContract } from '../../../src/transactions/marginRegistry.js';
@@ -94,6 +95,49 @@ describe('poolProxy PTB snapshots', () => {
 		['claimRebate', (m) => m.claimRebate(MGR_KEY)],
 		['withdrawMarginSettledAmounts', (m) => m.withdrawMarginSettledAmounts(POOL_KEY, MGR_ADDR)],
 		['updateCurrentPrice', (m) => m.updateCurrentPrice(POOL_KEY)],
+	];
+	it.each(cases)('%s', (_name, build) => {
+		expect(ptb(build(c()))).toMatchSnapshot();
+	});
+});
+
+describe('marginAdmin PTB snapshots', () => {
+	const c = () => new MarginAdminContract(config());
+	const ID = '0x000000000000000000000000000000000000000000000000000000000000abcd';
+	const PCP = {
+		minWithdrawRiskRatio: 2,
+		minBorrowRiskRatio: 1.5,
+		liquidationRiskRatio: 1.1,
+		targetLiquidationRiskRatio: 1.2,
+		userLiquidationReward: 0.05,
+		poolLiquidationReward: 0.01,
+	};
+	const cases: Array<[string, (m: MarginAdminContract) => (tx: Transaction) => unknown]> = [
+		['mintMaintainerCap', (m) => m.mintMaintainerCap()],
+		['revokeMaintainerCap', (m) => m.revokeMaintainerCap(ID)],
+		['registerDeepbookPool', (m) => (tx: Transaction) => m.registerDeepbookPool(POOL_KEY, tx.object(ID))(tx)],
+		['enableDeepbookPool', (m) => m.enableDeepbookPool(POOL_KEY)],
+		['disableDeepbookPool', (m) => m.disableDeepbookPool(POOL_KEY)],
+		['updateRiskParams', (m) => (tx: Transaction) => m.updateRiskParams(POOL_KEY, tx.object(ID))(tx)],
+		['setPriceTolerance', (m) => m.setPriceTolerance(POOL_KEY, 0.1)],
+		['setMaxPriceAge', (m) => m.setMaxPriceAge(POOL_KEY, 60000)],
+		['setMaxOrderTtl', (m) => m.setMaxOrderTtl(POOL_KEY, 60000)],
+		['setMinOpenRiskRatio', (m) => m.setMinOpenRiskRatio(POOL_KEY, 1.25)],
+		['addConfig', (m) => (tx: Transaction) => m.addConfig(tx.object(ID))(tx)],
+		['removeConfig', (m) => m.removeConfig()],
+		['enableVersion', (m) => m.enableVersion(3)],
+		['disableVersion', (m) => m.disableVersion(3)],
+		['newPoolConfig', (m) => m.newPoolConfig(POOL_KEY, PCP)],
+		['newPoolConfigWithLeverage', (m) => m.newPoolConfigWithLeverage(POOL_KEY, 5)],
+		['newCoinTypeData', (m) => m.newCoinTypeData(COIN_KEY, 100, 100)],
+		[
+			'newPythConfig',
+			(m) => m.newPythConfig([{ coinKey: COIN_KEY, maxConfBps: 100, maxEwmaDifferenceBps: 100 }], 60),
+		],
+		['mintPauseCap', (m) => m.mintPauseCap()],
+		['revokePauseCap', (m) => m.revokePauseCap(ID)],
+		['disableVersionPauseCap', (m) => m.disableVersionPauseCap(3, ID)],
+		['adminWithdrawDefaultReferralFees', (m) => m.adminWithdrawDefaultReferralFees(COIN_KEY)],
 	];
 	it.each(cases)('%s', (_name, build) => {
 		expect(ptb(build(c()))).toMatchSnapshot();


### PR DESCRIPTION
## Description

Follows review feedback on #1153 ([thread](https://github.com/MystenLabs/ts-sdks/pull/1153#discussion_r3624642875)): migrate the hand-written **margin** transaction builders from positional `moveCall` argument arrays to the generated codegen bindings with **named** arguments, so same-typed arguments (base/quote oracles, base/quote margin pools) can't be transposed. Moves the whole margin surface to the [sdk-building](https://sdk.mystenlabs.com/sui/sdk-building) pattern.

**Pure internal refactor — not a breaking change.** Public method signatures are unchanged; only *how* each builder constructs its `moveCall` changes. Human-unit conversion (`convertQuantity`/`convertPrice`/`convertRate`) and coin plumbing stay in the facade; codegen only handles call construction.

### Non-breaking, proven mechanically

`test/unit/transactions/margin-ptb-snapshot.test.ts` snapshots every migrated builder's emitted PTB (`tx.getData()` — inputs + commands). Migrating a builder must leave the snapshot **byte-identical** — that is the proof existing users see zero difference. Each commit runs `tsc` + the snapshot gate in CI mode (fails on any PTB change). **146 builders are snapshot-guarded.**

The gate caught **4 real PTB differences** a blind migration would have shipped — see per-file commits:
- `poolProxy` — a builder targets `place_limit_order_v2`, so the generated function is `placeLimitOrderV2`, not `placeLimitOrder`.
- `marginPool.withdraw` — a pre-built `tx.pure.option` reordered the PTB inputs (fixed by passing the raw value so codegen serializes in-order).
- `marginLiquidations.liquidate_base/quote` — the *opposite*: the original builds the `Option` arg first, so it's pre-built ahead of the call to keep input order.
- `marginAdmin.revokeMaintainerCap` — the original passes the cap id as an **object ref** but the generated binding encodes a pure **ID** (kept positional).

### Scope

The **margin** surface: 135 builders migrated across 8 files. `deepbook_margin` + `margin_liquidation` added to `sui-codegen.config.ts`. Core builders (~111) are a separate follow-up.

- [x] `marginRegistry` (14)
- [x] `marginTPSL` (11)
- [x] `poolProxy` (16)
- [x] `marginMaintainer` (9)
- [x] `marginPool` (18; `supplyToMarginPool` kept positional)
- [x] `marginAdmin` (19; `revokeMaintainerCap` kept positional)
- [x] `marginManager` (42)
- [x] `marginLiquidations` (6)

**Two builders are deliberately kept as positional moveCalls** (documented in-code) because their command/input interleaving doesn't reduce to a named-arg call without changing the PTB: `marginPool.supplyToMarginPool` (`coinWithBalance` + `option::none`) and `marginAdmin.revokeMaintainerCap` (object-ref vs pure-ID). Guaranteeing zero behavior change was the priority.

## Test plan

- [x] Per file: `tsc --noEmit` clean + snapshot gate byte-identical (CI mode), one commit each.
- [x] Full `pnpm build` clean, `pnpm vitest run` 165/165 (146 snapshot + 19 existing), `pnpm lint` clean.
- [ ] Independent review pass over the complete diff (in progress).

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.