### PR TITLE
fix(hashi): point default GraphQL URLs at the graphql.<network>.sui.io hosts

### DIFF
--- a/.changeset/hashi-graphql-endpoints.md
+++ b/.changeset/hashi-graphql-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@mysten/hashi': patch
+---
+
+Point default GraphQL URLs at the dedicated graphql.<network>.sui.io hosts. The fullnode-served /graphql endpoints are being retired — testnet already returns 404, which silently emptied the pending-request portion of `view.transactionHistory`. That failure now also logs a console warning instead of being swallowed. (Re-lands the fix from hashi-ts-sdk#46, which the monorepo migration predated.)

--- a/packages/hashi/src/client.ts
+++ b/packages/hashi/src/client.ts
@@ -96,10 +96,13 @@ const EVENT_REQUEST_IDS_QUERY = graphql(`
 	}
 `);
 
+// Dedicated GraphQL RPC hosts. The fullnode-served /graphql endpoints are
+// being retired (testnet already 404s); the graphql.<network>.sui.io hosts
+// are the supported homes.
 const GRAPHQL_URLS: Record<string, string> = {
-	devnet: 'https://fullnode.devnet.sui.io:443/graphql',
-	testnet: 'https://fullnode.testnet.sui.io:443/graphql',
-	mainnet: 'https://fullnode.mainnet.sui.io:443/graphql',
+	devnet: 'https://graphql.devnet.sui.io/graphql',
+	testnet: 'https://graphql.testnet.sui.io/graphql',
+	mainnet: 'https://graphql.mainnet.sui.io/graphql',
 	localnet: 'http://127.0.0.1:9000/graphql',
 };
 
@@ -1109,8 +1112,12 @@ export class HashiClient {
 					const classified = this.#classifyRequestObjects(objects, timeDelayMs);
 					items.push(...classified.items);
 				}
-			} catch {
-				// GraphQL endpoint may not be available (localnet, custom deployments).
+			} catch (err) {
+				// GraphQL endpoint may not be available (localnet, custom
+				// deployments). Warn instead of failing so the confirmed set
+				// still renders — but don't hide the miss: a dead endpoint here
+				// silently drops all in-flight requests from history.
+				console.warn('[hashi] transactionHistory: pending-request event query failed:', err);
 			}
 
 			items.sort((a, b) => Number(b.timestampMs - a.timestampMs));


### PR DESCRIPTION
## Problem

The `@mysten/hashi` monorepo migration was cut from a commit that predates [hashi-ts-sdk#46](https://github.com/MystenLabs/hashi-ts-sdk/pull/46), so its fix regressed: the default GraphQL URLs point at the fullnode-served `/graphql` endpoints, which are being retired. **Testnet already returns 404** there — and because the pending-request query in `view.transactionHistory` swallows failures in a bare `catch {}`, the result is that all in-flight deposits/withdrawals silently vanish from history for any consumer using the defaults on testnet.

## Fix (re-lands hashi-ts-sdk#46)

- Default GraphQL URLs for devnet/testnet/mainnet now point at the dedicated `graphql.<network>.sui.io/graphql` hosts (all three verified live; the existing query shape works against them unchanged)
- The pending-request catch logs a `console.warn` instead of hiding the miss

## Verification

The same endpoints + query shape are running in production for `hashi-frontend` (which passes `graphqlUrl` explicitly as a workaround for this regression — see MystenLabs/hashi-frontend#36): pending and confirmed history render correctly against live testnet and devnet. Changeset (patch) included.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.