### PR TITLE
test(sui): refetch cross-client consistency reads that straddle live-state changes

### DIFF
--- a/packages/sui/test/e2e/clients/core/system-state.test.ts
+++ b/packages/sui/test/e2e/clients/core/system-state.test.ts
@@ -26,6 +26,9 @@ describe('Core API - System State', () => {
 						},
 					};
 				},
+				// System state advances every localnet epoch; refetch when the
+				// three transports straddle a boundary mid-read.
+				{ attempts: 3 },
 			);
 		});
 

--- a/packages/sui/test/e2e/utils/setup.ts
+++ b/packages/sui/test/e2e/utils/setup.ts
@@ -229,30 +229,44 @@ export class TestToolbox {
 	 *
 	 * @param queryFn - Function that takes a client and returns a promise with the query result
 	 * @param normalize - Optional function to normalize results before comparison (e.g., to ignore cursor differences)
-	 * @param options - Options to skip the test entirely
+	 * @param options - Options to skip the test entirely, or to refetch on mismatch: for queries of
+	 *   live chain state (e.g. system state around a localnet epoch boundary), the state can advance
+	 *   between the three transport reads, so a strict single-shot comparison is flaky. `attempts`
+	 *   refetches the whole read set until the transports agree; a genuine transport inconsistency
+	 *   still fails on every attempt.
 	 */
 	async expectAllClientsReturnSameData<T, N = T>(
 		queryFn: (client: ClientWithCoreApi, kind: 'jsonrpc' | 'grpc' | 'graphql') => Promise<T>,
 		normalize?: (result: T) => N,
-		options?: { skip?: boolean },
+		options?: { skip?: boolean; attempts?: number },
 	) {
 		if (options?.skip) {
 			test.skip('all clients return same data', () => {});
 			return;
 		}
 
-		const [jsonRpcResult, grpcResult, graphqlResult] = await Promise.all([
-			queryFn(this.jsonRpcClient, 'jsonrpc'),
-			queryFn(this.grpcClient, 'grpc'),
-			queryFn(this.graphqlClient, 'graphql'),
-		]);
+		const attempts = options?.attempts ?? 1;
+		for (let attempt = 1; ; attempt++) {
+			const [jsonRpcResult, grpcResult, graphqlResult] = await Promise.all([
+				queryFn(this.jsonRpcClient, 'jsonrpc'),
+				queryFn(this.grpcClient, 'grpc'),
+				queryFn(this.graphqlClient, 'graphql'),
+			]);
 
-		const normalizedJson = normalize ? normalize(jsonRpcResult) : jsonRpcResult;
-		const normalizedGrpc = normalize ? normalize(grpcResult) : grpcResult;
-		const normalizedGraphql = normalize ? normalize(graphqlResult) : graphqlResult;
+			const normalizedJson = normalize ? normalize(jsonRpcResult) : jsonRpcResult;
+			const normalizedGrpc = normalize ? normalize(grpcResult) : grpcResult;
+			const normalizedGraphql = normalize ? normalize(graphqlResult) : graphqlResult;
 
-		expect(normalizedJson).toEqual(normalizedGrpc);
-		expect(normalizedJson).toEqual(normalizedGraphql);
+			try {
+				expect(normalizedJson).toEqual(normalizedGrpc);
+				expect(normalizedJson).toEqual(normalizedGraphql);
+				return;
+			} catch (error) {
+				if (attempt >= attempts) throw error;
+				// Let the chain settle before refetching all three transports.
+				await new Promise((resolve) => setTimeout(resolve, 500));
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

`Localnet` e2e runs flake on `all clients return same data: getCurrentSystemState` (seen on [#1159 CI](https://github.com/MystenLabs/ts-sdks/pull/1159), unrelated PR): the failing diff is always epoch-scoped state — `distributionCounter`, `stakeSubsidy.balance`, `storageFund.nonRefundableBalance`/`totalObjectStorageRebates` — i.e. the three transport reads straddled a localnet epoch boundary. The existing `{ retry: 3 }` re-runs the whole test but each attempt has the same race, and the timestamp normalization doesn't cover epoch-scoped values.

## Fix

`expectAllClientsReturnSameData` gains an `attempts` option: on comparison mismatch it refetches the entire read set (all three transports, still concurrent) after a 500ms pause, up to N times. A genuine transport inconsistency reproduces on every refetch and still fails; only boundary-straddles converge. Default `attempts: 1` keeps every other call site's strict single-shot behavior. `getCurrentSystemState` opts in with `attempts: 3`.

Formatted with the repo prettier config.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.