### PR TITLE
chore(kiosk): update generated codegen utilities

### DIFF
--- a/.changeset/config-mapped-arguments.md
+++ b/.changeset/config-mapped-arguments.md
@@ -1,0 +1,9 @@
+---
+'@mysten/codegen': minor
+---
+
+Add `configArguments` codegen option for mapping function parameters and package addresses to a
+runtime config object. Matched parameters become optional in generated `arguments` and are resolved
+from a typed `config` object instead (with per-function minimal config slices, resolver functions
+for generic types, and a generated per-package config interface in `config-args.ts`). Also treat
+`0x2::accumulator::AccumulatorRoot` as a well-known object that is auto-injected like `Clock`.

--- a/.changeset/config-mapped-arguments.md
+++ b/.changeset/config-mapped-arguments.md
@@ -4,6 +4,8 @@
 
 Add `configArguments` codegen option for mapping function parameters and package addresses to a
 runtime config object. Matched parameters become optional in generated `arguments` and are resolved
-from a typed `config` object instead (with per-function minimal config slices, resolver functions
-for generic types, and a generated per-package config interface in `config-args.ts`). Also treat
+from a typed optional `config` object instead, with per-function minimal config slices, resolver
+functions for generic types (receiving the matched parameter's normalized instantiation and
+call-site metadata), and a generated per-package config interface in `config-arguments.ts`.
+Misconfigured matchers are surfaced at generation time. Also treat
 `0x2::accumulator::AccumulatorRoot` as a well-known object that is auto-injected like `Clock`.

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -49,6 +49,30 @@ export default async function generate(
 				})
 			: config.packages;
 
+	// Package entries in any configArguments block must reference a package in this run — a typo'd
+	// name would otherwise silently never apply.
+	const knownPackageNames = new Set(normalizedPackages.map((p) => p.package));
+	const configArgumentBlocks = [
+		config.configArguments ?? {},
+		...normalizedPackages.map((p) => ('configArguments' in p ? (p.configArguments ?? {}) : {})),
+	];
+	for (const block of configArgumentBlocks) {
+		for (const [key, matcher] of Object.entries(block)) {
+			if ('package' in matcher && !knownPackageNames.has(matcher.package)) {
+				throw new Error(
+					`configArguments.${key} references package "${matcher.package}", which is not part of ` +
+						`this codegen run (packages: ${[...knownPackageNames].join(', ')})`,
+				);
+			}
+		}
+	}
+
+	const globalTypeConfigKeys = Object.entries(config.configArguments ?? {})
+		.filter(([, matcher]) => 'type' in matcher)
+		.map(([key]) => key);
+	const unresolvedConfigKeysByPackage: Set<string>[] = [];
+	const unusedConfigKeysByPackage: Set<string>[] = [];
+
 	const generateSummaries =
 		flags.noSummaries === undefined ? config.generateSummaries : !flags.noSummaries;
 
@@ -141,7 +165,7 @@ export default async function generate(
 					}
 				: config.generate;
 
-		await generateFromPackageSummary({
+		const result = await generateFromPackageSummary({
 			package: pkgWithOverrides,
 			prune: flags.noPrune === undefined ? config.prune : !flags.noPrune,
 			outputDir: flags.outputDir ?? config.output,
@@ -151,5 +175,31 @@ export default async function generate(
 			errorClass: config.errorClass,
 			configArguments: config.configArguments,
 		});
+
+		unresolvedConfigKeysByPackage.push(new Set(result.unresolvedConfigKeys));
+		unusedConfigKeysByPackage.push(new Set(result.unusedConfigKeys));
+	}
+
+	if (unresolvedConfigKeysByPackage.length === 0) {
+		return;
+	}
+
+	// Per-package unresolved global keys are only warnings (they may belong to another package in
+	// the run), but a global key that resolved nowhere — or matched nothing anywhere — is a
+	// misconfiguration for the run as a whole.
+	for (const key of globalTypeConfigKeys) {
+		if (unresolvedConfigKeysByPackage.every((keys) => keys.has(key))) {
+			throw new Error(
+				`configArguments.${key} did not resolve in any package in this codegen run — check the matcher type for typos`,
+			);
+		}
+		const usedSomewhere = unresolvedConfigKeysByPackage.some(
+			(unresolved, i) => !unresolved.has(key) && !unusedConfigKeysByPackage[i].has(key),
+		);
+		if (!usedSomewhere) {
+			console.warn(
+				`configArguments.${key} matched no generated function parameters in any package in this codegen run`,
+			);
+		}
 	}
 }

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -149,6 +149,7 @@ export default async function generate(
 			importExtension,
 			includePhantomTypeParameters: config.includePhantomTypeParameters,
 			errorClass: config.errorClass,
+			configArguments: config.configArguments,
 		});
 	}
 }

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { LocalContext } from '../../context.js';
-import { generateFromPackageSummary } from '../../../index.js';
+import { generateFromPackageSummary, resolvePackageRootAddress } from '../../../index.js';
 import { loadConfig, type GenerateBase, type PackageGenerate } from '../../../config.js';
 import { isValidNamedPackage, isValidSuiObjectId } from '@mysten/sui/utils';
 import { execSync } from 'node:child_process';
@@ -67,12 +67,6 @@ export default async function generate(
 		}
 	}
 
-	const globalTypeConfigKeys = Object.entries(config.configArguments ?? {})
-		.filter(([, matcher]) => 'type' in matcher)
-		.map(([key]) => key);
-	const unresolvedConfigKeysByPackage: Set<string>[] = [];
-	const unusedConfigKeysByPackage: Set<string>[] = [];
-
 	const generateSummaries =
 		flags.noSummaries === undefined ? config.generateSummaries : !flags.noSummaries;
 
@@ -105,6 +99,8 @@ export default async function generate(
 				}
 			: undefined;
 
+	// First ensure summaries exist for every package, then resolve each package's root address so
+	// configArguments matchers can reference any package in the run by its identifier.
 	for (const pkg of normalizedPackages) {
 		// Detect on-chain packages: they have 'network' field and no 'path'
 		const isOnChainPackage =
@@ -132,6 +128,18 @@ export default async function generate(
 				stdio: 'inherit',
 			});
 		}
+	}
+
+	const packageAddresses: Record<string, string> = {};
+	for (const pkg of normalizedPackages) {
+		if (!pkg.path) continue;
+		const address = await resolvePackageRootAddress(pkg.path);
+		if (address !== undefined) {
+			packageAddresses[pkg.package] = address;
+		}
+	}
+
+	for (const pkg of normalizedPackages) {
 		const importExtension =
 			flags.importExtension === undefined
 				? config.importExtension
@@ -165,7 +173,7 @@ export default async function generate(
 					}
 				: config.generate;
 
-		const result = await generateFromPackageSummary({
+		await generateFromPackageSummary({
 			package: pkgWithOverrides,
 			prune: flags.noPrune === undefined ? config.prune : !flags.noPrune,
 			outputDir: flags.outputDir ?? config.output,
@@ -174,32 +182,7 @@ export default async function generate(
 			includePhantomTypeParameters: config.includePhantomTypeParameters,
 			errorClass: config.errorClass,
 			configArguments: config.configArguments,
+			packageAddresses,
 		});
-
-		unresolvedConfigKeysByPackage.push(new Set(result.unresolvedConfigKeys));
-		unusedConfigKeysByPackage.push(new Set(result.unusedConfigKeys));
-	}
-
-	if (unresolvedConfigKeysByPackage.length === 0) {
-		return;
-	}
-
-	// Per-package unresolved global keys are only warnings (they may belong to another package in
-	// the run), but a global key that resolved nowhere — or matched nothing anywhere — is a
-	// misconfiguration for the run as a whole.
-	for (const key of globalTypeConfigKeys) {
-		if (unresolvedConfigKeysByPackage.every((keys) => keys.has(key))) {
-			throw new Error(
-				`configArguments.${key} did not resolve in any package in this codegen run — check the matcher type for typos`,
-			);
-		}
-		const usedSomewhere = unresolvedConfigKeysByPackage.some(
-			(unresolved, i) => !unresolved.has(key) && !unusedConfigKeysByPackage[i].has(key),
-		);
-		if (!usedSomewhere) {
-			console.warn(
-				`configArguments.${key} matched no generated function parameters in any package in this codegen run`,
-			);
-		}
 	}
 }

--- a/packages/codegen/src/config-arguments.ts
+++ b/packages/codegen/src/config-arguments.ts
@@ -31,8 +31,12 @@ export interface TypeConfigArgument {
 	 * resolver function as the config value (a static id cannot be correct across instantiations).
 	 */
 	isGeneric: boolean;
-	/** Whether this entry alone forces the config value to be a resolver function. */
-	requiresResolver: boolean;
+	/**
+	 * Canonical identity of the concrete type this entry binds, or `null` when it can bind many
+	 * (an uninstantiated generic). A key whose entries span multiple identities (or any `null`)
+	 * must be a resolver function.
+	 */
+	boundType: string | null;
 }
 
 export interface FunctionConfigArgument {
@@ -45,8 +49,8 @@ export interface FunctionConfigArgument {
 	parameterName?: string;
 	/** Position in the generated function's arguments (TxContext/well-known excluded). */
 	parameterIndex?: number;
-	/** Whether this entry alone forces the config value to be a resolver function. */
-	requiresResolver: boolean;
+	/** See `TypeConfigArgument.boundType`. */
+	boundType: string | null;
 }
 
 export interface PackageConfigArgument {
@@ -298,6 +302,35 @@ function typeHasTypeParameter(type: Type): boolean {
 	return 'TypeParameter' in type || 'NamedTypeParameter' in type;
 }
 
+function tagIdentity(tag: ParsedTypeTag): string {
+	if ('prim' in tag) return tag.prim;
+	if ('vector' in tag) return `vector<${tagIdentity(tag.vector)}>`;
+	const { address, module, name, typeArguments } = tag.datatype;
+	const base = `${address}::${module}::${name}`;
+	return typeArguments.length ? `${base}<${typeArguments.map(tagIdentity).join(',')}>` : base;
+}
+
+function canonicalTypeIdentity(
+	type: Type,
+	resolveAddress: (address: string) => string,
+): string | null {
+	if (typeof type === 'string') return type === 'signer' || type === '_' ? null : type;
+	if ('Reference' in type) return canonicalTypeIdentity(type.Reference[1], resolveAddress);
+	if ('vector' in type) {
+		const inner = canonicalTypeIdentity(type.vector, resolveAddress);
+		return inner === null ? null : `vector<${inner}>`;
+	}
+	if ('Datatype' in type) {
+		const args = type.Datatype.type_arguments.map((argument) =>
+			canonicalTypeIdentity(argument.argument, resolveAddress),
+		);
+		if (args.some((argument) => argument === null)) return null;
+		const base = `${normalizeAddress(resolveAddress(type.Datatype.module.address))}::${type.Datatype.module.name}::${type.Datatype.name}`;
+		return args.length ? `${base}<${args.join(',')}>` : base;
+	}
+	return null;
+}
+
 function parseFunctionMatcher(
 	key: string,
 	source: ConfigArgumentSource,
@@ -415,7 +448,9 @@ function parseFunctionMatcher(
 		parameterName: matcher.parameterName,
 		parameterIndex,
 		// A parameter typed with the function's own type parameters cannot be a single static id.
-		requiresResolver: typeHasTypeParameter(bound.type_),
+		boundType: typeHasTypeParameter(bound.type_)
+			? null
+			: canonicalTypeIdentity(bound.type_, (target) => registry.resolveAddress(target)),
 	};
 }
 
@@ -461,10 +496,8 @@ export function parseConfigArguments(
 			continue;
 		}
 
-		// One key may declare several matchers; it then resolves multiple bindings, so its config
-		// value must be a resolver function.
+		// One key may declare several matchers (e.g. several functions sharing one config value).
 		const matchers = Array.isArray(matcher) ? matcher : [matcher];
-		const multi = matchers.length > 1;
 
 		for (const single of matchers) {
 			const scopeAddress = source === 'package' ? currentAddress : null;
@@ -477,7 +510,7 @@ export function parseConfigArguments(
 					packageId: context.package.id,
 				});
 				if (entry) {
-					entries.push({ ...entry, requiresResolver: entry.requiresResolver || multi });
+					entries.push(entry);
 				}
 				continue;
 			}
@@ -544,7 +577,9 @@ export function parseConfigArguments(
 				typeArguments: uninstantiated ? null : typeArguments,
 				parameterName: single.parameterName,
 				isGeneric,
-				requiresResolver: (isGeneric && uninstantiated) || multi,
+				boundType: uninstantiated
+					? null
+					: tagIdentity({ datatype: { address, module, name, typeArguments } }),
 			});
 		}
 	}

--- a/packages/codegen/src/config-arguments.ts
+++ b/packages/codegen/src/config-arguments.ts
@@ -5,6 +5,7 @@ import { normalizeSuiAddress } from '@mysten/sui/utils';
 import type { ConfigArguments } from './config.js';
 import type { ModuleRegistry } from './module-registry.js';
 import type { Parameter, Type } from './types/summary.js';
+import { isWellKnownObjectParameter } from './utils.js';
 
 /** A parsed type tag from a `configArguments` matcher. Always fully concrete. */
 export type ParsedTypeTag =
@@ -30,6 +31,22 @@ export interface TypeConfigArgument {
 	 * resolver function as the config value (a static id cannot be correct across instantiations).
 	 */
 	isGeneric: boolean;
+	/** Whether this entry alone forces the config value to be a resolver function. */
+	requiresResolver: boolean;
+}
+
+export interface FunctionConfigArgument {
+	kind: 'function';
+	key: string;
+	source: ConfigArgumentSource;
+	address: string;
+	module: string;
+	functionName: string;
+	parameterName?: string;
+	/** Position in the generated function's arguments (TxContext/well-known excluded). */
+	parameterIndex?: number;
+	/** Whether this entry alone forces the config value to be a resolver function. */
+	requiresResolver: boolean;
 }
 
 export interface PackageConfigArgument {
@@ -39,7 +56,10 @@ export interface PackageConfigArgument {
 	package: string;
 }
 
-export type ParsedConfigArgument = TypeConfigArgument | PackageConfigArgument;
+export type ParsedConfigArgument =
+	| TypeConfigArgument
+	| FunctionConfigArgument
+	| PackageConfigArgument;
 
 export interface ConfigArgumentsContext {
 	/** Identifier (from the `packages` config) and resolved address of the package being generated. */
@@ -59,6 +79,44 @@ const FRAMEWORK_ADDRESS = /^0x0*[123]$/;
 
 function normalizeAddress(address: string) {
 	return HEX_ADDRESS.test(address) ? normalizeSuiAddress(address) : address;
+}
+
+function resolveQualifier(
+	packagePart: string | undefined,
+	unqualified: string,
+	tag: string,
+	ctx: { scopeAddress: string | null; packageAddresses: Record<string, string>; root: string },
+): string {
+	if (packagePart === undefined) {
+		if (ctx.scopeAddress === null) {
+			throw new Error(
+				`configArguments matcher "${ctx.root}": "${unqualified}" must be qualified ` +
+					`with a package in the global configArguments block (e.g. ` +
+					`"@pkg/name::${unqualified}"). Bare matchers are only supported in a package's own ` +
+					`configArguments block.`,
+			);
+		}
+		return ctx.scopeAddress;
+	}
+	if (FRAMEWORK_ADDRESS.test(packagePart)) {
+		return normalizeSuiAddress(packagePart);
+	}
+	if (HEX_ADDRESS.test(packagePart)) {
+		throw new Error(
+			`Invalid package "${packagePart}" in configArguments matcher "${tag}": package addresses ` +
+				`are network-specific and cannot be used in matchers (only the framework addresses ` +
+				`0x1-0x3 are chain-stable). Reference the package by its identifier from the codegen ` +
+				`config instead (e.g. "@pkg/name::${unqualified}").`,
+		);
+	}
+	const resolved = ctx.packageAddresses[packagePart];
+	if (resolved === undefined) {
+		throw new Error(
+			`Unknown package "${packagePart}" in configArguments matcher "${tag}". Known packages in ` +
+				`this codegen run: ${Object.keys(ctx.packageAddresses).join(', ')}`,
+		);
+	}
+	return resolved;
 }
 
 interface ParseContext {
@@ -160,39 +218,7 @@ function parseTypeTag(tag: string, ctx: ParseContext): ParsedTypeTag {
 		);
 	}
 
-	let address: string;
-
-	if (packagePart === undefined) {
-		// Codegen output is network-agnostic: a bare `module::Type` refers to the package whose
-		// configArguments block declares it.
-		if (ctx.scopeAddress === null) {
-			throw new Error(
-				`configArguments matcher "${ctx.root}": "${modulePart}::${namePart}" must be qualified ` +
-					`with a package in the global configArguments block (e.g. ` +
-					`"@pkg/name::${modulePart}::${namePart}"). Bare module::Type matchers are only ` +
-					`supported in a package's own configArguments block.`,
-			);
-		}
-		address = ctx.scopeAddress;
-	} else if (FRAMEWORK_ADDRESS.test(packagePart)) {
-		address = normalizeSuiAddress(packagePart);
-	} else if (HEX_ADDRESS.test(packagePart)) {
-		throw new Error(
-			`Invalid package "${packagePart}" in configArguments matcher "${tag}": package addresses ` +
-				`are network-specific and cannot be used in matchers (only the framework addresses ` +
-				`0x1-0x3 are chain-stable). Reference the package by its identifier from the codegen ` +
-				`config instead (e.g. "@pkg/name::${modulePart}::${namePart}").`,
-		);
-	} else {
-		const resolved = ctx.packageAddresses[packagePart];
-		if (resolved === undefined) {
-			throw new Error(
-				`Unknown package "${packagePart}" in configArguments matcher "${tag}". Known packages in ` +
-					`this codegen run: ${Object.keys(ctx.packageAddresses).join(', ')}`,
-			);
-		}
-		address = resolved;
-	}
+	const address = resolveQualifier(packagePart, `${modulePart}::${namePart}`, tag, ctx);
 
 	const typeArguments =
 		lt === -1
@@ -248,6 +274,151 @@ function assertFullyInstantiated(
 	}
 }
 
+function isContextParameter(type: Type, resolveAddress: (address: string) => string): boolean {
+	if (typeof type === 'string') return false;
+	if ('Reference' in type) return isContextParameter(type.Reference[1], resolveAddress);
+	if ('Datatype' in type) {
+		return (
+			normalizeAddress(resolveAddress(type.Datatype.module.address)) ===
+				normalizeSuiAddress('0x2') &&
+			type.Datatype.module.name === 'tx_context' &&
+			type.Datatype.name === 'TxContext'
+		);
+	}
+	return false;
+}
+
+function typeHasTypeParameter(type: Type): boolean {
+	if (typeof type === 'string') return false;
+	if ('Reference' in type) return typeHasTypeParameter(type.Reference[1]);
+	if ('vector' in type) return typeHasTypeParameter(type.vector);
+	if ('Datatype' in type) {
+		return type.Datatype.type_arguments.some((argument) => typeHasTypeParameter(argument.argument));
+	}
+	return 'TypeParameter' in type || 'NamedTypeParameter' in type;
+}
+
+function parseFunctionMatcher(
+	key: string,
+	source: ConfigArgumentSource,
+	matcher: { function: string; parameterName?: string; parameterIndex?: number },
+	{
+		registry,
+		scopeAddress,
+		packageAddresses,
+		packageId,
+	}: {
+		registry: ModuleRegistry;
+		scopeAddress: string | null;
+		packageAddresses: Record<string, string>;
+		packageId: string;
+	},
+): FunctionConfigArgument | null {
+	const parts = matcher.function.split('::');
+	if ((parts.length !== 2 && parts.length !== 3) || parts.some((part) => part.length === 0)) {
+		throw new Error(
+			`configArguments.${key}: invalid function "${matcher.function}". Expected ` +
+				`"module::function_name", optionally qualified with a package from the codegen config.`,
+		);
+	}
+
+	const packagePart = parts.length === 3 ? parts[0] : undefined;
+	const modulePart = parts[parts.length - 2];
+	const functionPart = parts[parts.length - 1];
+
+	if (!MOVE_IDENTIFIER.test(modulePart) || !MOVE_IDENTIFIER.test(functionPart)) {
+		throw new Error(`configArguments.${key}: invalid function "${matcher.function}"`);
+	}
+
+	if (matcher.parameterName !== undefined && matcher.parameterIndex !== undefined) {
+		throw new Error(
+			`configArguments.${key}: specify either parameterName or parameterIndex, not both`,
+		);
+	}
+
+	const address = resolveQualifier(
+		packagePart,
+		`${modulePart}::${functionPart}`,
+		matcher.function,
+		{
+			scopeAddress,
+			packageAddresses,
+			root: matcher.function,
+		},
+	);
+
+	const summary = registry.getSummaryByResolvedAddress(address, modulePart);
+	const func = summary?.functions[functionPart];
+
+	if (!func) {
+		if (registry.hasResolvedAddress(address)) {
+			throw new Error(
+				`configArguments.${key}: function "${matcher.function}" was not found in its package's summaries`,
+			);
+		}
+		if (source === 'package') {
+			console.warn(
+				`configArguments.${key}: function "${matcher.function}" is not part of ${packageId}'s ` +
+					`dependencies and will never match.`,
+			);
+		}
+		return null;
+	}
+
+	const resolveAddress = (target: string) => registry.resolveAddress(target);
+	// The same positions the generated arguments use: TxContext and auto-injected well-known
+	// objects are excluded.
+	const parameters = func.parameters.filter(
+		(param) =>
+			!isContextParameter(param.type_, resolveAddress) &&
+			!isWellKnownObjectParameter(param.type_, resolveAddress),
+	);
+
+	let bound: Parameter | undefined;
+	let parameterIndex = matcher.parameterIndex;
+
+	if (matcher.parameterName !== undefined) {
+		bound = parameters.find((param) => param.name === matcher.parameterName);
+		if (!bound) {
+			throw new Error(
+				`configArguments.${key}: function "${matcher.function}" has no parameter named ` +
+					`"${matcher.parameterName}"${parameters.some((param) => param.name === undefined) ? " (this package's summaries do not include parameter names — use parameterIndex instead)" : ''}`,
+			);
+		}
+		parameterIndex = undefined;
+	} else if (parameterIndex !== undefined) {
+		bound = parameters[parameterIndex];
+		if (!bound) {
+			throw new Error(
+				`configArguments.${key}: function "${matcher.function}" has ${parameters.length} ` +
+					`argument(s); parameterIndex ${parameterIndex} is out of range`,
+			);
+		}
+	} else {
+		if (parameters.length !== 1) {
+			throw new Error(
+				`configArguments.${key}: function "${matcher.function}" has ${parameters.length} ` +
+					`argument(s) — specify parameterName or parameterIndex`,
+			);
+		}
+		bound = parameters[0];
+		parameterIndex = 0;
+	}
+
+	return {
+		kind: 'function',
+		key,
+		source,
+		address,
+		module: modulePart,
+		functionName: functionPart,
+		parameterName: matcher.parameterName,
+		parameterIndex,
+		// A parameter typed with the function's own type parameters cannot be a single static id.
+		requiresResolver: typeHasTypeParameter(bound.type_),
+	};
+}
+
 /**
  * Parse and validate `configArguments` blocks against the modules loaded in `registry`.
  * Per-package entries are merged over global entries (per key).
@@ -285,74 +456,97 @@ export function parseConfigArguments(
 	}
 
 	for (const [key, { matcher, source }] of merged) {
-		if ('package' in matcher) {
+		if (!Array.isArray(matcher) && 'package' in matcher) {
 			entries.push({ kind: 'package', key, source, package: matcher.package });
 			continue;
 		}
 
-		const parsed = parseTypeTag(matcher.type, {
-			scopeAddress: source === 'package' ? currentAddress : null,
-			packageAddresses,
-			root: matcher.type,
-		});
+		// One key may declare several matchers; it then resolves multiple bindings, so its config
+		// value must be a resolver function.
+		const matchers = Array.isArray(matcher) ? matcher : [matcher];
+		const multi = matchers.length > 1;
 
-		if (!('datatype' in parsed)) {
-			throw new Error(
-				`configArguments.${key}: matcher type "${matcher.type}" must be a Move datatype`,
-			);
-		}
+		for (const single of matchers) {
+			const scopeAddress = source === 'package' ? currentAddress : null;
 
-		const { address, module, name, typeArguments } = parsed.datatype;
-		const summary = registry.getSummaryByResolvedAddress(address, module);
-		const datatype = summary?.structs[name] ?? summary?.enums[name];
+			if ('function' in single) {
+				const entry = parseFunctionMatcher(key, source, single, {
+					registry,
+					scopeAddress,
+					packageAddresses,
+					packageId: context.package.id,
+				});
+				if (entry) {
+					entries.push({ ...entry, requiresResolver: entry.requiresResolver || multi });
+				}
+				continue;
+			}
 
-		if (!datatype) {
-			if (registry.hasResolvedAddress(address)) {
-				// The matcher's package is part of this dependency closure, so the type has to
-				// exist — this is a typo.
+			const parsed = parseTypeTag(single.type, {
+				scopeAddress,
+				packageAddresses,
+				root: single.type,
+			});
+
+			if (!('datatype' in parsed)) {
 				throw new Error(
-					`configArguments.${key}: type "${matcher.type}" was not found in its package's summaries`,
+					`configArguments.${key}: matcher type "${single.type}" must be a Move datatype`,
 				);
 			}
-			// The matcher references a run package that isn't part of this package's dependency
-			// closure — it can't match anything here. It is validated when its own package is
-			// generated.
-			if (source === 'package') {
-				console.warn(
-					`configArguments.${key}: type "${matcher.type}" is not part of ${context.package.id}'s ` +
-						`dependencies and will never match — consider moving it to the global block or the ` +
-						`package it belongs to.`,
+
+			const { address, module, name, typeArguments } = parsed.datatype;
+			const summary = registry.getSummaryByResolvedAddress(address, module);
+			const datatype = summary?.structs[name] ?? summary?.enums[name];
+
+			if (!datatype) {
+				if (registry.hasResolvedAddress(address)) {
+					// The matcher's package is part of this dependency closure, so the type has to
+					// exist — this is a typo.
+					throw new Error(
+						`configArguments.${key}: type "${single.type}" was not found in its package's summaries`,
+					);
+				}
+				// The matcher references a run package that isn't part of this package's dependency
+				// closure — it can't match anything here. It is validated when its own package is
+				// generated.
+				if (source === 'package') {
+					console.warn(
+						`configArguments.${key}: type "${single.type}" is not part of ${context.package.id}'s ` +
+							`dependencies and will never match — consider moving it to the global block or the ` +
+							`package it belongs to.`,
+					);
+				}
+				continue;
+			}
+
+			const arity = datatype.type_parameters.length;
+			const isGeneric = arity > 0;
+			// A generic type written without `<...>` matches every instantiation.
+			const uninstantiated = isGeneric && !single.type.includes('<');
+
+			if (!uninstantiated && typeArguments.length !== arity) {
+				throw new Error(
+					`configArguments.${key}: type "${single.type}" expects ${arity} type argument(s), got ${typeArguments.length}`,
 				);
 			}
-			continue;
+
+			for (const argument of typeArguments) {
+				assertFullyInstantiated(argument, registry, single.type);
+			}
+
+			entries.push({
+				kind: 'type',
+				key,
+				source,
+				address,
+				module,
+				name,
+				typeArguments: uninstantiated ? null : typeArguments,
+				parameterName: single.parameterName,
+				isGeneric,
+				requiresResolver: (isGeneric && uninstantiated) || multi,
+			});
 		}
-
-		const arity = datatype.type_parameters.length;
-		const isGeneric = arity > 0;
-		// A generic type written without `<...>` matches every instantiation.
-		const uninstantiated = isGeneric && !matcher.type.includes('<');
-
-		if (!uninstantiated && typeArguments.length !== arity) {
-			throw new Error(
-				`configArguments.${key}: type "${matcher.type}" expects ${arity} type argument(s), got ${typeArguments.length}`,
-			);
-		}
-
-		for (const argument of typeArguments) {
-			assertFullyInstantiated(argument, registry, matcher.type);
-		}
-
-		entries.push({
-			kind: 'type',
-			key,
-			source,
-			address,
-			module,
-			name,
-			typeArguments: uninstantiated ? null : typeArguments,
-			parameterName: matcher.parameterName,
-			isGeneric,
-		});
 	}
 
 	return { entries };
@@ -411,32 +605,62 @@ export function findConfigArgumentMatch(
 	{
 		resolveAddress,
 		functionLabel,
+		functionRef,
+		parameterIndex,
 	}: {
 		resolveAddress: (address: string) => string;
 		functionLabel: string;
+		/** The module and function the parameter belongs to, for function matchers. */
+		functionRef: { moduleAddress: string; moduleName: string; functionName: string };
+		/** The parameter's position in the generated arguments. */
+		parameterIndex: number;
 	},
-): TypeConfigArgument | null {
+): TypeConfigArgument | FunctionConfigArgument | null {
 	let type = param.type_;
 	while (typeof type !== 'string' && 'Reference' in type) {
 		type = type.Reference[1];
 	}
 
-	if (typeof type === 'string' || !('Datatype' in type)) {
-		return null;
-	}
+	const datatype = typeof type !== 'string' && 'Datatype' in type ? type.Datatype : null;
+	const paramAddress = datatype ? normalizeAddress(resolveAddress(datatype.module.address)) : null;
+	const moduleAddress = normalizeAddress(resolveAddress(functionRef.moduleAddress));
 
-	const { Datatype } = type;
-	const paramAddress = normalizeAddress(resolveAddress(Datatype.module.address));
-
-	const candidates: { entry: TypeConfigArgument; specificity: number }[] = [];
-	const blockedNameMatchers: TypeConfigArgument[] = [];
+	const candidates: {
+		entry: TypeConfigArgument | FunctionConfigArgument;
+		specificity: number;
+	}[] = [];
+	const blockedNameMatchers: (TypeConfigArgument | FunctionConfigArgument)[] = [];
 
 	for (const entry of entries) {
-		if (entry.kind !== 'type') continue;
+		if (entry.kind === 'function') {
+			if (
+				entry.address !== moduleAddress ||
+				entry.module !== functionRef.moduleName ||
+				entry.functionName !== functionRef.functionName
+			) {
+				continue;
+			}
+			if (entry.parameterName !== undefined) {
+				if (param.name === undefined) {
+					blockedNameMatchers.push(entry);
+					continue;
+				}
+				if (entry.parameterName !== param.name) {
+					continue;
+				}
+			} else if (entry.parameterIndex !== parameterIndex) {
+				continue;
+			}
+			// Function matchers are the most specific form.
+			candidates.push({ entry, specificity: 4 });
+			continue;
+		}
+
+		if (entry.kind !== 'type' || !datatype) continue;
 		if (
 			entry.address !== paramAddress ||
-			entry.module !== Datatype.module.name ||
-			entry.name !== Datatype.name
+			entry.module !== datatype.module.name ||
+			entry.name !== datatype.name
 		) {
 			continue;
 		}
@@ -447,8 +671,8 @@ export function findConfigArgumentMatch(
 			// Fully instantiated matcher: only matches parameters concretely typed with that
 			// exact instantiation in the Move signature.
 			if (
-				Datatype.type_arguments.length !== entry.typeArguments.length ||
-				!Datatype.type_arguments.every((arg, i) =>
+				datatype.type_arguments.length !== entry.typeArguments.length ||
+				!datatype.type_arguments.every((arg, i) =>
 					typeEqualsTag(arg.argument, entry.typeArguments![i], resolveAddress),
 				)
 			) {
@@ -486,7 +710,7 @@ export function findConfigArgumentMatch(
 	const best = Math.max(...candidates.map((c) => c.specificity));
 	const winners = candidates.filter((c) => c.specificity === best);
 
-	if (winners.length > 1) {
+	if (winners.length > 1 && !winners.every((c) => c.entry.key === winners[0].entry.key)) {
 		throw new Error(
 			`Parameter ${param.name ?? '<unnamed>'} of ${functionLabel} is matched by multiple configArguments entries with equal specificity: ${winners
 				.map((c) => c.entry.key)

--- a/packages/codegen/src/config-arguments.ts
+++ b/packages/codegen/src/config-arguments.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { normalizeSuiAddress } from '@mysten/sui/utils';
+import { isValidNamedPackage, normalizeSuiAddress } from '@mysten/sui/utils';
 import type { ConfigArguments } from './config.js';
 import type { ModuleRegistry } from './module-registry.js';
 import type { Parameter, Type } from './types/summary.js';
@@ -12,15 +12,19 @@ export type ParsedTypeTag =
 	| { vector: ParsedTypeTag }
 	| { datatype: { address: string; module: string; name: string; typeArguments: ParsedTypeTag[] } };
 
+/** Whether an entry came from the shared global block or a package-scoped block. */
+export type ConfigArgumentSource = 'global' | 'package';
+
 export interface TypeConfigArgument {
 	kind: 'type';
 	key: string;
+	source: ConfigArgumentSource;
 	address: string;
 	module: string;
 	name: string;
 	/** `null` when the matcher is written without type arguments (matches every instantiation). */
 	typeArguments: ParsedTypeTag[] | null;
-	paramName?: string;
+	parameterName?: string;
 	/**
 	 * Whether the matched Move type is generic. Uninstantiated matchers on generic types require a
 	 * resolver function as the config value (a static id cannot be correct across instantiations).
@@ -31,12 +35,29 @@ export interface TypeConfigArgument {
 export interface PackageConfigArgument {
 	kind: 'package';
 	key: string;
+	source: ConfigArgumentSource;
 	package: string;
 }
 
 export type ParsedConfigArgument = TypeConfigArgument | PackageConfigArgument;
 
 const PRIMITIVES = new Set(['bool', 'u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'address']);
+const MOVE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
+
+function assertBalancedBrackets(tag: string) {
+	let depth = 0;
+	for (const char of tag) {
+		if (char === '<') depth++;
+		if (char === '>') depth--;
+		if (depth < 0) {
+			throw new Error(`Invalid type in configArguments matcher: "${tag}" (unbalanced '>')`);
+		}
+	}
+	if (depth !== 0) {
+		throw new Error(`Invalid type in configArguments matcher: "${tag}" (unbalanced '<')`);
+	}
+}
 
 function splitTopLevelTypeArgs(inner: string): string[] {
 	const parts: string[] = [];
@@ -52,19 +73,41 @@ function splitTopLevelTypeArgs(inner: string): string[] {
 		if (char === '>') depth--;
 		current += char;
 	}
-	if (current.trim()) parts.push(current.trim());
+	parts.push(current.trim());
 	return parts;
 }
 
-function parseTypeTag(tag: string, resolveAddress: (address: string) => string): ParsedTypeTag {
+function parseTypeTag(
+	tag: string,
+	resolveAddress: (address: string) => string,
+	{ isTypeArgument = false, root = tag }: { isTypeArgument?: boolean; root?: string } = {},
+): ParsedTypeTag {
 	const trimmed = tag.trim();
+
+	if (!isTypeArgument) {
+		assertBalancedBrackets(trimmed);
+	}
 
 	if (PRIMITIVES.has(trimmed)) {
 		return { prim: trimmed };
 	}
 
 	if (trimmed.startsWith('vector<') && trimmed.endsWith('>')) {
-		return { vector: parseTypeTag(trimmed.slice('vector<'.length, -1), resolveAddress) };
+		return {
+			vector: parseTypeTag(trimmed.slice('vector<'.length, -1), resolveAddress, {
+				isTypeArgument: true,
+				root,
+			}),
+		};
+	}
+
+	// A bare identifier in type-argument position is a type-parameter placeholder like `Pool<T>`.
+	if (isTypeArgument && MOVE_IDENTIFIER.test(trimmed)) {
+		throw new Error(
+			`configArguments matcher "${root}" contains the type parameter "${trimmed}" — partially ` +
+				`instantiated matchers are not supported. Use an uninstantiated matcher (no type ` +
+				`arguments) with a resolver function instead.`,
+		);
 	}
 
 	const lt = trimmed.indexOf('<');
@@ -81,24 +124,47 @@ function parseTypeTag(tag: string, resolveAddress: (address: string) => string):
 		throw new Error(`Invalid type in configArguments matcher: "${tag}"`);
 	}
 
+	const [addressPart, modulePart, namePart] = parts;
+
+	if (!MOVE_IDENTIFIER.test(modulePart) || !MOVE_IDENTIFIER.test(namePart)) {
+		throw new Error(
+			`Invalid type in configArguments matcher: "${tag}" ("${modulePart}::${namePart}" is not a valid module::type pair)`,
+		);
+	}
+
+	if (isValidNamedPackage(addressPart)) {
+		throw new Error(
+			`Invalid address "${addressPart}" in configArguments matcher "${tag}": MVR names cannot be ` +
+				`matched against package summaries. Use the package's named address from ` +
+				`address_mapping.json or its hex address instead.`,
+		);
+	}
+
+	if (!HEX_ADDRESS.test(addressPart) && !MOVE_IDENTIFIER.test(addressPart)) {
+		throw new Error(`Invalid address "${addressPart}" in configArguments matcher "${tag}"`);
+	}
+
 	const typeArguments =
 		lt === -1
 			? []
-			: splitTopLevelTypeArgs(trimmed.slice(lt + 1, -1)).map((arg) =>
-					parseTypeTag(arg, resolveAddress),
-				);
+			: splitTopLevelTypeArgs(trimmed.slice(lt + 1, -1)).map((arg) => {
+					if (arg.length === 0) {
+						throw new Error(
+							`Invalid type in configArguments matcher: "${tag}" (empty type argument)`,
+						);
+					}
+					return parseTypeTag(arg, resolveAddress, { isTypeArgument: true, root });
+				});
 
 	return {
 		datatype: {
-			address: resolveMatcherAddress(parts[0], resolveAddress),
-			module: parts[1],
-			name: parts[2],
+			address: resolveMatcherAddress(addressPart, resolveAddress),
+			module: modulePart,
+			name: namePart,
 			typeArguments,
 		},
 	};
 }
-
-const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
 
 function resolveMatcherAddress(address: string, resolveAddress: (address: string) => string) {
 	const resolved = resolveAddress(address);
@@ -106,25 +172,70 @@ function resolveMatcherAddress(address: string, resolveAddress: (address: string
 }
 
 /**
- * Parse and validate a `configArguments` record against the modules loaded in `registry`.
- * All addresses (in matchers and during matching) are resolved through the registry's address
- * mapping and normalized, so matchers can use named addresses from `address_mapping.json`.
+ * Check that every datatype nested in an instantiated matcher is itself fully instantiated,
+ * as far as the summaries can tell (unknown types are skipped).
+ */
+function assertFullyInstantiated(
+	tag: ParsedTypeTag,
+	registry: ModuleRegistry,
+	matcherType: string,
+) {
+	if ('prim' in tag) return;
+	if ('vector' in tag) {
+		assertFullyInstantiated(tag.vector, registry, matcherType);
+		return;
+	}
+
+	const { address, module, name, typeArguments } = tag.datatype;
+	const summary = registry.getSummaryByResolvedAddress(address, module);
+	const arity = (summary?.structs[name] ?? summary?.enums[name])?.type_parameters.length;
+
+	if (arity !== undefined && arity !== typeArguments.length) {
+		throw new Error(
+			`configArguments matcher "${matcherType}": ${module}::${name} expects ${arity} type ` +
+				`argument(s), got ${typeArguments.length}. Partially instantiated matchers are not ` +
+				`supported — use an uninstantiated matcher (no type arguments) with a resolver function instead.`,
+		);
+	}
+
+	for (const argument of typeArguments) {
+		assertFullyInstantiated(argument, registry, matcherType);
+	}
+}
+
+/**
+ * Parse and validate `configArguments` blocks against the modules loaded in `registry`.
+ * Per-package entries are merged over global entries (per key). All addresses (in matchers and
+ * during matching) are resolved through the registry's address mapping and normalized, so
+ * matchers can use named addresses from `address_mapping.json`.
  *
- * Type matchers referencing types that don't exist in this package's summaries are returned in
- * `unresolvedKeys` instead of the entry list — a shared global `configArguments` block may span
+ * Type matchers referencing types that don't exist in this package's summaries are a hard error
+ * when declared in a package-scoped block (they can only refer to this package's summaries), and
+ * are returned in `unresolvedKeys` when declared globally — a shared global block may span
  * multiple packages in one codegen run, and entries for other packages can't match anything here.
  */
 export function parseConfigArguments(
-	configArguments: ConfigArguments,
+	blocks: { global?: ConfigArguments; package?: ConfigArguments },
 	registry: ModuleRegistry,
 ): { entries: ParsedConfigArgument[]; unresolvedKeys: string[] } {
 	const resolveAddress = (address: string) => registry.resolveAddress(address);
 	const entries: ParsedConfigArgument[] = [];
 	const unresolvedKeys: string[] = [];
 
-	for (const [key, matcher] of Object.entries(configArguments)) {
+	const merged = new Map<
+		string,
+		{ matcher: NonNullable<ConfigArguments[string]>; source: ConfigArgumentSource }
+	>();
+	for (const [key, matcher] of Object.entries(blocks.global ?? {})) {
+		merged.set(key, { matcher, source: 'global' });
+	}
+	for (const [key, matcher] of Object.entries(blocks.package ?? {})) {
+		merged.set(key, { matcher, source: 'package' });
+	}
+
+	for (const [key, { matcher, source }] of merged) {
 		if ('package' in matcher) {
-			entries.push({ kind: 'package', key, package: matcher.package });
+			entries.push({ kind: 'package', key, source, package: matcher.package });
 			continue;
 		}
 
@@ -141,6 +252,14 @@ export function parseConfigArguments(
 		const datatype = summary?.structs[name] ?? summary?.enums[name];
 
 		if (!datatype) {
+			if (source === 'package') {
+				throw new Error(
+					`configArguments.${key}: type "${matcher.type}" was not found in this package's ` +
+						`summaries. Package-scoped configArguments can only reference types reachable from ` +
+						`this package — fix the type, or move the entry to the global configArguments block ` +
+						`if it targets another package.`,
+				);
+			}
 			unresolvedKeys.push(key);
 			continue;
 		}
@@ -156,14 +275,19 @@ export function parseConfigArguments(
 			);
 		}
 
+		for (const argument of typeArguments) {
+			assertFullyInstantiated(argument, registry, matcher.type);
+		}
+
 		entries.push({
 			kind: 'type',
 			key,
+			source,
 			address,
 			module,
 			name,
 			typeArguments: uninstantiated ? null : typeArguments,
-			paramName: matcher.name,
+			parameterName: matcher.parameterName,
 			isGeneric,
 		});
 	}
@@ -210,8 +334,13 @@ function typeEqualsTag(
  * Find the config entry matching a function parameter, or `null`.
  *
  * Most-specific matcher wins, decided statically: a fully instantiated matcher beats an
- * uninstantiated one, and a `name`-refined matcher beats a bare one at the same level. Ties are a
- * hard generation-time error.
+ * uninstantiated one, and a `parameterName`-refined matcher beats a bare one at the same level.
+ * Ties are a hard generation-time error.
+ *
+ * A `parameterName`-refined matcher never matches a parameter without a name — but if such a
+ * matcher would otherwise apply (type and instantiation match) and nothing else matches the
+ * parameter, that is a hard error: the matcher clearly targets this parameter's type and only the
+ * missing parameter names (bytecode summaries don't include them) prevent matching it.
  */
 export function findConfigArgumentMatch(
 	param: Parameter,
@@ -237,6 +366,7 @@ export function findConfigArgumentMatch(
 	const paramAddress = resolveMatcherAddress(Datatype.module.address, resolveAddress);
 
 	const candidates: { entry: TypeConfigArgument; specificity: number }[] = [];
+	const blockedNameMatchers: TypeConfigArgument[] = [];
 
 	for (const entry of entries) {
 		if (entry.kind !== 'type') continue;
@@ -248,16 +378,7 @@ export function findConfigArgumentMatch(
 			continue;
 		}
 
-		if (entry.paramName && param.name === undefined) {
-			throw new Error(
-				`configArguments.${entry.key} uses a parameter-name matcher, but parameters of ${functionLabel} have no names. ` +
-					`Name matchers are only supported for summaries generated from local packages.`,
-			);
-		}
-
-		if (entry.paramName && entry.paramName !== param.name) {
-			continue;
-		}
+		let specificity = 0;
 
 		if (entry.typeArguments !== null) {
 			// Fully instantiated matcher: only matches parameters concretely typed with that
@@ -270,13 +391,32 @@ export function findConfigArgumentMatch(
 			) {
 				continue;
 			}
-			candidates.push({ entry, specificity: 2 + (entry.paramName ? 1 : 0) });
-		} else {
-			candidates.push({ entry, specificity: entry.paramName ? 1 : 0 });
+			specificity += 2;
 		}
+
+		if (entry.parameterName) {
+			if (param.name === undefined) {
+				blockedNameMatchers.push(entry);
+				continue;
+			}
+			if (entry.parameterName !== param.name) {
+				continue;
+			}
+			specificity += 1;
+		}
+
+		candidates.push({ entry, specificity });
 	}
 
 	if (candidates.length === 0) {
+		if (blockedNameMatchers.length > 0) {
+			throw new Error(
+				`configArguments ${blockedNameMatchers.map((entry) => entry.key).join(', ')} use ` +
+					`parameterName matchers that would apply to a parameter of ${functionLabel}, but its ` +
+					`parameters have no names (bytecode summaries do not include parameter names). Remove ` +
+					`the parameterName refinement, or exclude this package from the matcher's scope.`,
+			);
+		}
 		return null;
 	}
 

--- a/packages/codegen/src/config-arguments.ts
+++ b/packages/codegen/src/config-arguments.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidNamedPackage, normalizeSuiAddress } from '@mysten/sui/utils';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
 import type { ConfigArguments } from './config.js';
 import type { ModuleRegistry } from './module-registry.js';
 import type { Parameter, Type } from './types/summary.js';
@@ -41,9 +41,37 @@ export interface PackageConfigArgument {
 
 export type ParsedConfigArgument = TypeConfigArgument | PackageConfigArgument;
 
+export interface ConfigArgumentsContext {
+	/** Identifier (from the `packages` config) and resolved address of the package being generated. */
+	package: { id: string; address: string };
+	/**
+	 * Resolved root addresses of the other packages in the codegen run, keyed by their `packages`
+	 * identifier. Matchers can reference any of these packages' types.
+	 */
+	packageAddresses?: Record<string, string>;
+}
+
 const PRIMITIVES = new Set(['bool', 'u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'address']);
 const MOVE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
+/** The only packages with chain-stable addresses. Everything else must use a package identifier. */
+const FRAMEWORK_ADDRESS = /^0x0*[123]$/;
+
+function normalizeAddress(address: string) {
+	return HEX_ADDRESS.test(address) ? normalizeSuiAddress(address) : address;
+}
+
+interface ParseContext {
+	/**
+	 * Address a bare `module::Type` resolves against, or `null` when there is no ambient package
+	 * (global block), which makes the qualifier required.
+	 */
+	scopeAddress: string | null;
+	/** Resolved addresses by package identifier from the `packages` config. */
+	packageAddresses: Record<string, string>;
+	root: string;
+	isTypeArgument?: boolean;
+}
 
 function assertBalancedBrackets(tag: string) {
 	let depth = 0;
@@ -77,14 +105,10 @@ function splitTopLevelTypeArgs(inner: string): string[] {
 	return parts;
 }
 
-function parseTypeTag(
-	tag: string,
-	resolveAddress: (address: string) => string,
-	{ isTypeArgument = false, root = tag }: { isTypeArgument?: boolean; root?: string } = {},
-): ParsedTypeTag {
+function parseTypeTag(tag: string, ctx: ParseContext): ParsedTypeTag {
 	const trimmed = tag.trim();
 
-	if (!isTypeArgument) {
+	if (!ctx.isTypeArgument) {
 		assertBalancedBrackets(trimmed);
 	}
 
@@ -94,17 +118,17 @@ function parseTypeTag(
 
 	if (trimmed.startsWith('vector<') && trimmed.endsWith('>')) {
 		return {
-			vector: parseTypeTag(trimmed.slice('vector<'.length, -1), resolveAddress, {
+			vector: parseTypeTag(trimmed.slice('vector<'.length, -1), {
+				...ctx,
 				isTypeArgument: true,
-				root,
 			}),
 		};
 	}
 
 	// A bare identifier in type-argument position is a type-parameter placeholder like `Pool<T>`.
-	if (isTypeArgument && MOVE_IDENTIFIER.test(trimmed)) {
+	if (ctx.isTypeArgument && MOVE_IDENTIFIER.test(trimmed)) {
 		throw new Error(
-			`configArguments matcher "${root}" contains the type parameter "${trimmed}" — partially ` +
+			`configArguments matcher "${ctx.root}" contains the type parameter "${trimmed}" — partially ` +
 				`instantiated matchers are not supported. Use an uninstantiated matcher (no type ` +
 				`arguments) with a resolver function instead.`,
 		);
@@ -114,9 +138,11 @@ function parseTypeTag(
 	const base = lt === -1 ? trimmed : trimmed.slice(0, lt);
 	const parts = base.split('::');
 
-	if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+	if ((parts.length !== 2 && parts.length !== 3) || parts.some((part) => part.length === 0)) {
 		throw new Error(
-			`Invalid type in configArguments matcher: "${tag}". Expected a fully-qualified Move type like "0x2::sui::SUI".`,
+			`Invalid type in configArguments matcher: "${tag}". Expected "module::Type", optionally ` +
+				`qualified with a package from the codegen config ("@pkg/name::module::Type") or a Sui ` +
+				`framework address ("0x2::module::Type").`,
 		);
 	}
 
@@ -124,7 +150,9 @@ function parseTypeTag(
 		throw new Error(`Invalid type in configArguments matcher: "${tag}"`);
 	}
 
-	const [addressPart, modulePart, namePart] = parts;
+	const packagePart = parts.length === 3 ? parts[0] : undefined;
+	const modulePart = parts[parts.length - 2];
+	const namePart = parts[parts.length - 1];
 
 	if (!MOVE_IDENTIFIER.test(modulePart) || !MOVE_IDENTIFIER.test(namePart)) {
 		throw new Error(
@@ -132,16 +160,38 @@ function parseTypeTag(
 		);
 	}
 
-	if (isValidNamedPackage(addressPart)) {
-		throw new Error(
-			`Invalid address "${addressPart}" in configArguments matcher "${tag}": MVR names cannot be ` +
-				`matched against package summaries. Use the package's named address from ` +
-				`address_mapping.json or its hex address instead.`,
-		);
-	}
+	let address: string;
 
-	if (!HEX_ADDRESS.test(addressPart) && !MOVE_IDENTIFIER.test(addressPart)) {
-		throw new Error(`Invalid address "${addressPart}" in configArguments matcher "${tag}"`);
+	if (packagePart === undefined) {
+		// Codegen output is network-agnostic: a bare `module::Type` refers to the package whose
+		// configArguments block declares it.
+		if (ctx.scopeAddress === null) {
+			throw new Error(
+				`configArguments matcher "${ctx.root}": "${modulePart}::${namePart}" must be qualified ` +
+					`with a package in the global configArguments block (e.g. ` +
+					`"@pkg/name::${modulePart}::${namePart}"). Bare module::Type matchers are only ` +
+					`supported in a package's own configArguments block.`,
+			);
+		}
+		address = ctx.scopeAddress;
+	} else if (FRAMEWORK_ADDRESS.test(packagePart)) {
+		address = normalizeSuiAddress(packagePart);
+	} else if (HEX_ADDRESS.test(packagePart)) {
+		throw new Error(
+			`Invalid package "${packagePart}" in configArguments matcher "${tag}": package addresses ` +
+				`are network-specific and cannot be used in matchers (only the framework addresses ` +
+				`0x1-0x3 are chain-stable). Reference the package by its identifier from the codegen ` +
+				`config instead (e.g. "@pkg/name::${modulePart}::${namePart}").`,
+		);
+	} else {
+		const resolved = ctx.packageAddresses[packagePart];
+		if (resolved === undefined) {
+			throw new Error(
+				`Unknown package "${packagePart}" in configArguments matcher "${tag}". Known packages in ` +
+					`this codegen run: ${Object.keys(ctx.packageAddresses).join(', ')}`,
+			);
+		}
+		address = resolved;
 	}
 
 	const typeArguments =
@@ -153,22 +203,17 @@ function parseTypeTag(
 							`Invalid type in configArguments matcher: "${tag}" (empty type argument)`,
 						);
 					}
-					return parseTypeTag(arg, resolveAddress, { isTypeArgument: true, root });
+					return parseTypeTag(arg, { ...ctx, isTypeArgument: true });
 				});
 
 	return {
 		datatype: {
-			address: resolveMatcherAddress(addressPart, resolveAddress),
+			address: normalizeAddress(address),
 			module: modulePart,
 			name: namePart,
 			typeArguments,
 		},
 	};
-}
-
-function resolveMatcherAddress(address: string, resolveAddress: (address: string) => string) {
-	const resolved = resolveAddress(address);
-	return HEX_ADDRESS.test(resolved) ? normalizeSuiAddress(resolved) : resolved;
 }
 
 /**
@@ -205,22 +250,28 @@ function assertFullyInstantiated(
 
 /**
  * Parse and validate `configArguments` blocks against the modules loaded in `registry`.
- * Per-package entries are merged over global entries (per key). All addresses (in matchers and
- * during matching) are resolved through the registry's address mapping and normalized, so
- * matchers can use named addresses from `address_mapping.json`.
+ * Per-package entries are merged over global entries (per key).
  *
- * Type matchers referencing types that don't exist in this package's summaries are a hard error
- * when declared in a package-scoped block (they can only refer to this package's summaries), and
- * are returned in `unresolvedKeys` when declared globally — a shared global block may span
- * multiple packages in one codegen run, and entries for other packages can't match anything here.
+ * Matchers identify packages network-agnostically: by the package identifiers from the codegen
+ * config (resolved through `context.packageAddresses`), by the ambient package for bare
+ * `module::Type` matchers in a package-scoped block, or by the chain-stable framework addresses
+ * 0x1-0x3. If a matcher's package is part of this package's summaries, the matched type must
+ * exist there (typos fail generation); matchers referencing run packages that aren't part of this
+ * dependency closure can't match anything here and are skipped.
  */
 export function parseConfigArguments(
 	blocks: { global?: ConfigArguments; package?: ConfigArguments },
 	registry: ModuleRegistry,
-): { entries: ParsedConfigArgument[]; unresolvedKeys: string[] } {
-	const resolveAddress = (address: string) => registry.resolveAddress(address);
+	context: ConfigArgumentsContext,
+): { entries: ParsedConfigArgument[] } {
 	const entries: ParsedConfigArgument[] = [];
-	const unresolvedKeys: string[] = [];
+	const currentAddress = normalizeAddress(context.package.address);
+	const packageAddresses: Record<string, string> = Object.fromEntries(
+		Object.entries({
+			...context.packageAddresses,
+			[context.package.id]: context.package.address,
+		}).map(([id, address]) => [id, normalizeAddress(address)]),
+	);
 
 	const merged = new Map<
 		string,
@@ -239,7 +290,11 @@ export function parseConfigArguments(
 			continue;
 		}
 
-		const parsed = parseTypeTag(matcher.type, resolveAddress);
+		const parsed = parseTypeTag(matcher.type, {
+			scopeAddress: source === 'package' ? currentAddress : null,
+			packageAddresses,
+			root: matcher.type,
+		});
 
 		if (!('datatype' in parsed)) {
 			throw new Error(
@@ -252,15 +307,23 @@ export function parseConfigArguments(
 		const datatype = summary?.structs[name] ?? summary?.enums[name];
 
 		if (!datatype) {
-			if (source === 'package') {
+			if (registry.hasResolvedAddress(address)) {
+				// The matcher's package is part of this dependency closure, so the type has to
+				// exist — this is a typo.
 				throw new Error(
-					`configArguments.${key}: type "${matcher.type}" was not found in this package's ` +
-						`summaries. Package-scoped configArguments can only reference types reachable from ` +
-						`this package — fix the type, or move the entry to the global configArguments block ` +
-						`if it targets another package.`,
+					`configArguments.${key}: type "${matcher.type}" was not found in its package's summaries`,
 				);
 			}
-			unresolvedKeys.push(key);
+			// The matcher references a run package that isn't part of this package's dependency
+			// closure — it can't match anything here. It is validated when its own package is
+			// generated.
+			if (source === 'package') {
+				console.warn(
+					`configArguments.${key}: type "${matcher.type}" is not part of ${context.package.id}'s ` +
+						`dependencies and will never match — consider moving it to the global block or the ` +
+						`package it belongs to.`,
+				);
+			}
 			continue;
 		}
 
@@ -292,7 +355,7 @@ export function parseConfigArguments(
 		});
 	}
 
-	return { entries, unresolvedKeys };
+	return { entries };
 }
 
 function typeEqualsTag(
@@ -316,7 +379,7 @@ function typeEqualsTag(
 		if (!('datatype' in tag)) return false;
 		const { Datatype } = type;
 		return (
-			resolveMatcherAddress(Datatype.module.address, resolveAddress) === tag.datatype.address &&
+			normalizeAddress(resolveAddress(Datatype.module.address)) === tag.datatype.address &&
 			Datatype.module.name === tag.datatype.module &&
 			Datatype.name === tag.datatype.name &&
 			Datatype.type_arguments.length === tag.datatype.typeArguments.length &&
@@ -363,7 +426,7 @@ export function findConfigArgumentMatch(
 	}
 
 	const { Datatype } = type;
-	const paramAddress = resolveMatcherAddress(Datatype.module.address, resolveAddress);
+	const paramAddress = normalizeAddress(resolveAddress(Datatype.module.address));
 
 	const candidates: { entry: TypeConfigArgument; specificity: number }[] = [];
 	const blockedNameMatchers: TypeConfigArgument[] = [];

--- a/packages/codegen/src/config-arguments.ts
+++ b/packages/codegen/src/config-arguments.ts
@@ -1,0 +1,295 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { normalizeSuiAddress } from '@mysten/sui/utils';
+import type { ConfigArguments } from './config.js';
+import type { ModuleRegistry } from './module-registry.js';
+import type { Parameter, Type } from './types/summary.js';
+
+/** A parsed type tag from a `configArguments` matcher. Always fully concrete. */
+export type ParsedTypeTag =
+	| { prim: string }
+	| { vector: ParsedTypeTag }
+	| { datatype: { address: string; module: string; name: string; typeArguments: ParsedTypeTag[] } };
+
+export interface TypeConfigArgument {
+	kind: 'type';
+	key: string;
+	address: string;
+	module: string;
+	name: string;
+	/** `null` when the matcher is written without type arguments (matches every instantiation). */
+	typeArguments: ParsedTypeTag[] | null;
+	paramName?: string;
+	/**
+	 * Whether the matched Move type is generic. Uninstantiated matchers on generic types require a
+	 * resolver function as the config value (a static id cannot be correct across instantiations).
+	 */
+	isGeneric: boolean;
+}
+
+export interface PackageConfigArgument {
+	kind: 'package';
+	key: string;
+	package: string;
+}
+
+export type ParsedConfigArgument = TypeConfigArgument | PackageConfigArgument;
+
+const PRIMITIVES = new Set(['bool', 'u8', 'u16', 'u32', 'u64', 'u128', 'u256', 'address']);
+
+function splitTopLevelTypeArgs(inner: string): string[] {
+	const parts: string[] = [];
+	let depth = 0;
+	let current = '';
+	for (const char of inner) {
+		if (char === ',' && depth === 0) {
+			parts.push(current.trim());
+			current = '';
+			continue;
+		}
+		if (char === '<') depth++;
+		if (char === '>') depth--;
+		current += char;
+	}
+	if (current.trim()) parts.push(current.trim());
+	return parts;
+}
+
+function parseTypeTag(tag: string, resolveAddress: (address: string) => string): ParsedTypeTag {
+	const trimmed = tag.trim();
+
+	if (PRIMITIVES.has(trimmed)) {
+		return { prim: trimmed };
+	}
+
+	if (trimmed.startsWith('vector<') && trimmed.endsWith('>')) {
+		return { vector: parseTypeTag(trimmed.slice('vector<'.length, -1), resolveAddress) };
+	}
+
+	const lt = trimmed.indexOf('<');
+	const base = lt === -1 ? trimmed : trimmed.slice(0, lt);
+	const parts = base.split('::');
+
+	if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+		throw new Error(
+			`Invalid type in configArguments matcher: "${tag}". Expected a fully-qualified Move type like "0x2::sui::SUI".`,
+		);
+	}
+
+	if (lt !== -1 && !trimmed.endsWith('>')) {
+		throw new Error(`Invalid type in configArguments matcher: "${tag}"`);
+	}
+
+	const typeArguments =
+		lt === -1
+			? []
+			: splitTopLevelTypeArgs(trimmed.slice(lt + 1, -1)).map((arg) =>
+					parseTypeTag(arg, resolveAddress),
+				);
+
+	return {
+		datatype: {
+			address: resolveMatcherAddress(parts[0], resolveAddress),
+			module: parts[1],
+			name: parts[2],
+			typeArguments,
+		},
+	};
+}
+
+const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
+
+function resolveMatcherAddress(address: string, resolveAddress: (address: string) => string) {
+	const resolved = resolveAddress(address);
+	return HEX_ADDRESS.test(resolved) ? normalizeSuiAddress(resolved) : resolved;
+}
+
+/**
+ * Parse and validate a `configArguments` record against the modules loaded in `registry`.
+ * All addresses (in matchers and during matching) are resolved through the registry's address
+ * mapping and normalized, so matchers can use named addresses from `address_mapping.json`.
+ *
+ * Type matchers referencing types that don't exist in this package's summaries are returned in
+ * `unresolvedKeys` instead of the entry list — a shared global `configArguments` block may span
+ * multiple packages in one codegen run, and entries for other packages can't match anything here.
+ */
+export function parseConfigArguments(
+	configArguments: ConfigArguments,
+	registry: ModuleRegistry,
+): { entries: ParsedConfigArgument[]; unresolvedKeys: string[] } {
+	const resolveAddress = (address: string) => registry.resolveAddress(address);
+	const entries: ParsedConfigArgument[] = [];
+	const unresolvedKeys: string[] = [];
+
+	for (const [key, matcher] of Object.entries(configArguments)) {
+		if ('package' in matcher) {
+			entries.push({ kind: 'package', key, package: matcher.package });
+			continue;
+		}
+
+		const parsed = parseTypeTag(matcher.type, resolveAddress);
+
+		if (!('datatype' in parsed)) {
+			throw new Error(
+				`configArguments.${key}: matcher type "${matcher.type}" must be a Move datatype`,
+			);
+		}
+
+		const { address, module, name, typeArguments } = parsed.datatype;
+		const summary = registry.getSummaryByResolvedAddress(address, module);
+		const datatype = summary?.structs[name] ?? summary?.enums[name];
+
+		if (!datatype) {
+			unresolvedKeys.push(key);
+			continue;
+		}
+
+		const arity = datatype.type_parameters.length;
+		const isGeneric = arity > 0;
+		// A generic type written without `<...>` matches every instantiation.
+		const uninstantiated = isGeneric && !matcher.type.includes('<');
+
+		if (!uninstantiated && typeArguments.length !== arity) {
+			throw new Error(
+				`configArguments.${key}: type "${matcher.type}" expects ${arity} type argument(s), got ${typeArguments.length}`,
+			);
+		}
+
+		entries.push({
+			kind: 'type',
+			key,
+			address,
+			module,
+			name,
+			typeArguments: uninstantiated ? null : typeArguments,
+			paramName: matcher.name,
+			isGeneric,
+		});
+	}
+
+	return { entries, unresolvedKeys };
+}
+
+function typeEqualsTag(
+	type: Type,
+	tag: ParsedTypeTag,
+	resolveAddress: (address: string) => string,
+): boolean {
+	if (typeof type === 'string') {
+		return 'prim' in tag && tag.prim === type;
+	}
+
+	if ('Reference' in type) {
+		return typeEqualsTag(type.Reference[1], tag, resolveAddress);
+	}
+
+	if ('vector' in type) {
+		return 'vector' in tag && typeEqualsTag(type.vector, tag.vector, resolveAddress);
+	}
+
+	if ('Datatype' in type) {
+		if (!('datatype' in tag)) return false;
+		const { Datatype } = type;
+		return (
+			resolveMatcherAddress(Datatype.module.address, resolveAddress) === tag.datatype.address &&
+			Datatype.module.name === tag.datatype.module &&
+			Datatype.name === tag.datatype.name &&
+			Datatype.type_arguments.length === tag.datatype.typeArguments.length &&
+			Datatype.type_arguments.every((arg, i) =>
+				typeEqualsTag(arg.argument, tag.datatype.typeArguments[i], resolveAddress),
+			)
+		);
+	}
+
+	// TypeParameter / NamedTypeParameter / tuple / fun never match a concrete tag.
+	return false;
+}
+
+/**
+ * Find the config entry matching a function parameter, or `null`.
+ *
+ * Most-specific matcher wins, decided statically: a fully instantiated matcher beats an
+ * uninstantiated one, and a `name`-refined matcher beats a bare one at the same level. Ties are a
+ * hard generation-time error.
+ */
+export function findConfigArgumentMatch(
+	param: Parameter,
+	entries: ParsedConfigArgument[],
+	{
+		resolveAddress,
+		functionLabel,
+	}: {
+		resolveAddress: (address: string) => string;
+		functionLabel: string;
+	},
+): TypeConfigArgument | null {
+	let type = param.type_;
+	while (typeof type !== 'string' && 'Reference' in type) {
+		type = type.Reference[1];
+	}
+
+	if (typeof type === 'string' || !('Datatype' in type)) {
+		return null;
+	}
+
+	const { Datatype } = type;
+	const paramAddress = resolveMatcherAddress(Datatype.module.address, resolveAddress);
+
+	const candidates: { entry: TypeConfigArgument; specificity: number }[] = [];
+
+	for (const entry of entries) {
+		if (entry.kind !== 'type') continue;
+		if (
+			entry.address !== paramAddress ||
+			entry.module !== Datatype.module.name ||
+			entry.name !== Datatype.name
+		) {
+			continue;
+		}
+
+		if (entry.paramName && param.name === undefined) {
+			throw new Error(
+				`configArguments.${entry.key} uses a parameter-name matcher, but parameters of ${functionLabel} have no names. ` +
+					`Name matchers are only supported for summaries generated from local packages.`,
+			);
+		}
+
+		if (entry.paramName && entry.paramName !== param.name) {
+			continue;
+		}
+
+		if (entry.typeArguments !== null) {
+			// Fully instantiated matcher: only matches parameters concretely typed with that
+			// exact instantiation in the Move signature.
+			if (
+				Datatype.type_arguments.length !== entry.typeArguments.length ||
+				!Datatype.type_arguments.every((arg, i) =>
+					typeEqualsTag(arg.argument, entry.typeArguments![i], resolveAddress),
+				)
+			) {
+				continue;
+			}
+			candidates.push({ entry, specificity: 2 + (entry.paramName ? 1 : 0) });
+		} else {
+			candidates.push({ entry, specificity: entry.paramName ? 1 : 0 });
+		}
+	}
+
+	if (candidates.length === 0) {
+		return null;
+	}
+
+	const best = Math.max(...candidates.map((c) => c.specificity));
+	const winners = candidates.filter((c) => c.specificity === best);
+
+	if (winners.length > 1) {
+		throw new Error(
+			`Parameter ${param.name ?? '<unnamed>'} of ${functionLabel} is matched by multiple configArguments entries with equal specificity: ${winners
+				.map((c) => c.entry.key)
+				.join(', ')}. Refine the matchers with type arguments or a parameter name.`,
+		);
+	}
+
+	return winners[0].entry;
+}

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -39,11 +39,14 @@ const FORBIDDEN_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 export const configArgumentMatcherSchema = z.union([
 	z.strictObject({
 		/**
-		 * Fully-qualified Move type to match function parameters against, e.g.
-		 * `0x...::margin_registry::MarginRegistry`. A generic type written without type arguments
-		 * (e.g. `0x...::pool::Pool`) matches every instantiation and requires a resolver function
-		 * as the config value. A fully instantiated generic (e.g. `0x...::margin_pool::MarginPool<0x2::sui::SUI>`)
-		 * only matches parameters concretely typed with that exact instantiation.
+		 * Move type to match function parameters against, written network-agnostically as
+		 * `module::TypeName`. In a package's own `configArguments` block a bare `module::TypeName`
+		 * refers to that package's type; other packages in the run are referenced by their
+		 * `packages` identifier (`@myapp/core::pool::Pool`), and the chain-stable framework
+		 * packages by address (`0x2::sui::SUI`). A generic type written without type arguments
+		 * matches every instantiation and requires a resolver function as the config value; a
+		 * fully instantiated generic (e.g. `pool::Pool<0x2::sui::SUI>`) only matches parameters
+		 * concretely typed with that exact instantiation.
 		 */
 		type: z.string(),
 		/**

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -33,9 +33,11 @@ export const moduleGenerateSchema = z.object({
 });
 
 const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+/** Keys that would collide with `Object.prototype` or mutate prototypes on plain objects. */
+const FORBIDDEN_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export const configArgumentMatcherSchema = z.union([
-	z.object({
+	z.strictObject({
 		/**
 		 * Fully-qualified Move type to match function parameters against, e.g.
 		 * `0x...::margin_registry::MarginRegistry`. A generic type written without type arguments
@@ -49,9 +51,9 @@ export const configArgumentMatcherSchema = z.union([
 		 * matched type. Only supported for summaries generated from local packages (bytecode
 		 * summaries do not include parameter names).
 		 */
-		name: z.string().optional(),
+		parameterName: z.string().optional(),
 	}),
-	z.object({
+	z.strictObject({
 		/**
 		 * Package entry, keyed by the package's name/MVR name from the `packages` config. Adds an
 		 * optional config key that overrides the package address used for generated calls.
@@ -61,10 +63,15 @@ export const configArgumentMatcherSchema = z.union([
 ]);
 
 export const configArgumentsSchema = z.record(
-	z.string().regex(IDENTIFIER, {
-		message:
-			'configArguments keys become properties of the generated config interface and must be valid identifiers',
-	}),
+	z
+		.string()
+		.regex(IDENTIFIER, {
+			message:
+				'configArguments keys become properties of the generated config interface and must be valid identifiers',
+		})
+		.refine((key) => !FORBIDDEN_CONFIG_KEYS.has(key), {
+			message: 'configArguments keys must not be prototype property names',
+		}),
 	configArgumentMatcherSchema,
 );
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -32,6 +32,45 @@ export const moduleGenerateSchema = z.object({
 	types: typesOptionSchema.optional(),
 });
 
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+export const configArgumentMatcherSchema = z.union([
+	z.object({
+		/**
+		 * Fully-qualified Move type to match function parameters against, e.g.
+		 * `0x...::margin_registry::MarginRegistry`. A generic type written without type arguments
+		 * (e.g. `0x...::pool::Pool`) matches every instantiation and requires a resolver function
+		 * as the config value. A fully instantiated generic (e.g. `0x...::margin_pool::MarginPool<0x2::sui::SUI>`)
+		 * only matches parameters concretely typed with that exact instantiation.
+		 */
+		type: z.string(),
+		/**
+		 * Optional Move parameter-name refinement, for signatures with two parameters of the same
+		 * matched type. Only supported for summaries generated from local packages (bytecode
+		 * summaries do not include parameter names).
+		 */
+		name: z.string().optional(),
+	}),
+	z.object({
+		/**
+		 * Package entry, keyed by the package's name/MVR name from the `packages` config. Adds an
+		 * optional config key that overrides the package address used for generated calls.
+		 */
+		package: z.string(),
+	}),
+]);
+
+export const configArgumentsSchema = z.record(
+	z.string().regex(IDENTIFIER, {
+		message:
+			'configArguments keys become properties of the generated config interface and must be valid identifiers',
+	}),
+	configArgumentMatcherSchema,
+);
+
+export type ConfigArgumentMatcher = z.infer<typeof configArgumentMatcherSchema>;
+export type ConfigArguments = z.infer<typeof configArgumentsSchema>;
+
 export const packageGenerateSchema = globalGenerateSchema.extend({
 	modules: z
 		.union([
@@ -49,6 +88,7 @@ export const onChainPackageSchema = z.object({
 	path: z.never().optional(),
 	network: z.enum(['mainnet', 'testnet']),
 	generate: packageGenerateSchema.optional(),
+	configArguments: configArgumentsSchema.optional(),
 });
 
 export const localPackageSchema = z.object({
@@ -56,6 +96,7 @@ export const localPackageSchema = z.object({
 	package: z.string(),
 	packageName: z.string().optional(),
 	generate: packageGenerateSchema.optional(),
+	configArguments: configArgumentsSchema.optional(),
 });
 
 export const packageConfigSchema = z.union([onChainPackageSchema, localPackageSchema]);
@@ -67,8 +108,6 @@ export type GenerateBase = z.infer<typeof globalGenerateSchema>;
 export type PackageGenerate = z.infer<typeof packageGenerateSchema>;
 export type FunctionsOption = z.infer<typeof functionsOptionSchema>;
 export type TypesOption = z.infer<typeof typesOptionSchema>;
-
-const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
 
 export const errorClassSchema = z.object({
 	name: z.string().regex(IDENTIFIER, {
@@ -84,6 +123,12 @@ export const configSchema = z.object({
 	generateSummaries: z.boolean().optional().default(true),
 	packages: z.array(packageConfigSchema),
 	generate: globalGenerateSchema.optional(),
+	/**
+	 * Maps config-object keys to Move type (or package) matchers. Matched function parameters are
+	 * resolved from a runtime config object instead of being required arguments. Per-package
+	 * `configArguments` entries are merged over these global entries.
+	 */
+	configArguments: configArgumentsSchema.optional(),
 	/** @deprecated Use `generate: { functions: { private: 'entry' } }` instead */
 	privateMethods: z.union([z.literal('none'), z.literal('entry'), z.literal('all')]).optional(),
 	importExtension: importExtensionSchema.optional().default('.js'),

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -36,33 +36,56 @@ const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
 /** Keys that would collide with `Object.prototype` or mutate prototypes on plain objects. */
 const FORBIDDEN_CONFIG_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+const typeMatcherSchema = z.strictObject({
+	/**
+	 * Move type to match function parameters against, written network-agnostically as
+	 * `module::TypeName`. In a package's own `configArguments` block a bare `module::TypeName`
+	 * refers to that package's type; other packages in the run are referenced by their
+	 * `packages` identifier (`@myapp/core::pool::Pool`), and the chain-stable framework
+	 * packages by address (`0x2::sui::SUI`). A generic type written without type arguments
+	 * matches every instantiation and requires a resolver function as the config value; a
+	 * fully instantiated generic (e.g. `pool::Pool<0x2::sui::SUI>`) only matches parameters
+	 * concretely typed with that exact instantiation.
+	 */
+	type: z.string(),
+	/**
+	 * Optional Move parameter-name refinement, for signatures with two parameters of the same
+	 * matched type. Only supported for summaries generated from local packages (bytecode
+	 * summaries do not include parameter names).
+	 */
+	parameterName: z.string().optional(),
+});
+
+const functionMatcherSchema = z.strictObject({
+	/**
+	 * A Move function whose parameter is configured directly, written `module::function_name`
+	 * (scoped like type matchers: bare form in a package's own block, `@pkg::module::fn`
+	 * otherwise). The parameter's type is derived from the signature.
+	 */
+	function: z.string(),
+	/** The Move name of the parameter to configure. */
+	parameterName: z.string().optional(),
+	/**
+	 * The position of the parameter to configure, in the generated function's arguments (the
+	 * same positions as the tuple form of `arguments` — `TxContext` and auto-injected well-known
+	 * objects are excluded). Use for summaries without parameter names. When both this and
+	 * `parameterName` are omitted, the function must have exactly one argument.
+	 */
+	parameterIndex: z.number().int().nonnegative().optional(),
+});
+
+const packageMatcherSchema = z.strictObject({
+	/**
+	 * Package entry, keyed by the package's name/MVR name from the `packages` config. Adds an
+	 * optional config key that overrides the package address used for generated calls.
+	 */
+	package: z.string(),
+});
+
 export const configArgumentMatcherSchema = z.union([
-	z.strictObject({
-		/**
-		 * Move type to match function parameters against, written network-agnostically as
-		 * `module::TypeName`. In a package's own `configArguments` block a bare `module::TypeName`
-		 * refers to that package's type; other packages in the run are referenced by their
-		 * `packages` identifier (`@myapp/core::pool::Pool`), and the chain-stable framework
-		 * packages by address (`0x2::sui::SUI`). A generic type written without type arguments
-		 * matches every instantiation and requires a resolver function as the config value; a
-		 * fully instantiated generic (e.g. `pool::Pool<0x2::sui::SUI>`) only matches parameters
-		 * concretely typed with that exact instantiation.
-		 */
-		type: z.string(),
-		/**
-		 * Optional Move parameter-name refinement, for signatures with two parameters of the same
-		 * matched type. Only supported for summaries generated from local packages (bytecode
-		 * summaries do not include parameter names).
-		 */
-		parameterName: z.string().optional(),
-	}),
-	z.strictObject({
-		/**
-		 * Package entry, keyed by the package's name/MVR name from the `packages` config. Adds an
-		 * optional config key that overrides the package address used for generated calls.
-		 */
-		package: z.string(),
-	}),
+	typeMatcherSchema,
+	functionMatcherSchema,
+	packageMatcherSchema,
 ]);
 
 export const configArgumentsSchema = z.record(
@@ -75,7 +98,12 @@ export const configArgumentsSchema = z.record(
 		.refine((key) => !FORBIDDEN_CONFIG_KEYS.has(key), {
 			message: 'configArguments keys must not be prototype property names',
 		}),
-	configArgumentMatcherSchema,
+	z.union([
+		configArgumentMatcherSchema,
+		// One key may resolve multiple types/parameters; its config value must then be a
+		// resolver function.
+		z.array(z.union([typeMatcherSchema, functionMatcherSchema])),
+	]),
 );
 
 export type ConfigArgumentMatcher = z.infer<typeof configArgumentMatcherSchema>;

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -154,7 +154,10 @@ export function normalizeMoveArguments(
 				throw new __ERROR_CLASS__(\`Expected arguments to be passed as an array\`);
 			}
 			const name = parameterNames[index];
-			arg = args[name as keyof typeof args];
+			arg =
+				name !== undefined && Object.prototype.hasOwnProperty.call(args, name)
+					? args[name as keyof typeof args]
+					: undefined;
 
 			if (arg === undefined) {
 				throw new __ERROR_CLASS__(\`Parameter \${name} is required\`);
@@ -193,9 +196,18 @@ export function normalizeMoveArguments(
 export interface ConfigResolverContext {
 	/**
 	 * The matched parameter's own instantiated type arguments (not the whole function's type
-	 * argument tuple), as fully-qualified type tags.
+	 * argument tuple), as fully-qualified type tags. Hex-addressed struct tags are normalized to
+	 * their long form before the resolver is invoked; MVR-named tags are passed through unchanged.
 	 */
 	typeArguments: string[];
+	/** The package address the generated call will be sent to. */
+	packageAddress: string;
+	/** The Move module of the generated call. */
+	moduleName: string;
+	/** The Move function of the generated call. */
+	functionName: string;
+	/** The Move name of the matched parameter, when the summary includes parameter names. */
+	parameterName?: string;
 }
 
 /**
@@ -210,7 +222,19 @@ export type ConfigValue =
 	| Exclude<TransactionObjectArgument, (...args: never[]) => unknown>
 	| ((ctx: ConfigResolverContext) => string | TransactionObjectArgument);
 
-export function resolveConfigArg(
+/** Normalize a hex-addressed struct tag to its long form; pass anything else through. */
+function normalizeConfigTypeTag(tag: string): string {
+	if (/[@/]/.test(tag) || !tag.includes('::')) {
+		return tag;
+	}
+	try {
+		return normalizeStructTag(tag);
+	} catch {
+		return tag;
+	}
+}
+
+export function resolveConfigArgument(
 	value: ConfigValue | undefined,
 	ctx: ConfigResolverContext,
 	name: string,
@@ -221,7 +245,22 @@ export function resolveConfigArg(
 		);
 	}
 
-	return typeof value === 'function' ? value(ctx) : value;
+	if (typeof value !== 'function') {
+		return value;
+	}
+
+	const resolved = value({
+		...ctx,
+		typeArguments: ctx.typeArguments.map(normalizeConfigTypeTag),
+	});
+
+	if (resolved == null) {
+		throw new __ERROR_CLASS__(
+			\`Config resolver for "\${name}" returned \${resolved} (\${ctx.moduleName}::\${ctx.functionName}, typeArguments: [\${ctx.typeArguments.join(', ')}])\`,
+		);
+	}
+
+	return resolved;
 }
 
 /**
@@ -234,9 +273,17 @@ export function applyConfigArguments<T extends object | unknown[]>(
 ): T {
 	if (Array.isArray(args)) {
 		const result = [...args];
+		const matchedIndexes = new Set(defaults.map((entry) => entry.index));
 		for (const entry of defaults) {
 			if (result[entry.index] === undefined) {
 				result[entry.index] = entry.resolve();
+			}
+		}
+		// Filling a trailing config-mapped position can extend the array past positions the
+		// caller omitted; catch those holes here rather than failing deep inside serialization.
+		for (let i = 0; i < result.length; i++) {
+			if (result[i] === undefined && !matchedIndexes.has(i)) {
+				throw new __ERROR_CLASS__(\`Missing argument at position \${i}\`);
 			}
 		}
 		return result as T;
@@ -244,8 +291,18 @@ export function applyConfigArguments<T extends object | unknown[]>(
 
 	const result: Record<string, unknown> = { ...args };
 	for (const entry of defaults) {
-		if (entry.name !== undefined && result[entry.name] === undefined) {
-			result[entry.name] = entry.resolve();
+		if (entry.name === undefined) {
+			continue;
+		}
+		// Own-property check so inherited properties (e.g. a key named "constructor") are never
+		// mistaken for explicitly passed arguments.
+		if (!Object.prototype.hasOwnProperty.call(result, entry.name) || result[entry.name] === undefined) {
+			Object.defineProperty(result, entry.name, {
+				value: entry.resolve(),
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
 		}
 	}
 	return result as T;

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -208,6 +208,8 @@ export interface ConfigResolverContext {
 	functionName: string;
 	/** The Move name of the matched parameter, when the summary includes parameter names. */
 	parameterName?: string;
+	/** The matched parameter's position in the generated function's arguments. */
+	parameterIndex: number;
 }
 
 /**

--- a/packages/codegen/src/generate-utils.ts
+++ b/packages/codegen/src/generate-utils.ts
@@ -28,7 +28,11 @@ import {
 	BcsTuple,
 } from '@mysten/sui/bcs';
 import { normalizeStructTag, normalizeSuiAddress } from '@mysten/sui/utils';
-import { type TransactionArgument, isArgument } from '@mysten/sui/transactions';
+import {
+	type TransactionArgument,
+	type TransactionObjectArgument,
+	isArgument,
+} from '@mysten/sui/transactions';
 import { type ClientWithCoreApi, type SuiClientTypes } from '@mysten/sui/client';
 
 const MOVE_STDLIB_ADDRESS = normalizeSuiAddress('0x1');
@@ -126,6 +130,12 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
+		if (argType === '0x2::accumulator::AccumulatorRoot') {
+			// Chain-wide shared singleton at a fixed address (SUI_ACCUMULATOR_ROOT_OBJECT_ID).
+			normalizedArgs.push((tx) => tx.object('0xacc'));
+			continue;
+		}
+
 		if (argType === '0x3::sui_system::SuiSystemState') {
 			normalizedArgs.push((tx) => tx.object.system());
 			continue;
@@ -175,6 +185,70 @@ export function normalizeMoveArguments(
 	}
 
 	return normalizedArgs;
+}
+
+/* -------------------------- Config-mapped arguments -------------------------- */
+
+/** Context passed to config resolver functions. */
+export interface ConfigResolverContext {
+	/**
+	 * The matched parameter's own instantiated type arguments (not the whole function's type
+	 * argument tuple), as fully-qualified type tags.
+	 */
+	typeArguments: string[];
+}
+
+/**
+ * A value in a generated config object: a plain object id/argument, or a resolver function.
+ *
+ * Any function is treated as a resolver and called with a \`ConfigResolverContext\`. To provide a
+ * transaction-callback object argument dynamically, return it from a resolver:
+ * \`(ctx) => (tx) => ...\`.
+ */
+export type ConfigValue =
+	| string
+	| Exclude<TransactionObjectArgument, (...args: never[]) => unknown>
+	| ((ctx: ConfigResolverContext) => string | TransactionObjectArgument);
+
+export function resolveConfigArg(
+	value: ConfigValue | undefined,
+	ctx: ConfigResolverContext,
+	name: string,
+): string | TransactionObjectArgument {
+	if (value == null) {
+		throw new __ERROR_CLASS__(
+			\`Missing config value for "\${name}": pass it explicitly in arguments, or include it in the config object\`,
+		);
+	}
+
+	return typeof value === 'function' ? value(ctx) : value;
+}
+
+/**
+ * Fill unset config-mapped positions in an arguments array/object with their resolved config
+ * values. Resolvers are only invoked for positions the caller did not pass explicitly.
+ */
+export function applyConfigArguments<T extends object | unknown[]>(
+	args: T,
+	defaults: readonly { index: number; name?: string; resolve: () => unknown }[],
+): T {
+	if (Array.isArray(args)) {
+		const result = [...args];
+		for (const entry of defaults) {
+			if (result[entry.index] === undefined) {
+				result[entry.index] = entry.resolve();
+			}
+		}
+		return result as T;
+	}
+
+	const result: Record<string, unknown> = { ...args };
+	for (const entry of defaults) {
+		if (entry.name !== undefined && result[entry.name] === undefined) {
+			result[entry.name] = entry.resolve();
+		}
+	}
+	return result as T;
 }
 
 /* -------------------------- Move type tags -------------------------- */

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -401,9 +401,11 @@ async function generateConfigInterface({
 			return `${key}?: string`;
 		}
 
-		// A key resolving multiple bindings (or a generic) must be a resolver function.
-		const requiresResolver =
-			group.length > 1 || group.some((entry) => entry.kind !== 'package' && entry.requiresResolver);
+		// A key binding multiple distinct types (or a generic) must be a resolver function.
+		const boundTypes = new Set(
+			group.flatMap((entry) => (entry.kind !== 'package' ? [entry.boundType] : [])),
+		);
+		const requiresResolver = boundTypes.size > 1 || boundTypes.has(null);
 
 		if (requiresResolver) {
 			const ctxName = builder.addImport(utilsModule, 'type ConfigResolverContext');

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -190,7 +190,8 @@ export async function generateFromPackageSummary({
 			: { entries: [] };
 
 	const packageEntries = configArgumentEntries.filter(
-		(entry) => entry.kind === 'package' && entry.package === pkg.package,
+		(entry): entry is ParsedConfigArgument & { kind: 'package' } =>
+			entry.kind === 'package' && entry.package === pkg.package,
 	);
 	if (packageEntries.length > 1) {
 		throw new Error(
@@ -287,7 +288,7 @@ export async function generateFromPackageSummary({
 	const normalizedCurrentAddress = normalizePackageAddress(currentPackageAddress);
 	const unusedOwnEntries = configArgumentEntries.filter(
 		(entry) =>
-			entry.kind === 'type' &&
+			entry.kind !== 'package' &&
 			entry.address === normalizedCurrentAddress &&
 			!usedConfigKeys.has(entry.key),
 	);
@@ -305,7 +306,7 @@ export async function generateFromPackageSummary({
 			outputDir,
 			packageName,
 			entries: configArgumentEntries.filter(
-				(entry) => entry.kind === 'type' || entry.package === pkg.package,
+				(entry) => entry.kind !== 'package' || entry.package === pkg.package,
 			),
 			importExtension,
 		});
@@ -390,21 +391,30 @@ async function generateConfigInterface({
 		camelCase(packageName.replaceAll(/[^A-Za-z0-9_$]+/g, '_').replace(/^(\d)/, '_$1')),
 	)}Config`;
 
-	const fields = entries.map((entry) => {
-		if (entry.kind === 'package') {
-			return `${entry.key}?: string`;
+	const fieldEntries = new Map<string, ParsedConfigArgument[]>();
+	for (const entry of entries) {
+		fieldEntries.set(entry.key, [...(fieldEntries.get(entry.key) ?? []), entry]);
+	}
+
+	const fields = [...fieldEntries.entries()].map(([key, group]) => {
+		if (group[0].kind === 'package') {
+			return `${key}?: string`;
 		}
 
-		if (entry.isGeneric && entry.typeArguments === null) {
+		// A key resolving multiple bindings (or a generic) must be a resolver function.
+		const requiresResolver =
+			group.length > 1 || group.some((entry) => entry.kind !== 'package' && entry.requiresResolver);
+
+		if (requiresResolver) {
 			const ctxName = builder.addImport(utilsModule, 'type ConfigResolverContext');
 			const objArgName = builder.addImport(
 				'@mysten/sui/transactions',
 				'type TransactionObjectArgument',
 			);
-			return `${entry.key}: (ctx: ${ctxName}) => string | ${objArgName}`;
+			return `${key}: (ctx: ${ctxName}) => string | ${objArgName}`;
 		}
 
-		return `${entry.key}: ${builder.addImport(utilsModule, 'type ConfigValue')}`;
+		return `${key}: ${builder.addImport(utilsModule, 'type ConfigValue')}`;
 	});
 
 	builder.statements.push(

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -165,16 +165,17 @@ export async function generateFromPackageSummary({
 		)
 	).flat();
 
-	const effectiveConfigArguments: ConfigArguments = {
-		...globalConfigArguments,
-		...pkg.configArguments,
-	};
+	const { entries: configArgumentEntries, unresolvedKeys } =
+		Object.keys(globalConfigArguments ?? {}).length || Object.keys(pkg.configArguments ?? {}).length
+			? parseConfigArguments(
+					{ global: globalConfigArguments, package: pkg.configArguments },
+					registry,
+				)
+			: { entries: [], unresolvedKeys: [] };
 
-	const { entries: configArgumentEntries, unresolvedKeys } = Object.keys(effectiveConfigArguments)
-		.length
-		? parseConfigArguments(effectiveConfigArguments, registry)
-		: { entries: [], unresolvedKeys: [] };
-
+	// Unresolved keys here are always from the global block (package-scoped unresolved matchers
+	// throw during parsing). They may belong to another package generated in the same run — the
+	// CLI aggregates these across packages and errors for keys that resolve nowhere.
 	if (unresolvedKeys.length > 0) {
 		console.warn(
 			`configArguments keys not resolvable in ${pkg.package} (skipped): ${unresolvedKeys.join(', ')}`,
@@ -266,21 +267,55 @@ export async function generateFromPackageSummary({
 		}),
 	);
 
+	const usedConfigKeys = new Set<string>();
+	for (const mod of modules) {
+		for (const key of mod.builder.usedConfigKeys) {
+			usedConfigKeys.add(key);
+		}
+	}
+
+	const unusedTypeEntries = configArgumentEntries.filter(
+		(entry) => entry.kind === 'type' && !usedConfigKeys.has(entry.key),
+	);
+	// Package-scoped entries can only target this package, so an unused one is a misconfiguration
+	// (wrong parameterName, wrong instantiation, or a function filtered out of generation).
+	const unusedPackageScoped = unusedTypeEntries.filter((entry) => entry.source === 'package');
+	if (unusedPackageScoped.length > 0) {
+		console.warn(
+			`configArguments keys that matched no generated function parameters in ${pkg.package}: ${unusedPackageScoped
+				.map((entry) => entry.key)
+				.join(', ')}`,
+		);
+	}
+
 	if (configArgumentEntries.length > 0) {
 		await generateConfigInterface({
 			packageOutputDir,
 			outputDir,
 			packageName,
-			entries: configArgumentEntries,
+			entries: configArgumentEntries.filter(
+				(entry) => entry.kind === 'type' || entry.package === pkg.package,
+			),
 			importExtension,
 		});
 	}
+
+	return {
+		/** Global-block keys whose matcher type was not found in this package's summaries. */
+		unresolvedConfigKeys: unresolvedKeys,
+		/** Global-block type keys that resolved here but matched no generated parameter. */
+		unusedConfigKeys: unusedTypeEntries
+			.filter((entry) => entry.source === 'global')
+			.map((entry) => entry.key),
+	};
 }
 
 /**
- * Emit `<output>/<packageName>/config-args.ts` with a convenience interface covering every
- * declared config key, for `satisfies` on the user side. The hyphenated filename can never
- * collide with a generated Move module file.
+ * Emit `<output>/<packageName>/config-arguments.ts` with a convenience interface covering this
+ * package's resolvable config keys (and its own package-address key), for `satisfies` on the user
+ * side. With a global block spanning multiple packages, intersect the per-package interfaces
+ * (`CoreConfig & MarginConfig`). The hyphenated filename can never collide with a generated Move
+ * module file.
  */
 async function generateConfigInterface({
 	packageOutputDir,
@@ -327,8 +362,8 @@ async function generateConfigInterface({
 
 	await mkdir(packageOutputDir, { recursive: true });
 	await writeFile(
-		join(packageOutputDir, 'config-args.ts'),
-		await builder.toString(packageOutputDir, 'config-args.ts', outputDir),
+		join(packageOutputDir, 'config-arguments.ts'),
+		await builder.toString(packageOutputDir, 'config-arguments.ts', outputDir),
 	);
 }
 

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -6,6 +6,7 @@ import { basename, join } from 'node:path';
 import { ModuleRegistry } from './module-registry.js';
 import { MoveModuleBuilder } from './move-module-builder.js';
 import { existsSync, statSync } from 'node:fs';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
 import { getUtilsContent } from './generate-utils.js';
 import { parse } from 'toml';
 import { FileBuilder } from './file-builder.js';
@@ -38,6 +39,7 @@ export async function generateFromPackageSummary({
 	includePhantomTypeParameters = false,
 	errorClass,
 	configArguments: globalConfigArguments,
+	packageAddresses,
 }: {
 	package: PackageConfig;
 	prune: boolean;
@@ -47,6 +49,12 @@ export async function generateFromPackageSummary({
 	includePhantomTypeParameters?: boolean;
 	errorClass?: ErrorClassConfig;
 	configArguments?: ConfigArguments;
+	/**
+	 * Resolved root addresses of the other packages in the codegen run, keyed by their `packages`
+	 * identifier, so `configArguments` matchers can reference them (see
+	 * `resolvePackageRootAddress`). The CLI builds this automatically.
+	 */
+	packageAddresses?: Record<string, string>;
 }) {
 	if (!pkg.path) {
 		throw new Error(`Package path is required (got ${pkg.package})`);
@@ -165,22 +173,21 @@ export async function generateFromPackageSummary({
 		)
 	).flat();
 
-	const { entries: configArgumentEntries, unresolvedKeys } =
+	const currentPackageAddress = isOnChainPackage
+		? rootPackageId!
+		: (addressMappings[mainPackageDir] ?? mainPackageDir);
+
+	const { entries: configArgumentEntries } =
 		Object.keys(globalConfigArguments ?? {}).length || Object.keys(pkg.configArguments ?? {}).length
 			? parseConfigArguments(
 					{ global: globalConfigArguments, package: pkg.configArguments },
 					registry,
+					{
+						package: { id: pkg.package, address: currentPackageAddress },
+						packageAddresses,
+					},
 				)
-			: { entries: [], unresolvedKeys: [] };
-
-	// Unresolved keys here are always from the global block (package-scoped unresolved matchers
-	// throw during parsing). They may belong to another package generated in the same run — the
-	// CLI aggregates these across packages and errors for keys that resolve nowhere.
-	if (unresolvedKeys.length > 0) {
-		console.warn(
-			`configArguments keys not resolvable in ${pkg.package} (skipped): ${unresolvedKeys.join(', ')}`,
-		);
-	}
+			: { entries: [] };
 
 	const packageEntries = configArgumentEntries.filter(
 		(entry) => entry.kind === 'package' && entry.package === pkg.package,
@@ -274,15 +281,19 @@ export async function generateFromPackageSummary({
 		}
 	}
 
-	const unusedTypeEntries = configArgumentEntries.filter(
-		(entry) => entry.kind === 'type' && !usedConfigKeys.has(entry.key),
+	// Every matcher is checked in the run of the package it targets: an unused entry targeting
+	// this package is a misconfiguration (wrong parameterName, wrong instantiation, or a function
+	// filtered out of generation). Entries targeting other packages are checked in their own runs.
+	const normalizedCurrentAddress = normalizePackageAddress(currentPackageAddress);
+	const unusedOwnEntries = configArgumentEntries.filter(
+		(entry) =>
+			entry.kind === 'type' &&
+			entry.address === normalizedCurrentAddress &&
+			!usedConfigKeys.has(entry.key),
 	);
-	// Package-scoped entries can only target this package, so an unused one is a misconfiguration
-	// (wrong parameterName, wrong instantiation, or a function filtered out of generation).
-	const unusedPackageScoped = unusedTypeEntries.filter((entry) => entry.source === 'package');
-	if (unusedPackageScoped.length > 0) {
+	if (unusedOwnEntries.length > 0) {
 		console.warn(
-			`configArguments keys that matched no generated function parameters in ${pkg.package}: ${unusedPackageScoped
+			`configArguments keys that matched no generated function parameters in ${pkg.package}: ${unusedOwnEntries
 				.map((entry) => entry.key)
 				.join(', ')}`,
 		);
@@ -299,15 +310,57 @@ export async function generateFromPackageSummary({
 			importExtension,
 		});
 	}
+}
 
-	return {
-		/** Global-block keys whose matcher type was not found in this package's summaries. */
-		unresolvedConfigKeys: unresolvedKeys,
-		/** Global-block type keys that resolved here but matched no generated parameter. */
-		unusedConfigKeys: unusedTypeEntries
-			.filter((entry) => entry.source === 'global')
-			.map((entry) => entry.key),
-	};
+const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
+
+function normalizePackageAddress(address: string) {
+	return HEX_ADDRESS.test(address) ? normalizeSuiAddress(address) : address;
+}
+
+/**
+ * Resolve a package's root address from its summaries directory, for the `packageAddresses` map
+ * passed to `generateFromPackageSummary`. Requires summaries to already exist at `pkgPath`.
+ */
+export async function resolvePackageRootAddress(pkgPath: string): Promise<string | undefined> {
+	const metadataPath = join(pkgPath, 'root_package_metadata.json');
+	if (existsSync(metadataPath)) {
+		const metadata: RootPackageMetadata = JSON.parse(await readFile(metadataPath, 'utf-8'));
+		return metadata.root_package_original_id ?? metadata.root_package_id;
+	}
+
+	const summaryDir = join(pkgPath, 'package_summaries');
+	if (!existsSync(join(summaryDir, 'address_mapping.json'))) {
+		return undefined;
+	}
+	const addressMappings: Record<string, string> = JSON.parse(
+		await readFile(join(summaryDir, 'address_mapping.json'), 'utf-8'),
+	);
+
+	let localAddressLabels: string[] = [];
+	let packageName = '';
+	try {
+		const parsedToml: { package?: { name?: unknown }; addresses?: Record<string, string> } = parse(
+			await readFile(join(pkgPath, 'Move.toml'), 'utf-8'),
+		);
+		localAddressLabels = Object.keys(parsedToml.addresses ?? {});
+		if (typeof parsedToml.package?.name === 'string') {
+			packageName = parsedToml.package.name.toLowerCase();
+		}
+	} catch {
+		// fall through to summary-directory-based resolution
+	}
+
+	const packages = (await readdir(summaryDir)).filter((file) =>
+		statSync(join(summaryDir, file)).isDirectory(),
+	);
+
+	try {
+		const mainDir = resolveLocalMainPackageDir(localAddressLabels, packages, packageName, pkgPath);
+		return addressMappings[mainDir] ?? mainDir;
+	} catch {
+		return undefined;
+	}
 }
 
 /**

--- a/packages/codegen/src/index.ts
+++ b/packages/codegen/src/index.ts
@@ -8,8 +8,13 @@ import { MoveModuleBuilder } from './move-module-builder.js';
 import { existsSync, statSync } from 'node:fs';
 import { getUtilsContent } from './generate-utils.js';
 import { parse } from 'toml';
+import { FileBuilder } from './file-builder.js';
+import { parseConfigArguments } from './config-arguments.js';
+import type { ParsedConfigArgument } from './config-arguments.js';
+import { camelCase, capitalize, parseTS } from './utils.js';
 import type { RootPackageMetadata } from './types/summary.js';
 import type {
+	ConfigArguments,
 	ErrorClassConfig,
 	FunctionsOption,
 	GenerateBase,
@@ -18,7 +23,11 @@ import type {
 	PackageGenerate,
 	TypesOption,
 } from './config.js';
-export { type SuiCodegenConfig } from './config.js';
+export {
+	type SuiCodegenConfig,
+	type ConfigArguments,
+	type ConfigArgumentMatcher,
+} from './config.js';
 
 export async function generateFromPackageSummary({
 	package: pkg,
@@ -28,6 +37,7 @@ export async function generateFromPackageSummary({
 	importExtension = '.js',
 	includePhantomTypeParameters = false,
 	errorClass,
+	configArguments: globalConfigArguments,
 }: {
 	package: PackageConfig;
 	prune: boolean;
@@ -36,6 +46,7 @@ export async function generateFromPackageSummary({
 	importExtension?: ImportExtension;
 	includePhantomTypeParameters?: boolean;
 	errorClass?: ErrorClassConfig;
+	configArguments?: ConfigArguments;
 }) {
 	if (!pkg.path) {
 		throw new Error(`Package path is required (got ${pkg.package})`);
@@ -154,6 +165,41 @@ export async function generateFromPackageSummary({
 		)
 	).flat();
 
+	const effectiveConfigArguments: ConfigArguments = {
+		...globalConfigArguments,
+		...pkg.configArguments,
+	};
+
+	const { entries: configArgumentEntries, unresolvedKeys } = Object.keys(effectiveConfigArguments)
+		.length
+		? parseConfigArguments(effectiveConfigArguments, registry)
+		: { entries: [], unresolvedKeys: [] };
+
+	if (unresolvedKeys.length > 0) {
+		console.warn(
+			`configArguments keys not resolvable in ${pkg.package} (skipped): ${unresolvedKeys.join(', ')}`,
+		);
+	}
+
+	const packageEntries = configArgumentEntries.filter(
+		(entry) => entry.kind === 'package' && entry.package === pkg.package,
+	);
+	if (packageEntries.length > 1) {
+		throw new Error(
+			`Multiple configArguments package entries match ${pkg.package}: ${packageEntries
+				.map((entry) => entry.key)
+				.join(', ')}`,
+		);
+	}
+	const packageConfigKey = packageEntries[0]?.key;
+
+	for (const mod of modules) {
+		mod.builder.setConfigArguments(
+			configArgumentEntries,
+			mod.isMainPackage ? packageConfigKey : undefined,
+		);
+	}
+
 	const packageGenerate: PackageGenerate | undefined = 'generate' in pkg ? pkg.generate : undefined;
 	const pkgModules = packageGenerate?.modules;
 	const pkgTypes: TypesOption = packageGenerate?.types ?? globalGenerate?.types ?? true;
@@ -218,6 +264,71 @@ export async function generateFromPackageSummary({
 				await mod.builder.toString(packageDir, fileRelToPackage, outputDir),
 			);
 		}),
+	);
+
+	if (configArgumentEntries.length > 0) {
+		await generateConfigInterface({
+			packageOutputDir,
+			outputDir,
+			packageName,
+			entries: configArgumentEntries,
+			importExtension,
+		});
+	}
+}
+
+/**
+ * Emit `<output>/<packageName>/config-args.ts` with a convenience interface covering every
+ * declared config key, for `satisfies` on the user side. The hyphenated filename can never
+ * collide with a generated Move module file.
+ */
+async function generateConfigInterface({
+	packageOutputDir,
+	outputDir,
+	packageName,
+	entries,
+	importExtension,
+}: {
+	packageOutputDir: string;
+	outputDir: string;
+	packageName: string;
+	entries: ParsedConfigArgument[];
+	importExtension: ImportExtension;
+}) {
+	const builder = new FileBuilder();
+	const utilsModule = `~outputRoot/utils/index${importExtension}`;
+
+	const interfaceName = `${capitalize(
+		camelCase(packageName.replaceAll(/[^A-Za-z0-9_$]+/g, '_').replace(/^(\d)/, '_$1')),
+	)}Config`;
+
+	const fields = entries.map((entry) => {
+		if (entry.kind === 'package') {
+			return `${entry.key}?: string`;
+		}
+
+		if (entry.isGeneric && entry.typeArguments === null) {
+			const ctxName = builder.addImport(utilsModule, 'type ConfigResolverContext');
+			const objArgName = builder.addImport(
+				'@mysten/sui/transactions',
+				'type TransactionObjectArgument',
+			);
+			return `${entry.key}: (ctx: ${ctxName}) => string | ${objArgName}`;
+		}
+
+		return `${entry.key}: ${builder.addImport(utilsModule, 'type ConfigValue')}`;
+	});
+
+	builder.statements.push(
+		...parseTS /* ts */ `export interface ${interfaceName} {
+			${fields.join(';\n')}
+		}`,
+	);
+
+	await mkdir(packageOutputDir, { recursive: true });
+	await writeFile(
+		join(packageOutputDir, 'config-args.ts'),
+		await builder.toString(packageOutputDir, 'config-args.ts', outputDir),
 	);
 }
 

--- a/packages/codegen/src/module-registry.ts
+++ b/packages/codegen/src/module-registry.ts
@@ -1,8 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { normalizeSuiAddress } from '@mysten/sui/utils';
 import type { MoveModuleBuilder } from './move-module-builder.js';
 import type { Ability, ModuleSummary } from './types/summary.js';
+
+const HEX_ADDRESS = /^0x[0-9a-fA-F]{1,64}$/;
+
+function normalizeAddress(address: string) {
+	return HEX_ADDRESS.test(address) ? normalizeSuiAddress(address) : address;
+}
 
 export class ModuleRegistry {
 	readonly addressMappings: Record<string, string>;
@@ -29,6 +36,27 @@ export class ModuleRegistry {
 
 	getSummary(address: string, module: string): ModuleSummary | undefined {
 		return this.getBuilder(address, module)?.summary;
+	}
+
+	/**
+	 * Look up a module by its resolved (canonical) address. Builders are keyed by the address
+	 * used in their summaries, which may be a named address — this scans by resolving each
+	 * builder's address instead.
+	 */
+	getSummaryByResolvedAddress(resolvedAddress: string, module: string): ModuleSummary | undefined {
+		const direct = this.getSummary(resolvedAddress, module);
+		if (direct) return direct;
+
+		for (const builder of this.#builders.values()) {
+			if (
+				builder.summary.id.name === module &&
+				normalizeAddress(this.resolveAddress(builder.summary.id.address)) ===
+					normalizeAddress(resolvedAddress)
+			) {
+				return builder.summary;
+			}
+		}
+		return undefined;
 	}
 
 	getAbilities(address: string, module: string, name: string): Ability[] | undefined {

--- a/packages/codegen/src/module-registry.ts
+++ b/packages/codegen/src/module-registry.ts
@@ -64,6 +64,17 @@ export class ModuleRegistry {
 		return summary?.structs[name]?.abilities ?? summary?.enums[name]?.abilities;
 	}
 
+	/** Whether any loaded module belongs to a package with this resolved address. */
+	hasResolvedAddress(resolvedAddress: string): boolean {
+		const normalized = normalizeAddress(resolvedAddress);
+		for (const builder of this.#builders.values()) {
+			if (normalizeAddress(this.resolveAddress(builder.summary.id.address)) === normalized) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	#keyOf(address: string, module: string): string {
 		return `${address}::${module}`;
 	}

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -612,11 +612,7 @@ export class MoveModuleBuilder extends FileBuilder {
 			// Parameters (by index into `requiredParameters`) resolved from the runtime config
 			// object instead of being required arguments.
 			const configMatches = new Map<number, TypeConfigArgument | FunctionConfigArgument>();
-			// Keys that match more than one parameter of this signature: legal, but the config
-			// value must be a resolver (it receives per-parameter context).
-			const multiMatchedKeys = new Set<string>();
 			if (this.#configArguments.length > 0) {
-				const matchesByKey = new Map<string, number>();
 				requiredParameters.forEach((param, i) => {
 					const match = findConfigArgumentMatch(param, this.#configArguments, {
 						resolveAddress: (address) => this.#resolveAddress(address),
@@ -630,13 +626,7 @@ export class MoveModuleBuilder extends FileBuilder {
 					});
 					if (!match) return;
 					configMatches.set(i, match);
-					matchesByKey.set(match.key, (matchesByKey.get(match.key) ?? 0) + 1);
 				});
-				for (const [key, count] of matchesByKey) {
-					if (count > 1) {
-						multiMatchedKeys.add(key);
-					}
-				}
 				for (const match of configMatches.values()) {
 					this.usedConfigKeys.add(match.key);
 				}
@@ -749,16 +739,14 @@ export class MoveModuleBuilder extends FileBuilder {
 			for (const match of configMatches.values()) {
 				if (seenConfigKeys.has(match.key)) continue;
 				seenConfigKeys.add(match.key);
-				// A key must be a resolver function when it can resolve more than one binding:
-				// an uninstantiated generic, multiple declared matchers, or multiple parameters
-				// matched in this signature.
-				const keyEntries = this.#configArguments.filter(
-					(entry) => entry.kind !== 'package' && entry.key === match.key,
+				// A key must be a resolver function when it can bind more than one distinct type
+				// (or a generic). Multiple matchers sharing one concrete type share a plain value.
+				const boundTypes = new Set(
+					this.#configArguments.flatMap((entry) =>
+						entry.kind !== 'package' && entry.key === match.key ? [entry.boundType] : [],
+					),
 				);
-				const requiresResolver =
-					keyEntries.length > 1 ||
-					keyEntries.some((entry) => entry.kind !== 'package' && entry.requiresResolver) ||
-					multiMatchedKeys.has(match.key);
+				const requiresResolver = boundTypes.size > 1 || boundTypes.has(null);
 				configSliceFields.push(
 					requiresResolver
 						? `${match.key}: (ctx: ${this.#getImportName('ConfigResolverContext')}) => string | ${this.#getImportName('TransactionObjectArgument')}`

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -13,7 +13,11 @@ import {
 	SUI_SYSTEM_ADDRESS,
 } from './render-types.js';
 import { findConfigArgumentMatch } from './config-arguments.js';
-import type { ParsedConfigArgument, TypeConfigArgument } from './config-arguments.js';
+import type {
+	FunctionConfigArgument,
+	ParsedConfigArgument,
+	TypeConfigArgument,
+} from './config-arguments.js';
 import {
 	camelCase,
 	capitalize,
@@ -607,39 +611,30 @@ export class MoveModuleBuilder extends FileBuilder {
 			const functionLabel = `${this.summary.id.address}::${this.summary.id.name}::${name}`;
 			// Parameters (by index into `requiredParameters`) resolved from the runtime config
 			// object instead of being required arguments.
-			const configMatches = new Map<number, TypeConfigArgument>();
+			const configMatches = new Map<number, TypeConfigArgument | FunctionConfigArgument>();
+			// Keys that match more than one parameter of this signature: legal, but the config
+			// value must be a resolver (it receives per-parameter context).
+			const multiMatchedKeys = new Set<string>();
 			if (this.#configArguments.length > 0) {
-				const bareMatches = new Map<string, number[]>();
+				const matchesByKey = new Map<string, number>();
 				requiredParameters.forEach((param, i) => {
 					const match = findConfigArgumentMatch(param, this.#configArguments, {
 						resolveAddress: (address) => this.#resolveAddress(address),
 						functionLabel,
+						functionRef: {
+							moduleAddress: this.summary.id.address,
+							moduleName: this.summary.id.name,
+							functionName: name,
+						},
+						parameterIndex: i,
 					});
 					if (!match) return;
 					configMatches.set(i, match);
-					if (!match.parameterName) {
-						bareMatches.set(match.key, [...(bareMatches.get(match.key) ?? []), i]);
-					}
+					matchesByKey.set(match.key, (matchesByKey.get(match.key) ?? 0) + 1);
 				});
-				for (const [key, matched] of bareMatches) {
-					if (matched.length > 1) {
-						if (matched.every((i) => requiredParameters[i].name)) {
-							throw new Error(
-								`configArguments.${key} matches multiple parameters of ${functionLabel} (${matched
-									.map((i) => requiredParameters[i].name)
-									.join(', ')}). Add a \`parameterName\` refinement to disambiguate.`,
-							);
-						}
-						// Bytecode summaries have no parameter names, so refinement is impossible —
-						// skip config mapping for this function instead of failing the run.
-						console.warn(
-							`configArguments.${key} matches multiple parameters of ${functionLabel}, which cannot ` +
-								`be disambiguated because its parameters have no names. Config mapping is skipped ` +
-								`for this function.`,
-						);
-						for (const i of matched) {
-							configMatches.delete(i);
-						}
+				for (const [key, count] of matchesByKey) {
+					if (count > 1) {
+						multiMatchedKeys.add(key);
 					}
 				}
 				for (const match of configMatches.values()) {
@@ -754,10 +749,18 @@ export class MoveModuleBuilder extends FileBuilder {
 			for (const match of configMatches.values()) {
 				if (seenConfigKeys.has(match.key)) continue;
 				seenConfigKeys.add(match.key);
-				// An uninstantiated matcher on a generic type requires a resolver function — a
-				// static id cannot be correct across instantiations.
+				// A key must be a resolver function when it can resolve more than one binding:
+				// an uninstantiated generic, multiple declared matchers, or multiple parameters
+				// matched in this signature.
+				const keyEntries = this.#configArguments.filter(
+					(entry) => entry.kind !== 'package' && entry.key === match.key,
+				);
+				const requiresResolver =
+					keyEntries.length > 1 ||
+					keyEntries.some((entry) => entry.kind !== 'package' && entry.requiresResolver) ||
+					multiMatchedKeys.has(match.key);
 				configSliceFields.push(
-					match.isGeneric && match.typeArguments === null
+					requiresResolver
 						? `${match.key}: (ctx: ${this.#getImportName('ConfigResolverContext')}) => string | ${this.#getImportName('TransactionObjectArgument')}`
 						: `${match.key}: ${this.#getImportName('ConfigValue')}`,
 				);
@@ -812,7 +815,7 @@ export class MoveModuleBuilder extends FileBuilder {
 					});
 					return tag.includes('${') ? `\`${tag}\`` : `'${tag}'`;
 				});
-				const ctx = `{ typeArguments: [${ctxTags.join(', ')}], packageAddress, moduleName: '${this.summary.id.name}', functionName: '${name}'${
+				const ctx = `{ typeArguments: [${ctxTags.join(', ')}], packageAddress, moduleName: '${this.summary.id.name}', functionName: '${name}', parameterIndex: ${i}${
 					param.name ? `, parameterName: ${JSON.stringify(param.name)}` : ''
 				} }`;
 				return `{ index: ${i}, ${param.name ? `name: ${JSON.stringify(camelCase(param.name))}, ` : ''}resolve: () => ${this.#getImportName('resolveConfigArgument')}(options.config?.${match.key}, ${ctx}, ${JSON.stringify(match.key)}) }`;

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -23,7 +23,7 @@ import {
 	parseTS,
 	withComment,
 } from './utils.js';
-import type { Fields, ModuleSummary, Type, TypeParameter } from './types/summary.js';
+import type { Datatype, Fields, ModuleSummary, Type, TypeParameter } from './types/summary.js';
 import type { FunctionsOption, ImportExtension, TypesOption } from './config.js';
 import { join } from 'node:path';
 import { isValidSuiObjectId } from '@mysten/sui/utils';
@@ -38,7 +38,7 @@ const IMPORT_MAP = {
 	MoveEnum: { module: '~outputRoot/utils/index', isType: false },
 	normalizeMoveArguments: { module: '~outputRoot/utils/index', isType: false },
 	RawTransactionArgument: { module: '~outputRoot/utils/index', isType: true },
-	resolveConfigArg: { module: '~outputRoot/utils/index', isType: false },
+	resolveConfigArgument: { module: '~outputRoot/utils/index', isType: false },
 	applyConfigArguments: { module: '~outputRoot/utils/index', isType: false },
 	ConfigValue: { module: '~outputRoot/utils/index', isType: true },
 	ConfigResolverContext: { module: '~outputRoot/utils/index', isType: true },
@@ -62,6 +62,8 @@ export class MoveModuleBuilder extends FileBuilder {
 	#includePhantomTypeParameters: boolean;
 	#configArguments: ParsedConfigArgument[] = [];
 	#packageConfigKey?: string;
+	/** Config keys that matched at least one parameter of a rendered function. */
+	readonly usedConfigKeys = new Set<string>();
 
 	constructor({
 		mvrNameOrAddress,
@@ -162,6 +164,34 @@ export class MoveModuleBuilder extends FileBuilder {
 	setConfigArguments(entries: ParsedConfigArgument[], packageConfigKey?: string) {
 		this.#configArguments = entries;
 		this.#packageConfigKey = packageConfigKey;
+	}
+
+	/**
+	 * The address this module's generated type tags use for `name`: the type-origin address when
+	 * known, otherwise the same address BCS type names use (MVR name / root package id / resolved
+	 * summary address).
+	 */
+	getTypeTagAddress(name: string): string {
+		const origin = this.#typeOrigins?.[name];
+		if (origin) {
+			return origin;
+		}
+		const moduleTypeName = this.#getModuleTypeName();
+		return moduleTypeName.startsWith('0x') || /[@/]/.test(moduleTypeName)
+			? moduleTypeName
+			: this.#resolveAddress(moduleTypeName);
+	}
+
+	/**
+	 * Address for a datatype appearing in a resolver-context type tag: delegate to the defining
+	 * module's builder so origins and MVR names match generated BCS type names.
+	 */
+	#getResolverTagAddress(datatype: Datatype): string {
+		const builder = this.registry.getBuilder(datatype.module.address, datatype.module.name);
+		if (builder) {
+			return builder.getTypeTagAddress(datatype.name);
+		}
+		return this.#resolveAddress(datatype.module.address);
 	}
 
 	override async getHeader() {
@@ -579,7 +609,7 @@ export class MoveModuleBuilder extends FileBuilder {
 			// object instead of being required arguments.
 			const configMatches = new Map<number, TypeConfigArgument>();
 			if (this.#configArguments.length > 0) {
-				const bareMatches = new Map<string, string[]>();
+				const bareMatches = new Map<string, number[]>();
 				requiredParameters.forEach((param, i) => {
 					const match = findConfigArgumentMatch(param, this.#configArguments, {
 						resolveAddress: (address) => this.#resolveAddress(address),
@@ -587,20 +617,33 @@ export class MoveModuleBuilder extends FileBuilder {
 					});
 					if (!match) return;
 					configMatches.set(i, match);
-					if (!match.paramName) {
-						bareMatches.set(match.key, [
-							...(bareMatches.get(match.key) ?? []),
-							param.name ?? `#${i}`,
-						]);
+					if (!match.parameterName) {
+						bareMatches.set(match.key, [...(bareMatches.get(match.key) ?? []), i]);
 					}
 				});
 				for (const [key, matched] of bareMatches) {
 					if (matched.length > 1) {
-						throw new Error(
-							`configArguments.${key} matches multiple parameters of ${functionLabel} (${matched.join(', ')}). ` +
-								`Add a \`name\` refinement to disambiguate.`,
+						if (matched.every((i) => requiredParameters[i].name)) {
+							throw new Error(
+								`configArguments.${key} matches multiple parameters of ${functionLabel} (${matched
+									.map((i) => requiredParameters[i].name)
+									.join(', ')}). Add a \`parameterName\` refinement to disambiguate.`,
+							);
+						}
+						// Bytecode summaries have no parameter names, so refinement is impossible —
+						// skip config mapping for this function instead of failing the run.
+						console.warn(
+							`configArguments.${key} matches multiple parameters of ${functionLabel}, which cannot ` +
+								`be disambiguated because its parameters have no names. Config mapping is skipped ` +
+								`for this function.`,
 						);
+						for (const i of matched) {
+							configMatches.delete(i);
+						}
 					}
+				}
+				for (const match of configMatches.values()) {
+					this.usedConfigKeys.add(match.key);
 				}
 			}
 			const hasConfigMatches = configMatches.size > 0;
@@ -648,14 +691,21 @@ export class MoveModuleBuilder extends FileBuilder {
 				)
 				.join(',\n');
 
-			// Tuple items: optional tuple elements can't precede required ones, so config-matched
-			// positions accept an explicit `undefined` instead.
+			// Tuple items: a config-matched suffix becomes genuinely optional tuple elements.
+			// Optional elements can't precede required ones, so matched positions followed by a
+			// required one accept an explicit `undefined` instead.
+			const lastUnmatchedIndex = renderedArgTypes.reduce(
+				(last, _, i) => (configMatches.has(i) ? last : i),
+				-1,
+			);
 			const argumentTupleItems = renderedArgTypes
 				.map((type, i) => {
+					const paramName = requiredParameters[i].name;
+					if (configMatches.has(i) && i > lastUnmatchedIndex) {
+						return paramName ? `${camelCase(paramName)}?: ${wrap(type)}` : `${wrap(type)}?`;
+					}
 					const itemType = configMatches.has(i) ? `${wrap(type)} | undefined` : wrap(type);
-					return requiredParameters[i].name
-						? `${camelCase(requiredParameters[i].name)}: ${itemType}`
-						: itemType;
+					return paramName ? `${camelCase(paramName)}: ${itemType}` : itemType;
 				})
 				.join(',\n');
 
@@ -716,8 +766,7 @@ export class MoveModuleBuilder extends FileBuilder {
 				configSliceFields.push(`${packageConfigKey}?: string`);
 			}
 
-			const argumentsOptional =
-				requiredParameters.length === 0 || requiredParameters.every((_, i) => configMatches.has(i));
+			const argumentsOptional = requiredParameters.every((_, i) => configMatches.has(i));
 
 			this.statements.push(
 				...parseTS /* ts */ `export interface ${optionsInterface}${genericTypes} {
@@ -729,7 +778,7 @@ export class MoveModuleBuilder extends FileBuilder {
 					},
 					${
 						configSliceFields.length > 0
-							? `config${hasConfigMatches ? '' : '?'}: {
+							? `config?: {
 								${configSliceFields.join(',\n')}
 							},`
 							: ''
@@ -759,10 +808,14 @@ export class MoveModuleBuilder extends FileBuilder {
 						summary: this.summary,
 						typeParameters: func.type_parameters,
 						registry: this.registry,
+						getDatatypeTagAddress: (datatype) => this.#getResolverTagAddress(datatype),
 					});
 					return tag.includes('${') ? `\`${tag}\`` : `'${tag}'`;
 				});
-				return `{ index: ${i}, ${param.name ? `name: ${JSON.stringify(camelCase(param.name))}, ` : ''}resolve: () => ${this.#getImportName('resolveConfigArg')}(options.config.${match.key}, { typeArguments: [${ctxTags.join(', ')}] }, ${JSON.stringify(match.key)}) }`;
+				const ctx = `{ typeArguments: [${ctxTags.join(', ')}], packageAddress, moduleName: '${this.summary.id.name}', functionName: '${name}'${
+					param.name ? `, parameterName: ${JSON.stringify(param.name)}` : ''
+				} }`;
+				return `{ index: ${i}, ${param.name ? `name: ${JSON.stringify(camelCase(param.name))}, ` : ''}resolve: () => ${this.#getImportName('resolveConfigArgument')}(options.config?.${match.key}, ${ctx}, ${JSON.stringify(match.key)}) }`;
 			});
 
 			const baseArgumentsExpr = `options.arguments${
@@ -779,9 +832,7 @@ export class MoveModuleBuilder extends FileBuilder {
 				: baseArgumentsExpr;
 
 			const packageAddressExpr = `options.package${
-				packageConfigKey
-					? ` ?? options.config${hasConfigMatches ? '' : '?'}.${packageConfigKey}`
-					: ''
+				packageConfigKey ? ` ?? options.config?.${packageConfigKey}` : ''
 			}${packageIsRequired ? '' : ` ?? '${this.#mvrNameOrAddress}'`}`;
 
 			this.statements.push(

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -7,10 +7,13 @@ import { ModuleRegistry } from './module-registry.js';
 import {
 	getSafeName,
 	isSupportedRawTransactionInput,
+	renderResolverTypeTag,
 	renderTypeSignature,
 	SUI_FRAMEWORK_ADDRESS,
 	SUI_SYSTEM_ADDRESS,
 } from './render-types.js';
+import { findConfigArgumentMatch } from './config-arguments.js';
+import type { ParsedConfigArgument, TypeConfigArgument } from './config-arguments.js';
 import {
 	camelCase,
 	capitalize,
@@ -35,6 +38,11 @@ const IMPORT_MAP = {
 	MoveEnum: { module: '~outputRoot/utils/index', isType: false },
 	normalizeMoveArguments: { module: '~outputRoot/utils/index', isType: false },
 	RawTransactionArgument: { module: '~outputRoot/utils/index', isType: true },
+	resolveConfigArg: { module: '~outputRoot/utils/index', isType: false },
+	applyConfigArguments: { module: '~outputRoot/utils/index', isType: false },
+	ConfigValue: { module: '~outputRoot/utils/index', isType: true },
+	ConfigResolverContext: { module: '~outputRoot/utils/index', isType: true },
+	TransactionObjectArgument: { module: '@mysten/sui/transactions', isType: true },
 } as const;
 
 type ImportName = keyof typeof IMPORT_MAP;
@@ -52,6 +60,8 @@ export class MoveModuleBuilder extends FileBuilder {
 	#importNames: Partial<Record<ImportName, string>> = {};
 	#importExtension: ImportExtension;
 	#includePhantomTypeParameters: boolean;
+	#configArguments: ParsedConfigArgument[] = [];
+	#packageConfigKey?: string;
 
 	constructor({
 		mvrNameOrAddress,
@@ -142,6 +152,16 @@ export class MoveModuleBuilder extends FileBuilder {
 			this.#importNames[name] = this.addImport(module, importSpec);
 		}
 		return this.#importNames[name]!;
+	}
+
+	/**
+	 * Configure parsed `configArguments` entries for this module's generated functions. Must be
+	 * called before `renderFunctions`. `packageConfigKey` is the config key (if any) that supplies
+	 * this package's call address.
+	 */
+	setConfigArguments(entries: ParsedConfigArgument[], packageConfigKey?: string) {
+		this.#configArguments = entries;
+		this.#packageConfigKey = packageConfigKey;
 	}
 
 	override async getHeader() {
@@ -554,6 +574,37 @@ export class MoveModuleBuilder extends FileBuilder {
 					!isWellKnownObjectParameter(param.type_, (address) => this.#resolveAddress(address)),
 			);
 
+			const functionLabel = `${this.summary.id.address}::${this.summary.id.name}::${name}`;
+			// Parameters (by index into `requiredParameters`) resolved from the runtime config
+			// object instead of being required arguments.
+			const configMatches = new Map<number, TypeConfigArgument>();
+			if (this.#configArguments.length > 0) {
+				const bareMatches = new Map<string, string[]>();
+				requiredParameters.forEach((param, i) => {
+					const match = findConfigArgumentMatch(param, this.#configArguments, {
+						resolveAddress: (address) => this.#resolveAddress(address),
+						functionLabel,
+					});
+					if (!match) return;
+					configMatches.set(i, match);
+					if (!match.paramName) {
+						bareMatches.set(match.key, [
+							...(bareMatches.get(match.key) ?? []),
+							param.name ?? `#${i}`,
+						]);
+					}
+				});
+				for (const [key, matched] of bareMatches) {
+					if (matched.length > 1) {
+						throw new Error(
+							`configArguments.${key} matches multiple parameters of ${functionLabel} (${matched.join(', ')}). ` +
+								`Add a \`name\` refinement to disambiguate.`,
+						);
+					}
+				}
+			}
+			const hasConfigMatches = configMatches.size > 0;
+
 			const normalizeName =
 				parameters.length > 0 ? this.#getImportName('normalizeMoveArguments') : null;
 
@@ -588,12 +639,24 @@ export class MoveModuleBuilder extends FileBuilder {
 			const wrap = (type: string | null): string =>
 				type === null ? transactionArgName! : `${rawTxArgName}<${type}>`;
 
-			const argumentsTypes = renderedArgTypes
+			// Interface fields: config-matched parameters become optional properties.
+			const argumentFields = renderedArgTypes
 				.map((type, i) =>
 					requiredParameters[i].name
-						? `${camelCase(requiredParameters[i].name)}: ${wrap(type)}`
+						? `${camelCase(requiredParameters[i].name)}${configMatches.has(i) ? '?' : ''}: ${wrap(type)}`
 						: wrap(type),
 				)
+				.join(',\n');
+
+			// Tuple items: optional tuple elements can't precede required ones, so config-matched
+			// positions accept an explicit `undefined` instead.
+			const argumentTupleItems = renderedArgTypes
+				.map((type, i) => {
+					const itemType = configMatches.has(i) ? `${wrap(type)} | undefined` : wrap(type);
+					return requiredParameters[i].name
+						? `${camelCase(requiredParameters[i].name)}: ${itemType}`
+						: itemType;
+				})
 				.join(',\n');
 
 			const bcsTypeName = usedTypeParameters.size > 0 ? this.#getImportName('BcsType') : null;
@@ -621,24 +684,56 @@ export class MoveModuleBuilder extends FileBuilder {
 			if (hasAllParameterNames) {
 				this.statements.push(
 					...parseTS /* ts */ `export interface ${argumentsInterface}${genericTypes} {
-						${argumentsTypes}
+						${argumentFields}
 					}`,
 				);
 			}
 
 			const optionsInterface = this.getUnusedName(`${capitalize(fnName.replace(/^_/, ''))}Options`);
 			const packageIsRequired = !this.#mvrNameOrAddress;
+			// The package-address config key only applies when a generated default exists —
+			// otherwise `package` stays required and always takes precedence.
+			const packageConfigKey = packageIsRequired ? undefined : this.#packageConfigKey;
 			const requiresOptions =
-				packageIsRequired || argumentsTypes.length > 0 || func.type_parameters.length > 0;
+				packageIsRequired || requiredParameters.length > 0 || func.type_parameters.length > 0;
+
+			// The minimal structural config slice for this function: only the keys whose matchers
+			// hit its parameters, plus this package's own package key if declared.
+			const configSliceFields: string[] = [];
+			const seenConfigKeys = new Set<string>();
+			for (const match of configMatches.values()) {
+				if (seenConfigKeys.has(match.key)) continue;
+				seenConfigKeys.add(match.key);
+				// An uninstantiated matcher on a generic type requires a resolver function — a
+				// static id cannot be correct across instantiations.
+				configSliceFields.push(
+					match.isGeneric && match.typeArguments === null
+						? `${match.key}: (ctx: ${this.#getImportName('ConfigResolverContext')}) => string | ${this.#getImportName('TransactionObjectArgument')}`
+						: `${match.key}: ${this.#getImportName('ConfigValue')}`,
+				);
+			}
+			if (packageConfigKey) {
+				configSliceFields.push(`${packageConfigKey}?: string`);
+			}
+
+			const argumentsOptional =
+				requiredParameters.length === 0 || requiredParameters.every((_, i) => configMatches.has(i));
 
 			this.statements.push(
 				...parseTS /* ts */ `export interface ${optionsInterface}${genericTypes} {
 					package${packageIsRequired ? ': string' : '?: string'}
-					${argumentsTypes.length > 0 ? 'arguments: ' : 'arguments?: '}${
+					arguments${argumentsOptional ? '?' : ''}: ${
 						hasAllParameterNames
-							? `${argumentsInterface}${genericTypeArgs} | [${argumentsTypes}]`
-							: `[${argumentsTypes}]`
+							? `${argumentsInterface}${genericTypeArgs} | [${argumentTupleItems}]`
+							: `[${argumentTupleItems}]`
 					},
+					${
+						configSliceFields.length > 0
+							? `config${hasConfigMatches ? '' : '?'}: {
+								${configSliceFields.join(',\n')}
+							},`
+							: ''
+					}
 					${
 						func.type_parameters.length
 							? `typeArguments: [${func.type_parameters.map(() => 'string').join(', ')}]`
@@ -647,11 +742,53 @@ export class MoveModuleBuilder extends FileBuilder {
 			}`,
 			);
 
+			// Config-matched positions are resolved lazily — only when the caller did not pass the
+			// argument explicitly.
+			const configDefaults = [...configMatches.entries()].map(([i, match]) => {
+				const param = requiredParameters[i];
+				let paramType = param.type_;
+				while (typeof paramType !== 'string' && 'Reference' in paramType) {
+					paramType = paramType.Reference[1];
+				}
+				const paramTypeArguments =
+					typeof paramType !== 'string' && 'Datatype' in paramType
+						? paramType.Datatype.type_arguments
+						: [];
+				const ctxTags = paramTypeArguments.map((arg) => {
+					const tag = renderResolverTypeTag(arg.argument, {
+						summary: this.summary,
+						typeParameters: func.type_parameters,
+						registry: this.registry,
+					});
+					return tag.includes('${') ? `\`${tag}\`` : `'${tag}'`;
+				});
+				return `{ index: ${i}, ${param.name ? `name: ${JSON.stringify(camelCase(param.name))}, ` : ''}resolve: () => ${this.#getImportName('resolveConfigArg')}(options.config.${match.key}, { typeArguments: [${ctxTags.join(', ')}] }, ${JSON.stringify(match.key)}) }`;
+			});
+
+			const baseArgumentsExpr = `options.arguments${
+				requiredParameters.length === 0
+					? ' ?? []'
+					: argumentsOptional
+						? hasAllParameterNames
+							? ' ?? {}'
+							: ' ?? []'
+						: ''
+			}`;
+			const argumentsExpr = hasConfigMatches
+				? `${this.#getImportName('applyConfigArguments')}(${baseArgumentsExpr}, [${configDefaults.join(', ')}])`
+				: baseArgumentsExpr;
+
+			const packageAddressExpr = `options.package${
+				packageConfigKey
+					? ` ?? options.config${hasConfigMatches ? '' : '?'}.${packageConfigKey}`
+					: ''
+			}${packageIsRequired ? '' : ` ?? '${this.#mvrNameOrAddress}'`}`;
+
 			this.statements.push(
 				...(await withComment(
 					func,
 					parseTS /* ts */ `export function ${fnName}${genericTypes}(options: ${optionsInterface}${genericTypeArgs}${requiresOptions ? '' : ' = {}'}) {
-					const packageAddress = options.package${packageIsRequired ? '' : ` ?? '${this.#mvrNameOrAddress}'`};
+					const packageAddress = ${packageAddressExpr};
 					${
 						parameters.length > 0
 							? `const argumentsTypes = [
@@ -676,7 +813,7 @@ export class MoveModuleBuilder extends FileBuilder {
 						package: packageAddress,
 						module: '${this.summary.id.name}',
 						function: '${name}',
-						${parameters.length > 0 ? `arguments: ${normalizeName}(options.arguments${argumentsTypes.length > 0 ? '' : ' ?? []'} , argumentsTypes${hasAllParameterNames ? `, parameterNames` : ''}),` : ''}
+						${parameters.length > 0 ? `arguments: ${normalizeName}(${argumentsExpr}, argumentsTypes${hasAllParameterNames ? `, parameterNames` : ''}),` : ''}
 						${func.type_parameters.length ? 'typeArguments: options.typeArguments' : ''}
 					})
 				}`,

--- a/packages/codegen/src/render-types.ts
+++ b/packages/codegen/src/render-types.ts
@@ -185,6 +185,59 @@ export function renderTypeSignature(type: Type, options: RenderTypeSignatureOpti
 	throw new Error(`Unknown type signature: ${JSON.stringify(type, null, 2)}`);
 }
 
+/**
+ * Render a type as a full type-tag string for config resolver contexts. Unlike the `typeTag`
+ * format (which emits `null` for non-pure datatypes because the runtime doesn't need those tags),
+ * this always produces a real tag. Function type parameters are interpolated from the generated
+ * function's `options.typeArguments`, so the result may be a template-literal fragment.
+ */
+export function renderResolverTypeTag(
+	type: Type,
+	options: Pick<RenderTypeSignatureOptions, 'summary' | 'typeParameters' | 'registry'>,
+): string {
+	if (typeof type === 'string') {
+		if (type === 'signer' || type === '_') {
+			throw new Error(`${type} is not supported in type arguments`);
+		}
+		return type;
+	}
+
+	if ('Reference' in type) {
+		return renderResolverTypeTag(type.Reference[1], options);
+	}
+
+	if ('vector' in type) {
+		return `vector<${renderResolverTypeTag(type.vector, options)}>`;
+	}
+
+	if ('TypeParameter' in type) {
+		return `\${options.typeArguments[${type.TypeParameter}]}`;
+	}
+
+	if ('NamedTypeParameter' in type) {
+		const originalIndex =
+			options.typeParameters?.findIndex((p) => p.name === type.NamedTypeParameter) ?? -1;
+		if (originalIndex === -1) {
+			throw new Error(`Named type parameter ${type.NamedTypeParameter} not found`);
+		}
+		return `\${options.typeArguments[${originalIndex}]}`;
+	}
+
+	if ('Datatype' in type) {
+		const { Datatype } = type;
+		const address = resolveAddress(options, Datatype.module.address);
+		const base = `${address}::${Datatype.module.name}::${Datatype.name}`;
+		if (Datatype.type_arguments.length === 0) {
+			return base;
+		}
+		return `${base}<${Datatype.type_arguments
+			.map((arg) => renderResolverTypeTag(arg.argument, options))
+			.join(', ')}>`;
+	}
+
+	throw new Error(`Unknown type signature: ${JSON.stringify(type, null, 2)}`);
+}
+
 function getDatatypeAbilities(
 	type: Datatype,
 	options: Pick<RenderTypeSignatureOptions, 'summary' | 'registry'>,
@@ -260,6 +313,8 @@ function renderDataType(type: Datatype, options: RenderTypeSignatureOptions): st
 			if (type.module.name === 'random' && type.name === 'Random') return '0x2::random::Random';
 			if (type.module.name === 'deny_list' && type.name === 'DenyList')
 				return '0x2::deny_list::DenyList';
+			if (type.module.name === 'accumulator' && type.name === 'AccumulatorRoot')
+				return '0x2::accumulator::AccumulatorRoot';
 			if (type.module.name === 'object' && (type.name === 'ID' || type.name === 'UID'))
 				return '0x2::object::ID';
 		}

--- a/packages/codegen/src/render-types.ts
+++ b/packages/codegen/src/render-types.ts
@@ -193,7 +193,14 @@ export function renderTypeSignature(type: Type, options: RenderTypeSignatureOpti
  */
 export function renderResolverTypeTag(
 	type: Type,
-	options: Pick<RenderTypeSignatureOptions, 'summary' | 'typeParameters' | 'registry'>,
+	options: Pick<RenderTypeSignatureOptions, 'summary' | 'typeParameters' | 'registry'> & {
+		/**
+		 * Overrides the address used for a concrete datatype (e.g. to use type-origin addresses or
+		 * MVR names consistent with generated BCS type names). Falls back to the registry's
+		 * address mapping.
+		 */
+		getDatatypeTagAddress?: (datatype: Datatype) => string;
+	},
 ): string {
 	if (typeof type === 'string') {
 		if (type === 'signer' || type === '_') {
@@ -225,7 +232,8 @@ export function renderResolverTypeTag(
 
 	if ('Datatype' in type) {
 		const { Datatype } = type;
-		const address = resolveAddress(options, Datatype.module.address);
+		const address =
+			options.getDatatypeTagAddress?.(Datatype) ?? resolveAddress(options, Datatype.module.address);
 		const base = `${address}::${Datatype.module.name}::${Datatype.name}`;
 		if (Datatype.type_arguments.length === 0) {
 			return base;

--- a/packages/codegen/src/utils.ts
+++ b/packages/codegen/src/utils.ts
@@ -168,6 +168,10 @@ export function isWellKnownObjectParameter(
 		if (Datatype.module.name === 'clock') {
 			return Datatype.name === 'Clock';
 		}
+
+		if (Datatype.module.name === 'accumulator') {
+			return Datatype.name === 'AccumulatorRoot';
+		}
 	}
 
 	if (address === SUI_SYSTEM_ADDRESS) {

--- a/packages/codegen/tests/codegen-output.test.ts
+++ b/packages/codegen/tests/codegen-output.test.ts
@@ -586,6 +586,68 @@ describe('function codegen output', () => {
 		expect(fnBody?.[0]).toContain("'0x2::clock::Clock'");
 	});
 
+	it('function with well-known AccumulatorRoot parameter', async () => {
+		const summary = {
+			id: { address: 'testpkg', name: 'settlement' },
+			doc: '',
+			immediate_dependencies: [],
+			attributes: [],
+			functions: {
+				settle: {
+					source_index: 0,
+					index: 0,
+					doc: '',
+					attributes: [],
+					visibility: 'Public',
+					entry: false,
+					macro_: false,
+					type_parameters: [],
+					parameters: [
+						{
+							name: 'root',
+							type_: {
+								Reference: [
+									true,
+									{
+										Datatype: {
+											module: { address: 'sui', name: 'accumulator' },
+											name: 'AccumulatorRoot',
+											type_arguments: [],
+										},
+									},
+								],
+							},
+						},
+						{ name: 'amount', type_: 'u64' },
+					],
+					return_: [],
+				},
+			},
+			structs: {},
+			enums: {},
+		};
+
+		const builder = new MoveModuleBuilder({
+			summary: summary as any,
+			registry: new ModuleRegistry(ADDRESS_MAPPINGS),
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+		builder.includeFunctions();
+		const output = await render(builder, { functions: true });
+
+		// AccumulatorRoot should be auto-injected, not in the arguments interface
+		const argInterface = output.match(/export interface SettleArguments[\s\S]*?^}/m);
+		expect(argInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface SettleArguments {
+			    amount: RawTransactionArgument<number | bigint>;
+			}"
+		`);
+
+		const fnBody = output.match(/export function settle[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain("'0x2::accumulator::AccumulatorRoot'");
+	});
+
 	it('function with enum parameter (is_active)', async () => {
 		const { registry } = await createBuilders();
 		registry.includeTypes();

--- a/packages/codegen/tests/config-arguments.test.ts
+++ b/packages/codegen/tests/config-arguments.test.ts
@@ -473,7 +473,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'register',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'register', parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'register', parameterIndex: 0, parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
@@ -511,7 +511,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'lookup',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'lookup', parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'lookup', parameterIndex: 0, parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
@@ -552,7 +552,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'container_size',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "container", resolve: () => resolveConfigArgument(options.config?.container, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'registry', functionName: 'container_size', parameterName: "container" }, "container") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "container", resolve: () => resolveConfigArgument(options.config?.container, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'registry', functionName: 'container_size', parameterIndex: 0, parameterName: "container" }, "container") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -596,7 +596,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'use_concrete',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.suiPool, { typeArguments: ['0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'], packageAddress, moduleName: 'pools', functionName: 'use_concrete', parameterName: "pool" }, "suiPool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.suiPool, { typeArguments: ['0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'], packageAddress, moduleName: 'pools', functionName: 'use_concrete', parameterIndex: 0, parameterName: "pool" }, "suiPool") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
@@ -633,7 +633,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'use_generic',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic', parameterName: "pool" }, "pool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic', parameterIndex: 0, parameterName: "pool" }, "pool") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -664,36 +664,109 @@ describe('config-driven function codegen', () => {
 		expect(fnBody?.[0]).toContain(`typeArguments: ['${ORIGIN_V1}::pools::Coin']`);
 	});
 
-	it('errors when a bare matcher hits two named parameters in one signature', async () => {
+	it('allows one key to match multiple parameters, forcing a resolver-typed config value', async () => {
 		const builder = createPoolsBuilder({
 			pool: { type: '@test/testpkg::pools::Pool' },
 		});
 		builder.includeFunctions(['swap']);
+		const output = await render(builder);
 
-		await expect(render(builder)).rejects.toThrowError(
-			/configArguments\.pool matches multiple parameters of testpkg::pools::swap \(base_pool, quote_pool\)/,
+		// Both base_pool and quote_pool resolve through config.pool; the resolver
+		// disambiguates via ctx (parameterName/parameterIndex/typeArguments).
+		const optionsInterface = output.match(/export interface SwapOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toContain(
+			'pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument',
+		);
+
+		const fnBody = output.match(/export function swap[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain('parameterIndex: 0');
+		expect(fnBody?.[0]).toContain('parameterIndex: 1');
+	});
+
+	it('allows one key to declare matchers for multiple types, forcing a resolver-typed config value', async () => {
+		const builder = createPoolsBuilder({
+			objects: [
+				{ type: '@test/testpkg::pools::Coin' },
+				{ type: '@test/testpkg::pools::Pool<0x2::sui::SUI>' },
+			],
+		});
+		builder.includeFunctions(['use_concrete']);
+		const output = await render(builder);
+
+		const optionsInterface = output.match(/export interface UseConcreteOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toContain(
+			'objects: (ctx: ConfigResolverContext) => string | TransactionObjectArgument',
 		);
 	});
 
-	it('warns and skips config mapping when a bare matcher hits two nameless parameters', async () => {
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-		try {
-			const builder = createPoolsBuilder(
-				{ pool: { type: '@test/testpkg::pools::Pool' } },
-				{ parameterNames: false },
-			);
-			builder.includeFunctions(['swap']);
-			const output = await render(builder);
+	it('function matchers configure a single function parameter directly', async () => {
+		const { registry } = await createBuilders({
+			// lookup has exactly one argument, so the parameter can be inferred.
+			lookupRegistry: { function: '@test/testpkg::registry::lookup' },
+			registerRegistry: {
+				function: '@test/testpkg::registry::register',
+				parameterName: 'registry',
+			},
+		});
+		registry.includeFunctions(['lookup', 'register']);
+		const output = await render(registry);
 
-			expect(warn).toHaveBeenCalledWith(
-				expect.stringContaining('configArguments.pool matches multiple parameters'),
-			);
-			// swap is still generated, without config mapping.
-			const optionsInterface = output.match(/export interface SwapOptions[\s\S]*?^}/m);
-			expect(optionsInterface?.[0]).not.toContain('config');
-		} finally {
-			warn.mockRestore();
-		}
+		const lookupOptions = output.match(/export interface LookupOptions[\s\S]*?^}/m);
+		expect(lookupOptions?.[0]).toContain('lookupRegistry: ConfigValue');
+
+		const registerOptions = output.match(/export interface RegisterOptions[\s\S]*?^}/m);
+		expect(registerOptions?.[0]).toContain('registerRegistry: ConfigValue');
+		// The function matcher only applies to its own function.
+		expect(registerOptions?.[0]).not.toContain('lookupRegistry');
+	});
+
+	it('function matchers win over type matchers and support parameterIndex', async () => {
+		const builder = createPoolsBuilder({
+			pool: { type: '@test/testpkg::pools::Pool' },
+			concretePool: { function: '@test/testpkg::pools::use_concrete', parameterIndex: 0 },
+		});
+		builder.includeFunctions(['use_concrete', 'use_generic']);
+		const output = await render(builder);
+
+		const concreteOptions = output.match(/export interface UseConcreteOptions[\s\S]*?^}/m);
+		expect(concreteOptions?.[0]).toContain('concretePool: ConfigValue');
+		const concreteSlice = concreteOptions?.[0].match(/config\?: \{[\s\S]*?\}/);
+		expect(concreteSlice?.[0]).not.toContain('pool: (ctx');
+
+		const genericOptions = output.match(/export interface UseGenericOptions[\s\S]*?^}/m);
+		expect(genericOptions?.[0]).toContain('pool:');
+	});
+
+	it('validates function matchers at parse time', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+		const parse = (matcher: object) =>
+			parseConfigArguments({ global: { key: matcher as never } }, registry, TESTPKG_CONTEXT);
+
+		expect(() => parse({ function: '@test/testpkg::pools::nope' })).toThrowError(
+			/was not found in its package's summaries/,
+		);
+		expect(() => parse({ function: '@test/testpkg::pools::swap' })).toThrowError(
+			/has 2 argument\(s\) — specify parameterName or parameterIndex/,
+		);
+		expect(() =>
+			parse({ function: '@test/testpkg::pools::swap', parameterName: 'nope' }),
+		).toThrowError(/has no parameter named "nope"/);
+		expect(() => parse({ function: '@test/testpkg::pools::swap', parameterIndex: 5 })).toThrowError(
+			/parameterIndex 5 is out of range/,
+		);
+		expect(() =>
+			parse({
+				function: '@test/testpkg::pools::swap',
+				parameterName: 'base_pool',
+				parameterIndex: 0,
+			}),
+		).toThrowError(/not both/);
 	});
 
 	it('generates tuple-only bindings for nameless summaries with a matched parameter', async () => {
@@ -733,7 +806,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'use_generic',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic' }, "pool") }]), argumentsTypes),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic', parameterIndex: 0 }, "pool") }]), argumentsTypes),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -780,7 +853,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'swap',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "basePool", resolve: () => resolveConfigArgument(options.config?.basePool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterName: "base_pool" }, "basePool") }, { index: 1, name: "quotePool", resolve: () => resolveConfigArgument(options.config?.quotePool, { typeArguments: [\`\${options.typeArguments[1]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterName: "quote_pool" }, "quotePool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "basePool", resolve: () => resolveConfigArgument(options.config?.basePool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterIndex: 0, parameterName: "base_pool" }, "basePool") }, { index: 1, name: "quotePool", resolve: () => resolveConfigArgument(options.config?.quotePool, { typeArguments: [\`\${options.typeArguments[1]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterIndex: 1, parameterName: "quote_pool" }, "quotePool") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -1190,6 +1263,7 @@ describe('generateFromPackageSummary with configArguments', () => {
 				moduleName: 'registry',
 				functionName: 'container_size',
 				parameterName: 'container',
+				parameterIndex: 0,
 			},
 		]);
 		expect(json.inputs).toEqual([{ UnresolvedObject: { objectId: CONTAINER_ID } }]);

--- a/packages/codegen/tests/config-arguments.test.ts
+++ b/packages/codegen/tests/config-arguments.test.ts
@@ -1,0 +1,791 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { readFile, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import ts from 'typescript';
+import { Transaction } from '@mysten/sui/transactions';
+import { ModuleRegistry } from '../src/module-registry.js';
+import { MoveModuleBuilder } from '../src/move-module-builder.js';
+import { parseConfigArguments } from '../src/config-arguments.js';
+import { generateFromPackageSummary } from '../src/index.js';
+import type { ConfigArguments } from '../src/config.js';
+
+const FIXTURE_PATH = join(__dirname, 'move/testpkg');
+const SUMMARIES_DIR = join(FIXTURE_PATH, 'package_summaries');
+const GENERATED_DIR = join(__dirname, 'generated-config');
+
+const ADDRESS_MAPPINGS = {
+	std: '0x0000000000000000000000000000000000000000000000000000000000000001',
+	sui: '0x0000000000000000000000000000000000000000000000000000000000000002',
+	testpkg: '0x0000000000000000000000000000000000000000000000000000000000000000',
+};
+
+async function createBuilders(configArguments: ConfigArguments, packageConfigKey?: string) {
+	const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+	const counter = await MoveModuleBuilder.fromSummaryFile(
+		join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
+		registry,
+		'@test/testpkg',
+	);
+	const registryBuilder = await MoveModuleBuilder.fromSummaryFile(
+		join(SUMMARIES_DIR, 'testpkg', 'registry.json'),
+		registry,
+		'@test/testpkg',
+	);
+
+	const { entries } = parseConfigArguments(configArguments, registry);
+	counter.setConfigArguments(entries, packageConfigKey);
+	registryBuilder.setConfigArguments(entries, packageConfigKey);
+
+	return { counter, registry: registryBuilder, moduleRegistry: registry };
+}
+
+async function render(builder: MoveModuleBuilder) {
+	await builder.renderFunctions();
+	return builder.toString('./', './testpkg/test.ts');
+}
+
+/**
+ * A synthetic module with a generic `Pool<phantom T>` type used by functions in generic,
+ * concretely-instantiated, and same-type-twice positions.
+ */
+function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = {}) {
+	const poolType = (typeArgument: unknown) => ({
+		Reference: [
+			false,
+			{
+				Datatype: {
+					module: { address: 'testpkg', name: 'pools' },
+					name: 'Pool',
+					type_arguments: [{ phantom: true, argument: typeArgument }],
+				},
+			},
+		],
+	});
+	const suiType = {
+		Datatype: { module: { address: 'sui', name: 'sui' }, name: 'SUI', type_arguments: [] },
+	};
+	const param = (name: string, type_: unknown) => (parameterNames ? { name, type_ } : { type_ });
+	const fn = (parameters: unknown[], type_parameters: unknown[] = []) => ({
+		source_index: 0,
+		index: 0,
+		doc: '',
+		attributes: [],
+		visibility: 'Public',
+		entry: false,
+		macro_: false,
+		type_parameters,
+		parameters,
+		return_: [],
+	});
+
+	return {
+		id: { address: 'testpkg', name: 'pools' },
+		doc: '',
+		immediate_dependencies: [],
+		attributes: [],
+		functions: {
+			use_generic: fn(
+				[param('pool', poolType({ TypeParameter: 0 })), param('amount', 'u64')],
+				[{ name: 'T', phantom: false, constraints: [] }],
+			),
+			use_concrete: fn([param('pool', poolType(suiType)), param('amount', 'u64')]),
+			swap: fn(
+				[
+					param('base_pool', poolType({ TypeParameter: 0 })),
+					param('quote_pool', poolType({ TypeParameter: 1 })),
+				],
+				[
+					{ name: 'Base', phantom: false, constraints: [] },
+					{ name: 'Quote', phantom: false, constraints: [] },
+				],
+			),
+		},
+		structs: {
+			Pool: {
+				index: 0,
+				doc: '',
+				attributes: [],
+				abilities: ['Key'],
+				type_parameters: [{ name: 'T', phantom: true, constraints: [] }],
+				fields: {
+					positional_fields: false,
+					fields: { id: { index: 0, doc: null, type_: 'address' } },
+				},
+			},
+		},
+		enums: {},
+	};
+}
+
+function createPoolsBuilder(
+	configArguments: ConfigArguments,
+	options: { parameterNames?: boolean } = {},
+) {
+	const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+	const builder = new MoveModuleBuilder({
+		summary: poolsSummary(options) as any,
+		registry,
+		mvrNameOrAddress: '@test/testpkg',
+		importExtension: '.js',
+	});
+	const { entries } = parseConfigArguments(configArguments, registry);
+	builder.setConfigArguments(entries);
+	return builder;
+}
+
+describe('parseConfigArguments', () => {
+	it('parses type, instantiated type, and package matchers', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		const { entries, unresolvedKeys } = parseConfigArguments(
+			{
+				pool: { type: 'testpkg::pools::Pool' },
+				suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+				pkg: { package: '@test/testpkg' },
+			},
+			registry,
+		);
+
+		expect(unresolvedKeys).toEqual([]);
+		expect(entries).toMatchObject([
+			{
+				kind: 'type',
+				key: 'pool',
+				module: 'pools',
+				name: 'Pool',
+				typeArguments: null,
+				isGeneric: true,
+			},
+			{
+				kind: 'type',
+				key: 'suiPool',
+				typeArguments: [
+					{
+						datatype: {
+							address: '0x0000000000000000000000000000000000000000000000000000000000000002',
+							module: 'sui',
+							name: 'SUI',
+							typeArguments: [],
+						},
+					},
+				],
+				isGeneric: true,
+			},
+			{ kind: 'package', key: 'pkg', package: '@test/testpkg' },
+		]);
+	});
+
+	it('reports matchers for types that are not in the summaries as unresolved', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		const { entries, unresolvedKeys } = parseConfigArguments(
+			{
+				missingType: { type: 'testpkg::pools::DoesNotExist' },
+				missingModule: { type: '0x999::other::Thing' },
+				pool: { type: 'testpkg::pools::Pool' },
+			},
+			registry,
+		);
+
+		expect(unresolvedKeys).toEqual(['missingType', 'missingModule']);
+		expect(entries.map((entry) => entry.key)).toEqual(['pool']);
+	});
+
+	it('rejects malformed matcher types', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+
+		expect(() => parseConfigArguments({ bad: { type: 'Pool' } }, registry)).toThrowError(
+			/Expected a fully-qualified Move type/,
+		);
+		expect(() => parseConfigArguments({ bad: { type: 'u64' } }, registry)).toThrowError(
+			/must be a Move datatype/,
+		);
+	});
+
+	it('rejects instantiated matchers with the wrong arity', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		expect(() =>
+			parseConfigArguments(
+				{ pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI, u64>' } },
+				registry,
+			),
+		).toThrowError(/expects 1 type argument\(s\), got 2/);
+	});
+});
+
+describe('config-driven function codegen', () => {
+	it('non-generic matcher: matched parameter becomes optional with a required config slice', async () => {
+		const { registry } = await createBuilders({
+			registryObj: { type: 'testpkg::registry::Registry' },
+		});
+		registry.includeFunctions(['register']);
+		const output = await render(registry);
+
+		const argInterface = output.match(/export interface RegisterArguments[\s\S]*?^}/m);
+		expect(argInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface RegisterArguments {
+			    registry?: RawTransactionArgument<string>;
+			    name: RawTransactionArgument<string>;
+			    tags: RawTransactionArgument<Array<string>>;
+			}"
+		`);
+
+		const optionsInterface = output.match(/export interface RegisterOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface RegisterOptions {
+			    package?: string;
+			    arguments: RegisterArguments | [
+			        registry: RawTransactionArgument<string> | undefined,
+			        name: RawTransactionArgument<string>,
+			        tags: RawTransactionArgument<Array<string>>
+			    ];
+			    config: {
+			        registryObj: ConfigValue;
+			    };
+			}"
+		`);
+
+		const fnBody = output.match(/export function register[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toMatchInlineSnapshot(`
+			"export function register(options: RegisterOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null,
+			        '0x1::string::String',
+			        'vector<0x1::string::String>'
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["registry", "name", "tags"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'registry',
+			        function: 'register',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "registry", resolve: () => resolveConfigArg(options.config.registryObj, { typeArguments: [] }, "registryObj") }]), argumentsTypes, parameterNames),
+			    });
+			}"
+		`);
+	});
+
+	it('makes arguments optional when every parameter is config-matched', async () => {
+		const { registry } = await createBuilders({
+			registryObj: { type: 'testpkg::registry::Registry' },
+		});
+		registry.includeFunctions(['lookup']);
+		const output = await render(registry);
+
+		const optionsInterface = output.match(/export interface LookupOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface LookupOptions {
+			    package?: string;
+			    arguments?: LookupArguments | [
+			        registry: RawTransactionArgument<string> | undefined
+			    ];
+			    config: {
+			        registryObj: ConfigValue;
+			    };
+			}"
+		`);
+
+		const fnBody = output.match(/export function lookup[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toMatchInlineSnapshot(`
+			"export function lookup(options: LookupOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["registry"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'registry',
+			        function: 'lookup',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "registry", resolve: () => resolveConfigArg(options.config.registryObj, { typeArguments: [] }, "registryObj") }]), argumentsTypes, parameterNames),
+			    });
+			}"
+		`);
+	});
+
+	it('uninstantiated generic matcher: config value requires a resolver and receives the parameter instantiation', async () => {
+		const { registry } = await createBuilders({
+			container: { type: 'testpkg::registry::Container' },
+		});
+		registry.includeFunctions(['container_size']);
+		const output = await render(registry);
+
+		const optionsInterface = output.match(/export interface ContainerSizeOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface ContainerSizeOptions {
+			    package?: string;
+			    arguments?: ContainerSizeArguments | [
+			        container: RawTransactionArgument<string> | undefined
+			    ];
+			    config: {
+			        container: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			    };
+			    typeArguments: [
+			        string
+			    ];
+			}"
+		`);
+
+		const fnBody = output.match(/export function containerSize[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toMatchInlineSnapshot(`
+			"export function containerSize(options: ContainerSizeOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["container"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'registry',
+			        function: 'container_size',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "container", resolve: () => resolveConfigArg(options.config.container, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "container") }]), argumentsTypes, parameterNames),
+			        typeArguments: options.typeArguments
+			    });
+			}"
+		`);
+	});
+
+	it('instantiated matcher only matches concrete instantiations and wins over the uninstantiated matcher', async () => {
+		const builder = createPoolsBuilder({
+			pool: { type: 'testpkg::pools::Pool' },
+			suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+		});
+		builder.includeFunctions(['use_generic', 'use_concrete']);
+		const output = await render(builder);
+
+		// use_concrete is concretely typed Pool<SUI> in the Move signature: the instantiated
+		// matcher wins and a plain value is allowed.
+		const concreteOptions = output.match(/export interface UseConcreteOptions[\s\S]*?^}/m);
+		expect(concreteOptions?.[0]).toMatchInlineSnapshot(`
+			"export interface UseConcreteOptions {
+			    package?: string;
+			    arguments: UseConcreteArguments | [
+			        pool: RawTransactionArgument<string> | undefined,
+			        amount: RawTransactionArgument<number | bigint>
+			    ];
+			    config: {
+			        suiPool: ConfigValue;
+			    };
+			}"
+		`);
+
+		const concreteBody = output.match(/export function useConcrete[\s\S]*?^}/m);
+		expect(concreteBody?.[0]).toMatchInlineSnapshot(`
+			"export function useConcrete(options: UseConcreteOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null,
+			        'u64'
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["pool", "amount"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'pools',
+			        function: 'use_concrete',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArg(options.config.suiPool, { typeArguments: ['0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'] }, "suiPool") }]), argumentsTypes, parameterNames),
+			    });
+			}"
+		`);
+
+		// use_generic is typed Pool<T>: it always binds to the uninstantiated matcher, which
+		// requires a resolver function.
+		const genericOptions = output.match(/export interface UseGenericOptions[\s\S]*?^}/m);
+		expect(genericOptions?.[0]).toMatchInlineSnapshot(`
+			"export interface UseGenericOptions {
+			    package?: string;
+			    arguments: UseGenericArguments | [
+			        pool: RawTransactionArgument<string> | undefined,
+			        amount: RawTransactionArgument<number | bigint>
+			    ];
+			    config: {
+			        pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			    };
+			    typeArguments: [
+			        string
+			    ];
+			}"
+		`);
+
+		const genericBody = output.match(/export function useGeneric[\s\S]*?^}/m);
+		expect(genericBody?.[0]).toMatchInlineSnapshot(`
+			"export function useGeneric(options: UseGenericOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null,
+			        'u64'
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["pool", "amount"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'pools',
+			        function: 'use_generic',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArg(options.config.pool, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "pool") }]), argumentsTypes, parameterNames),
+			        typeArguments: options.typeArguments
+			    });
+			}"
+		`);
+	});
+
+	it('errors when a bare matcher hits two parameters in one signature', async () => {
+		const builder = createPoolsBuilder({
+			pool: { type: 'testpkg::pools::Pool' },
+		});
+		builder.includeFunctions(['swap']);
+
+		await expect(render(builder)).rejects.toThrowError(
+			/configArguments\.pool matches multiple parameters of testpkg::pools::swap \(base_pool, quote_pool\)/,
+		);
+	});
+
+	it('name refinement disambiguates two parameters of the same type', async () => {
+		const builder = createPoolsBuilder({
+			basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' },
+			quotePool: { type: 'testpkg::pools::Pool', name: 'quote_pool' },
+		});
+		builder.includeFunctions(['swap']);
+		const output = await render(builder);
+
+		const optionsInterface = output.match(/export interface SwapOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface SwapOptions {
+			    package?: string;
+			    arguments?: SwapArguments | [
+			        basePool: RawTransactionArgument<string> | undefined,
+			        quotePool: RawTransactionArgument<string> | undefined
+			    ];
+			    config: {
+			        basePool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			        quotePool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			    };
+			    typeArguments: [
+			        string,
+			        string
+			    ];
+			}"
+		`);
+
+		const fnBody = output.match(/export function swap[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toMatchInlineSnapshot(`
+			"export function swap(options: SwapOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null,
+			        null
+			    ] satisfies (string | null)[];
+			    const parameterNames = ["basePool", "quotePool"];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'pools',
+			        function: 'swap',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "basePool", resolve: () => resolveConfigArg(options.config.basePool, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "basePool") }, { index: 1, name: "quotePool", resolve: () => resolveConfigArg(options.config.quotePool, { typeArguments: [\`\${options.typeArguments[1]}\`] }, "quotePool") }]), argumentsTypes, parameterNames),
+			        typeArguments: options.typeArguments
+			    });
+			}"
+		`);
+	});
+
+	it('name-refined matchers win over a bare matcher for the same type', async () => {
+		const builder = createPoolsBuilder({
+			pool: { type: 'testpkg::pools::Pool' },
+			basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' },
+			quotePool: { type: 'testpkg::pools::Pool', name: 'quote_pool' },
+		});
+		builder.includeFunctions(['swap', 'use_generic']);
+		const output = await render(builder);
+
+		// swap binds base/quote to the name-refined keys; use_generic still binds `pool`.
+		const swapOptions = output.match(/export interface SwapOptions[\s\S]*?^}/m);
+		expect(swapOptions?.[0]).toContain('basePool');
+		expect(swapOptions?.[0]).toContain('quotePool');
+		expect(swapOptions?.[0]).not.toContain('pool:');
+
+		const genericOptions = output.match(/export interface UseGenericOptions[\s\S]*?^}/m);
+		expect(genericOptions?.[0]).toContain('pool:');
+	});
+
+	it('errors when two matchers of equal specificity hit the same parameter', async () => {
+		const builder = createPoolsBuilder({
+			poolA: { type: 'testpkg::pools::Pool' },
+			poolB: { type: 'testpkg::pools::Pool' },
+		});
+		builder.includeFunctions(['use_generic']);
+
+		await expect(render(builder)).rejects.toThrowError(
+			/matched by multiple configArguments entries with equal specificity: poolA, poolB/,
+		);
+	});
+
+	it('errors when a name matcher targets a summary without parameter names', async () => {
+		const builder = createPoolsBuilder(
+			{ basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' } },
+			{ parameterNames: false },
+		);
+		builder.includeFunctions(['swap']);
+
+		await expect(render(builder)).rejects.toThrowError(
+			/parameters of testpkg::pools::swap have no names/,
+		);
+	});
+
+	it('package entries are added to the package-address precedence chain', async () => {
+		const { registry } = await createBuilders(
+			{
+				registryObj: { type: 'testpkg::registry::Registry' },
+				testpkgAddress: { package: '@test/testpkg' },
+			},
+			'testpkgAddress',
+		);
+		registry.includeFunctions(['lookup']);
+		const output = await render(registry);
+
+		const fnBody = output.match(/export function lookup[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain(
+			"const packageAddress = options.package ?? options.config.testpkgAddress ?? '@test/testpkg';",
+		);
+	});
+
+	it('package entries alone produce an optional config slice', async () => {
+		const { registry } = await createBuilders(
+			{ testpkgAddress: { package: '@test/testpkg' } },
+			'testpkgAddress',
+		);
+		registry.includeFunctions(['lookup']);
+		const output = await render(registry);
+
+		const optionsInterface = output.match(/export interface LookupOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface LookupOptions {
+			    package?: string;
+			    arguments: LookupArguments | [
+			        registry: RawTransactionArgument<string>
+			    ];
+			    config?: {
+			        testpkgAddress?: string;
+			    };
+			}"
+		`);
+
+		const fnBody = output.match(/export function lookup[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain(
+			"const packageAddress = options.package ?? options.config?.testpkgAddress ?? '@test/testpkg';",
+		);
+	});
+
+	it('keeps origin-addressed type tags while calls use the config-supplied package address', async () => {
+		const ORIGIN_V1 = '0x000000000000000000000000000000000000000000000000000000000000aaaa';
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		const builder = await MoveModuleBuilder.fromSummaryFile(
+			join(SUMMARIES_DIR, 'testpkg', 'registry.json'),
+			registry,
+			'@test/testpkg',
+			'.js',
+			false,
+			{ Registry: ORIGIN_V1, Container: ORIGIN_V1 },
+		);
+		const { entries } = parseConfigArguments(
+			{
+				registryObj: { type: 'testpkg::registry::Registry' },
+				testpkgAddress: { package: '@test/testpkg' },
+			},
+			registry,
+		);
+		builder.setConfigArguments(entries, 'testpkgAddress');
+		builder.includeTypes(['Registry']);
+		builder.includeFunctions(['lookup']);
+		await builder.renderBCSTypes();
+		const output = await render(builder);
+
+		// BCS type names keep the origin address; the call package comes from the config chain.
+		expect(output).toContain(`name: \`${ORIGIN_V1}::registry::Registry\``);
+		expect(output).toContain(
+			"const packageAddress = options.package ?? options.config.testpkgAddress ?? '@test/testpkg';",
+		);
+	});
+});
+
+describe('generateFromPackageSummary with configArguments', () => {
+	afterAll(async () => {
+		await rm(GENERATED_DIR, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	async function generate() {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		await generateFromPackageSummary({
+			package: {
+				package: '@test/testpkg',
+				path: FIXTURE_PATH,
+				configArguments: {
+					registryObj: { type: 'testpkg::registry::Registry' },
+					container: { type: 'testpkg::registry::Container' },
+					testpkgAddress: { package: '@test/testpkg' },
+					missing: { type: 'testpkg::registry::DoesNotExist' },
+				},
+			},
+			prune: true,
+			outputDir: GENERATED_DIR,
+		});
+		return warn;
+	}
+
+	it('emits config-args.ts and config-driven bindings, warning on unresolved keys', async () => {
+		const warn = await generate();
+
+		expect(warn).toHaveBeenCalledWith(
+			'configArguments keys not resolvable in @test/testpkg (skipped): missing',
+		);
+
+		const configArgs = await readFile(join(GENERATED_DIR, 'testpkg', 'config-args.ts'), 'utf-8');
+		expect(configArgs).toMatchInlineSnapshot(`
+			"/**************************************************************
+			 * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+			 **************************************************************/
+			import { type ConfigValue, type ConfigResolverContext } from '../utils/index.js';
+			import { type TransactionObjectArgument } from '@mysten/sui/transactions';
+			export interface TestpkgConfig {
+			    registryObj: ConfigValue;
+			    container: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			    testpkgAddress?: string;
+			}"
+		`);
+
+		const registryModule = await readFile(join(GENERATED_DIR, 'testpkg', 'registry.ts'), 'utf-8');
+		expect(registryModule).toContain('applyConfigArguments');
+		expect(registryModule).toContain('resolveConfigArg');
+	});
+
+	it('generated output typechecks under strict settings', { timeout: 60_000 }, async () => {
+		await generate();
+
+		const files: string[] = [];
+		const walk = async (dir: string) => {
+			for (const entry of await readdir(dir, { withFileTypes: true })) {
+				const path = join(dir, entry.name);
+				if (entry.isDirectory()) {
+					await walk(path);
+				} else if (entry.name.endsWith('.ts')) {
+					files.push(path);
+				}
+			}
+		};
+		await walk(GENERATED_DIR);
+
+		const program = ts.createProgram({
+			rootNames: files,
+			options: {
+				target: ts.ScriptTarget.ES2020,
+				module: ts.ModuleKind.NodeNext,
+				moduleResolution: ts.ModuleResolutionKind.NodeNext,
+				strict: true,
+				noUncheckedIndexedAccess: true,
+				noEmit: true,
+				skipLibCheck: true,
+				esModuleInterop: true,
+				lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
+			},
+		});
+
+		const diagnostics = ts
+			.getPreEmitDiagnostics(program)
+			.filter((diagnostic) => diagnostic.file && files.includes(diagnostic.file.fileName));
+
+		const messages = diagnostics.map((diagnostic) => {
+			const text = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+			if (diagnostic.file && diagnostic.start !== undefined) {
+				const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+				return `[${diagnostic.file.fileName}:${line + 1}:${character + 1}] ${text}`;
+			}
+			return text;
+		});
+
+		expect(messages, `Generated output has type errors:\n${messages.join('\n')}`).toEqual([]);
+	});
+
+	it('config values are applied at runtime, with explicit arguments overriding', async () => {
+		await generate();
+
+		const mod = await import(join(GENERATED_DIR, 'testpkg', 'registry.js'));
+		const PACKAGE_ID = '0x00000000000000000000000000000000000000000000000000000000000000ee';
+		const REGISTRY_ID = '0x0000000000000000000000000000000000000000000000000000000000000123';
+
+		// Config-provided object id and package address.
+		const tx = new Transaction();
+		tx.add(
+			mod.lookup({
+				config: { registryObj: REGISTRY_ID, testpkgAddress: PACKAGE_ID },
+			}),
+		);
+		const json = JSON.parse(await tx.toJSON());
+		expect(json.inputs).toEqual([{ UnresolvedObject: { objectId: REGISTRY_ID } }]);
+		expect(json.commands[0].MoveCall.package).toBe(PACKAGE_ID);
+
+		// An explicitly passed argument overrides config resolution.
+		const OVERRIDE_ID = '0x0000000000000000000000000000000000000000000000000000000000000456';
+		const tx2 = new Transaction();
+		tx2.add(
+			mod.lookup({
+				arguments: { registry: OVERRIDE_ID },
+				config: {
+					registryObj: () => {
+						throw new Error('should not be called');
+					},
+					testpkgAddress: PACKAGE_ID,
+				},
+			}),
+		);
+		const json2 = JSON.parse(await tx2.toJSON());
+		expect(json2.inputs).toEqual([{ UnresolvedObject: { objectId: OVERRIDE_ID } }]);
+	});
+
+	it('resolvers receive the matched parameter instantiation at runtime', async () => {
+		await generate();
+
+		const mod = await import(join(GENERATED_DIR, 'testpkg', 'registry.js'));
+		const PACKAGE_ID = '0x00000000000000000000000000000000000000000000000000000000000000ee';
+		const CONTAINER_ID = '0x0000000000000000000000000000000000000000000000000000000000000789';
+		const contexts: unknown[] = [];
+
+		const tx = new Transaction();
+		tx.add(
+			mod.containerSize({
+				typeArguments: ['0x2::sui::SUI'],
+				config: {
+					container: (ctx: unknown) => {
+						contexts.push(ctx);
+						return CONTAINER_ID;
+					},
+					testpkgAddress: PACKAGE_ID,
+				},
+			}),
+		);
+		const json = JSON.parse(await tx.toJSON());
+
+		expect(contexts).toEqual([{ typeArguments: ['0x2::sui::SUI'] }]);
+		expect(json.inputs).toEqual([{ UnresolvedObject: { objectId: CONTAINER_ID } }]);
+	});
+});

--- a/packages/codegen/tests/config-arguments.test.ts
+++ b/packages/codegen/tests/config-arguments.test.ts
@@ -720,6 +720,23 @@ describe('config-driven function codegen', () => {
 		expect(registerOptions?.[0]).not.toContain('lookupRegistry');
 	});
 
+	it('multiple matchers binding the same concrete type keep a plain config value', async () => {
+		const { registry } = await createBuilders({
+			reg: [
+				{ function: '@test/testpkg::registry::lookup' },
+				{ function: '@test/testpkg::registry::register', parameterName: 'registry' },
+			],
+		});
+		registry.includeFunctions(['lookup', 'register']);
+		const output = await render(registry);
+
+		// Both bindings are `registry::Registry`, so one static id serves both functions.
+		const lookupOptions = output.match(/export interface LookupOptions[\s\S]*?^}/m);
+		expect(lookupOptions?.[0]).toContain('reg: ConfigValue');
+		const registerOptions = output.match(/export interface RegisterOptions[\s\S]*?^}/m);
+		expect(registerOptions?.[0]).toContain('reg: ConfigValue');
+	});
+
 	it('function matchers win over type matchers and support parameterIndex', async () => {
 		const builder = createPoolsBuilder({
 			pool: { type: '@test/testpkg::pools::Pool' },

--- a/packages/codegen/tests/config-arguments.test.ts
+++ b/packages/codegen/tests/config-arguments.test.ts
@@ -23,6 +23,10 @@ const ADDRESS_MAPPINGS = {
 	testpkg: '0x0000000000000000000000000000000000000000000000000000000000000000',
 };
 
+const TESTPKG_CONTEXT = {
+	package: { id: '@test/testpkg', address: ADDRESS_MAPPINGS.testpkg },
+};
+
 async function createBuilders(configArguments: ConfigArguments, packageConfigKey?: string) {
 	const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
 	const counter = await MoveModuleBuilder.fromSummaryFile(
@@ -36,7 +40,7 @@ async function createBuilders(configArguments: ConfigArguments, packageConfigKey
 		'@test/testpkg',
 	);
 
-	const { entries } = parseConfigArguments({ global: configArguments }, registry);
+	const { entries } = parseConfigArguments({ global: configArguments }, registry, TESTPKG_CONTEXT);
 	counter.setConfigArguments(entries, packageConfigKey);
 	registryBuilder.setConfigArguments(entries, packageConfigKey);
 
@@ -149,7 +153,7 @@ function createPoolsBuilder(
 		importExtension: '.js',
 		typeOrigins: options.typeOrigins,
 	});
-	const { entries } = parseConfigArguments({ global: configArguments }, registry);
+	const { entries } = parseConfigArguments({ global: configArguments }, registry, TESTPKG_CONTEXT);
 	builder.setConfigArguments(entries);
 	return builder;
 }
@@ -176,7 +180,7 @@ describe('configArguments schema', () => {
 });
 
 describe('parseConfigArguments', () => {
-	it('parses type, instantiated type, and package matchers', async () => {
+	function createRegistry() {
 		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
 		new MoveModuleBuilder({
 			summary: poolsSummary() as any,
@@ -184,24 +188,28 @@ describe('parseConfigArguments', () => {
 			mvrNameOrAddress: '@test/testpkg',
 			importExtension: '.js',
 		});
+		return registry;
+	}
 
-		const { entries, unresolvedKeys } = parseConfigArguments(
+	it('parses package-qualified, framework-qualified, and package matchers', async () => {
+		const { entries } = parseConfigArguments(
 			{
 				global: {
-					pool: { type: 'testpkg::pools::Pool' },
-					suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+					pool: { type: '@test/testpkg::pools::Pool' },
+					suiPool: { type: '@test/testpkg::pools::Pool<0x2::sui::SUI>' },
 					pkg: { package: '@test/testpkg' },
 				},
 			},
-			registry,
+			createRegistry(),
+			TESTPKG_CONTEXT,
 		);
 
-		expect(unresolvedKeys).toEqual([]);
 		expect(entries).toMatchObject([
 			{
 				kind: 'type',
 				key: 'pool',
 				source: 'global',
+				address: '0x0000000000000000000000000000000000000000000000000000000000000000',
 				module: 'pools',
 				name: 'Pool',
 				typeArguments: null,
@@ -226,26 +234,78 @@ describe('parseConfigArguments', () => {
 		]);
 	});
 
-	it('merges package-scoped entries over global entries per key', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
+	it('resolves bare module::Type matchers against the declaring package', async () => {
+		const { entries } = parseConfigArguments(
+			{
+				package: {
+					pool: { type: 'pools::Pool' },
+					coinPool: { type: 'pools::Pool<pools::Coin>' },
+				},
+			},
+			createRegistry(),
+			TESTPKG_CONTEXT,
+		);
 
+		expect(entries).toMatchObject([
+			{
+				key: 'pool',
+				address: '0x0000000000000000000000000000000000000000000000000000000000000000',
+				module: 'pools',
+				name: 'Pool',
+				typeArguments: null,
+			},
+			{
+				key: 'coinPool',
+				typeArguments: [
+					{
+						datatype: {
+							address: '0x0000000000000000000000000000000000000000000000000000000000000000',
+							module: 'pools',
+							name: 'Coin',
+						},
+					},
+				],
+			},
+		]);
+	});
+
+	it('requires package qualification for global matchers', async () => {
+		expect(() =>
+			parseConfigArguments(
+				{ global: { pool: { type: 'pools::Pool' } } },
+				createRegistry(),
+				TESTPKG_CONTEXT,
+			),
+		).toThrowError(/must be qualified with a package in the global configArguments block/);
+	});
+
+	it('resolves other run packages through the packageAddresses map', async () => {
+		const { entries } = parseConfigArguments(
+			{ global: { pool: { type: '@other/pkg::pools::Pool' } } },
+			createRegistry(),
+			{
+				...TESTPKG_CONTEXT,
+				// @other/pkg resolves to the same summary package in this test closure.
+				packageAddresses: { '@other/pkg': ADDRESS_MAPPINGS.testpkg },
+			},
+		);
+
+		expect(entries).toMatchObject([{ key: 'pool', module: 'pools', name: 'Pool' }]);
+	});
+
+	it('merges package-scoped entries over global entries per key', async () => {
 		const { entries } = parseConfigArguments(
 			{
 				global: {
-					pool: { type: 'testpkg::pools::Pool' },
-					coin: { type: 'testpkg::pools::Coin' },
+					pool: { type: '@test/testpkg::pools::Pool' },
+					coin: { type: '@test/testpkg::pools::Coin' },
 				},
 				package: {
-					pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+					pool: { type: 'pools::Pool<0x2::sui::SUI>' },
 				},
 			},
-			registry,
+			createRegistry(),
+			TESTPKG_CONTEXT,
 		);
 
 		// Map insertion order keeps the global position for overridden keys.
@@ -255,107 +315,113 @@ describe('parseConfigArguments', () => {
 		]);
 	});
 
-	it('reports global matchers for types that are not in the summaries as unresolved', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
-
-		const { entries, unresolvedKeys } = parseConfigArguments(
-			{
-				global: {
-					missingType: { type: 'testpkg::pools::DoesNotExist' },
-					missingModule: { type: '0x999::other::Thing' },
-					pool: { type: 'testpkg::pools::Pool' },
+	it('skips matchers for run packages outside this dependency closure', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			// Global entries for other packages are silently inapplicable here (they are
+			// validated when their own package is generated).
+			const { entries } = parseConfigArguments(
+				{ global: { other: { type: '@other/pkg::vault::Vault' } } },
+				createRegistry(),
+				{
+					...TESTPKG_CONTEXT,
+					packageAddresses: {
+						'@other/pkg': '0x0000000000000000000000000000000000000000000000000000000000000042',
+					},
 				},
-			},
-			registry,
-		);
+			);
+			expect(entries).toEqual([]);
+			expect(warn).not.toHaveBeenCalled();
 
-		expect(unresolvedKeys).toEqual(['missingType', 'missingModule']);
-		expect(entries.map((entry) => entry.key)).toEqual(['pool']);
+			// A package-scoped entry referencing a package that is not a dependency can never
+			// match, which deserves a warning.
+			parseConfigArguments(
+				{ package: { other: { type: '@other/pkg::vault::Vault' } } },
+				createRegistry(),
+				{
+					...TESTPKG_CONTEXT,
+					packageAddresses: {
+						'@other/pkg': '0x0000000000000000000000000000000000000000000000000000000000000042',
+					},
+				},
+			);
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('will never match'));
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
-	it('errors for package-scoped matchers whose type is not in the summaries', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
-
+	it('errors when the matched type does not exist in a package that is part of the closure', async () => {
 		expect(() =>
 			parseConfigArguments(
-				{ package: { missing: { type: 'testpkg::pools::DoesNotExist' } } },
-				registry,
+				{ global: { missing: { type: '@test/testpkg::pools::DoesNotExist' } } },
+				createRegistry(),
+				TESTPKG_CONTEXT,
 			),
-		).toThrowError(/was not found in this package's summaries/);
+		).toThrowError(/was not found in its package's summaries/);
 	});
 
 	it('rejects malformed matcher types', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
+		const registry = createRegistry();
+		const parse = (type: string) =>
+			parseConfigArguments({ global: { bad: { type } } }, registry, TESTPKG_CONTEXT);
 
-		const parse = (type: string) => parseConfigArguments({ global: { bad: { type } } }, registry);
-
-		expect(() => parse('Pool')).toThrowError(/Expected a fully-qualified Move type/);
+		expect(() => parse('Pool')).toThrowError(/Expected "module::Type"/);
 		expect(() => parse('u64')).toThrowError(/must be a Move datatype/);
-		expect(() => parse('testpkg::pools::Pool<0x2::sui::SUI>>')).toThrowError(/unbalanced '>'/);
-		expect(() => parse('testpkg::pools::Pool<0x2::sui::SUI')).toThrowError(/unbalanced '</);
-		expect(() => parse('testpkg::pools::Coin<>')).toThrowError(/empty type argument/);
-		expect(() => parse('testpkg::pools::Pool <0x2::sui::SUI>')).toThrowError(
+		expect(() => parse('@test/testpkg::pools::Pool<0x2::sui::SUI>>')).toThrowError(
+			/unbalanced '>'/,
+		);
+		expect(() => parse('@test/testpkg::pools::Pool<0x2::sui::SUI')).toThrowError(/unbalanced '</);
+		expect(() => parse('@test/testpkg::pools::Coin<>')).toThrowError(/empty type argument/);
+		expect(() => parse('@test/testpkg::pools::Pool <0x2::sui::SUI>')).toThrowError(
 			/is not a valid module::type pair/,
 		);
-		expect(() => parse('testpkg::pools::Pool<2::sui::SUI>')).toThrowError(/Invalid address "2"/);
-		expect(() => parse('@test/testpkg::pools::Pool')).toThrowError(
-			/MVR names cannot be matched against package summaries/,
+		expect(() => parse('2::sui::SUI')).toThrowError(/Unknown package "2"/);
+		expect(() => parse('@unknown/pkg::pools::Pool')).toThrowError(
+			/Unknown package "@unknown\/pkg"/,
+		);
+	});
+
+	it('rejects non-framework package addresses', async () => {
+		const registry = createRegistry();
+		const parse = (type: string) =>
+			parseConfigArguments({ global: { bad: { type } } }, registry, TESTPKG_CONTEXT);
+
+		expect(() => parse('0x999::vault::Vault')).toThrowError(
+			/package addresses are network-specific/,
+		);
+		expect(() => parse('@test/testpkg::pools::Pool<0xabc123::coin::COIN>')).toThrowError(
+			/package addresses are network-specific/,
 		);
 	});
 
 	it('rejects partially instantiated matchers with a dedicated error', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
+		const registry = createRegistry();
 
 		expect(() =>
-			parseConfigArguments({ global: { pool: { type: 'testpkg::pools::Pool<T>' } } }, registry),
+			parseConfigArguments(
+				{ global: { pool: { type: '@test/testpkg::pools::Pool<T>' } } },
+				registry,
+				TESTPKG_CONTEXT,
+			),
 		).toThrowError(/partially instantiated matchers are not supported/);
 
 		// A nested uninstantiated generic is also a partial instantiation.
 		expect(() =>
 			parseConfigArguments(
-				{ global: { pool: { type: 'testpkg::pools::Pool<testpkg::pools::Pool>' } } },
+				{ global: { pool: { type: '@test/testpkg::pools::Pool<@test/testpkg::pools::Pool>' } } },
 				registry,
+				TESTPKG_CONTEXT,
 			),
 		).toThrowError(/Partially instantiated matchers are not supported/);
 	});
 
 	it('rejects instantiated matchers with the wrong arity', async () => {
-		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
-		new MoveModuleBuilder({
-			summary: poolsSummary() as any,
-			registry,
-			mvrNameOrAddress: '@test/testpkg',
-			importExtension: '.js',
-		});
-
 		expect(() =>
 			parseConfigArguments(
-				{ global: { pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI, u64>' } } },
-				registry,
+				{ global: { pool: { type: '@test/testpkg::pools::Pool<0x2::sui::SUI, u64>' } } },
+				createRegistry(),
+				TESTPKG_CONTEXT,
 			),
 		).toThrowError(/expects 1 type argument\(s\), got 2/);
 	});
@@ -364,7 +430,7 @@ describe('parseConfigArguments', () => {
 describe('config-driven function codegen', () => {
 	it('non-generic matcher: matched parameter becomes optional with an optional config slice', async () => {
 		const { registry } = await createBuilders({
-			registryObj: { type: 'testpkg::registry::Registry' },
+			registryObj: { type: '@test/testpkg::registry::Registry' },
 		});
 		registry.includeFunctions(['register']);
 		const output = await render(registry);
@@ -415,7 +481,7 @@ describe('config-driven function codegen', () => {
 
 	it('makes arguments optional and the tuple suffix optional when every parameter is config-matched', async () => {
 		const { registry } = await createBuilders({
-			registryObj: { type: 'testpkg::registry::Registry' },
+			registryObj: { type: '@test/testpkg::registry::Registry' },
 		});
 		registry.includeFunctions(['lookup']);
 		const output = await render(registry);
@@ -453,7 +519,7 @@ describe('config-driven function codegen', () => {
 
 	it('uninstantiated generic matcher: config value requires a resolver and receives the parameter instantiation', async () => {
 		const { registry } = await createBuilders({
-			container: { type: 'testpkg::registry::Container' },
+			container: { type: '@test/testpkg::registry::Container' },
 		});
 		registry.includeFunctions(['container_size']);
 		const output = await render(registry);
@@ -495,8 +561,8 @@ describe('config-driven function codegen', () => {
 
 	it('instantiated matcher only matches concrete instantiations and wins over the uninstantiated matcher', async () => {
 		const builder = createPoolsBuilder({
-			pool: { type: 'testpkg::pools::Pool' },
-			suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+			pool: { type: '@test/testpkg::pools::Pool' },
+			suiPool: { type: '@test/testpkg::pools::Pool<0x2::sui::SUI>' },
 		});
 		builder.includeFunctions(['use_generic', 'use_concrete']);
 		const output = await render(builder);
@@ -576,7 +642,7 @@ describe('config-driven function codegen', () => {
 
 	it('resolver context tags for own-package types use the package name, not the placeholder address', async () => {
 		const builder = createPoolsBuilder({
-			pool: { type: 'testpkg::pools::Pool' },
+			pool: { type: '@test/testpkg::pools::Pool' },
 		});
 		builder.includeFunctions(['use_own_coin']);
 		const output = await render(builder);
@@ -588,7 +654,7 @@ describe('config-driven function codegen', () => {
 	it('resolver context tags use origin addresses for upgraded packages', async () => {
 		const ORIGIN_V1 = '0x000000000000000000000000000000000000000000000000000000000000aaaa';
 		const builder = createPoolsBuilder(
-			{ pool: { type: 'testpkg::pools::Pool' } },
+			{ pool: { type: '@test/testpkg::pools::Pool' } },
 			{ typeOrigins: { Coin: ORIGIN_V1 } },
 		);
 		builder.includeFunctions(['use_own_coin']);
@@ -600,7 +666,7 @@ describe('config-driven function codegen', () => {
 
 	it('errors when a bare matcher hits two named parameters in one signature', async () => {
 		const builder = createPoolsBuilder({
-			pool: { type: 'testpkg::pools::Pool' },
+			pool: { type: '@test/testpkg::pools::Pool' },
 		});
 		builder.includeFunctions(['swap']);
 
@@ -613,7 +679,7 @@ describe('config-driven function codegen', () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		try {
 			const builder = createPoolsBuilder(
-				{ pool: { type: 'testpkg::pools::Pool' } },
+				{ pool: { type: '@test/testpkg::pools::Pool' } },
 				{ parameterNames: false },
 			);
 			builder.includeFunctions(['swap']);
@@ -632,7 +698,7 @@ describe('config-driven function codegen', () => {
 
 	it('generates tuple-only bindings for nameless summaries with a matched parameter', async () => {
 		const builder = createPoolsBuilder(
-			{ pool: { type: 'testpkg::pools::Pool' } },
+			{ pool: { type: '@test/testpkg::pools::Pool' } },
 			{ parameterNames: false },
 		);
 		builder.includeFunctions(['use_generic']);
@@ -676,8 +742,8 @@ describe('config-driven function codegen', () => {
 
 	it('name refinement disambiguates two parameters of the same type', async () => {
 		const builder = createPoolsBuilder({
-			basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
-			quotePool: { type: 'testpkg::pools::Pool', parameterName: 'quote_pool' },
+			basePool: { type: '@test/testpkg::pools::Pool', parameterName: 'base_pool' },
+			quotePool: { type: '@test/testpkg::pools::Pool', parameterName: 'quote_pool' },
 		});
 		builder.includeFunctions(['swap']);
 		const output = await render(builder);
@@ -723,9 +789,9 @@ describe('config-driven function codegen', () => {
 
 	it('name-refined matchers win over a bare matcher for the same type', async () => {
 		const builder = createPoolsBuilder({
-			pool: { type: 'testpkg::pools::Pool' },
-			basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
-			quotePool: { type: 'testpkg::pools::Pool', parameterName: 'quote_pool' },
+			pool: { type: '@test/testpkg::pools::Pool' },
+			basePool: { type: '@test/testpkg::pools::Pool', parameterName: 'base_pool' },
+			quotePool: { type: '@test/testpkg::pools::Pool', parameterName: 'quote_pool' },
 		});
 		builder.includeFunctions(['swap', 'use_generic']);
 		const output = await render(builder);
@@ -742,8 +808,8 @@ describe('config-driven function codegen', () => {
 
 	it('errors when two matchers of equal specificity hit the same parameter', async () => {
 		const builder = createPoolsBuilder({
-			poolA: { type: 'testpkg::pools::Pool' },
-			poolB: { type: 'testpkg::pools::Pool' },
+			poolA: { type: '@test/testpkg::pools::Pool' },
+			poolB: { type: '@test/testpkg::pools::Pool' },
 		});
 		builder.includeFunctions(['use_generic']);
 
@@ -754,7 +820,7 @@ describe('config-driven function codegen', () => {
 
 	it('errors when a name matcher would apply to a nameless parameter and nothing else matches', async () => {
 		const builder = createPoolsBuilder(
-			{ basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' } },
+			{ basePool: { type: '@test/testpkg::pools::Pool', parameterName: 'base_pool' } },
 			{ parameterNames: false },
 		);
 		builder.includeFunctions(['swap']);
@@ -769,7 +835,7 @@ describe('config-driven function codegen', () => {
 		// Pool<Coin>, so the matcher is filtered by instantiation before the nameless check.
 		const builder = createPoolsBuilder(
 			{
-				suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>', parameterName: 'sui_pool' },
+				suiPool: { type: '@test/testpkg::pools::Pool<0x2::sui::SUI>', parameterName: 'sui_pool' },
 			},
 			{ parameterNames: false },
 		);
@@ -783,8 +849,8 @@ describe('config-driven function codegen', () => {
 	it('falls back to a bare matcher instead of erroring when a name matcher hits a nameless parameter', async () => {
 		const builder = createPoolsBuilder(
 			{
-				pool: { type: 'testpkg::pools::Pool' },
-				basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
+				pool: { type: '@test/testpkg::pools::Pool' },
+				basePool: { type: '@test/testpkg::pools::Pool', parameterName: 'base_pool' },
 			},
 			{ parameterNames: false },
 		);
@@ -798,7 +864,7 @@ describe('config-driven function codegen', () => {
 	it('package entries are added to the package-address precedence chain', async () => {
 		const { registry } = await createBuilders(
 			{
-				registryObj: { type: 'testpkg::registry::Registry' },
+				registryObj: { type: '@test/testpkg::registry::Registry' },
 				testpkgAddress: { package: '@test/testpkg' },
 			},
 			'testpkgAddress',
@@ -853,11 +919,12 @@ describe('config-driven function codegen', () => {
 		const { entries } = parseConfigArguments(
 			{
 				global: {
-					registryObj: { type: 'testpkg::registry::Registry' },
+					registryObj: { type: '@test/testpkg::registry::Registry' },
 					testpkgAddress: { package: '@test/testpkg' },
 				},
 			},
 			registry,
+			TESTPKG_CONTEXT,
 		);
 		builder.setConfigArguments(entries, 'testpkgAddress');
 		builder.includeTypes(['Registry']);
@@ -884,7 +951,7 @@ describe('generateFromPackageSummary with configArguments', () => {
 
 	async function generate() {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-		const result = await generateFromPackageSummary({
+		await generateFromPackageSummary({
 			package: {
 				package: '@test/testpkg',
 				path: FIXTURE_PATH,
@@ -892,25 +959,24 @@ describe('generateFromPackageSummary with configArguments', () => {
 			prune: true,
 			outputDir: GENERATED_DIR,
 			configArguments: {
-				registryObj: { type: 'testpkg::registry::Registry' },
-				container: { type: 'testpkg::registry::Container' },
+				registryObj: { type: '@test/testpkg::registry::Registry' },
+				container: { type: '@test/testpkg::registry::Container' },
 				testpkgAddress: { package: '@test/testpkg' },
-				missing: { type: 'testpkg::registry::DoesNotExist' },
-				unusedEntry: { type: 'testpkg::registry::Entry' },
+				unusedEntry: { type: '@test/testpkg::registry::Entry' },
 			},
 		});
-		return { warn, result };
+		return warn;
 	}
 
-	it('emits config-arguments.ts and config-driven bindings, reporting unresolved and unused keys', async () => {
-		const { warn, result } = await generate();
+	it('emits config-arguments.ts and config-driven bindings, warning on unused keys', async () => {
+		const warn = await generate();
 
-		expect(warn).toHaveBeenCalledWith(
-			'configArguments keys not resolvable in @test/testpkg (skipped): missing',
-		);
-		expect(result.unresolvedConfigKeys).toEqual(['missing']);
 		// Entry is a plain store struct that no generated function takes as a parameter.
-		expect(result.unusedConfigKeys).toEqual(['unusedEntry']);
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'configArguments keys that matched no generated function parameters in @test/testpkg: unusedEntry',
+			),
+		);
 
 		const configArgs = await readFile(
 			join(GENERATED_DIR, 'testpkg', 'config-arguments.ts'),
@@ -935,20 +1001,20 @@ describe('generateFromPackageSummary with configArguments', () => {
 		expect(registryModule).toContain('resolveConfigArgument');
 	});
 
-	it('errors for unresolved keys in a package-scoped block', async () => {
+	it('errors when a matcher references a type missing from its package', async () => {
 		await expect(
 			generateFromPackageSummary({
 				package: {
 					package: '@test/testpkg',
 					path: FIXTURE_PATH,
 					configArguments: {
-						missing: { type: 'testpkg::registry::DoesNotExist' },
+						missing: { type: '@test/testpkg::registry::DoesNotExist' },
 					},
 				},
 				prune: true,
 				outputDir: GENERATED_DIR,
 			}),
-		).rejects.toThrowError(/was not found in this package's summaries/);
+		).rejects.toThrowError(/was not found in its package's summaries/);
 	});
 
 	it('warns for unused keys in a package-scoped block', async () => {
@@ -958,7 +1024,7 @@ describe('generateFromPackageSummary with configArguments', () => {
 				package: '@test/testpkg',
 				path: FIXTURE_PATH,
 				configArguments: {
-					unusedEntry: { type: 'testpkg::registry::Entry' },
+					unusedEntry: { type: '@test/testpkg::registry::Entry' },
 				},
 			},
 			prune: true,

--- a/packages/codegen/tests/config-arguments.test.ts
+++ b/packages/codegen/tests/config-arguments.test.ts
@@ -10,6 +10,7 @@ import { ModuleRegistry } from '../src/module-registry.js';
 import { MoveModuleBuilder } from '../src/move-module-builder.js';
 import { parseConfigArguments } from '../src/config-arguments.js';
 import { generateFromPackageSummary } from '../src/index.js';
+import { configArgumentsSchema } from '../src/config.js';
 import type { ConfigArguments } from '../src/config.js';
 
 const FIXTURE_PATH = join(__dirname, 'move/testpkg');
@@ -35,7 +36,7 @@ async function createBuilders(configArguments: ConfigArguments, packageConfigKey
 		'@test/testpkg',
 	);
 
-	const { entries } = parseConfigArguments(configArguments, registry);
+	const { entries } = parseConfigArguments({ global: configArguments }, registry);
 	counter.setConfigArguments(entries, packageConfigKey);
 	registryBuilder.setConfigArguments(entries, packageConfigKey);
 
@@ -49,7 +50,8 @@ async function render(builder: MoveModuleBuilder) {
 
 /**
  * A synthetic module with a generic `Pool<phantom T>` type used by functions in generic,
- * concretely-instantiated, and same-type-twice positions.
+ * concretely-instantiated, and same-type-twice positions, plus a `Coin` type used as a concrete
+ * own-package type argument.
  */
 function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = {}) {
 	const poolType = (typeArgument: unknown) => ({
@@ -66,6 +68,9 @@ function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = 
 	});
 	const suiType = {
 		Datatype: { module: { address: 'sui', name: 'sui' }, name: 'SUI', type_arguments: [] },
+	};
+	const ownCoinType = {
+		Datatype: { module: { address: 'testpkg', name: 'pools' }, name: 'Coin', type_arguments: [] },
 	};
 	const param = (name: string, type_: unknown) => (parameterNames ? { name, type_ } : { type_ });
 	const fn = (parameters: unknown[], type_parameters: unknown[] = []) => ({
@@ -92,6 +97,7 @@ function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = 
 				[{ name: 'T', phantom: false, constraints: [] }],
 			),
 			use_concrete: fn([param('pool', poolType(suiType)), param('amount', 'u64')]),
+			use_own_coin: fn([param('pool', poolType(ownCoinType)), param('amount', 'u64')]),
 			swap: fn(
 				[
 					param('base_pool', poolType({ TypeParameter: 0 })),
@@ -115,6 +121,17 @@ function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = 
 					fields: { id: { index: 0, doc: null, type_: 'address' } },
 				},
 			},
+			Coin: {
+				index: 1,
+				doc: '',
+				attributes: [],
+				abilities: ['Store'],
+				type_parameters: [],
+				fields: {
+					positional_fields: false,
+					fields: { value: { index: 0, doc: null, type_: 'u64' } },
+				},
+			},
 		},
 		enums: {},
 	};
@@ -122,7 +139,7 @@ function poolsSummary({ parameterNames = true }: { parameterNames?: boolean } = 
 
 function createPoolsBuilder(
 	configArguments: ConfigArguments,
-	options: { parameterNames?: boolean } = {},
+	options: { parameterNames?: boolean; typeOrigins?: Record<string, string> } = {},
 ) {
 	const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
 	const builder = new MoveModuleBuilder({
@@ -130,11 +147,33 @@ function createPoolsBuilder(
 		registry,
 		mvrNameOrAddress: '@test/testpkg',
 		importExtension: '.js',
+		typeOrigins: options.typeOrigins,
 	});
-	const { entries } = parseConfigArguments(configArguments, registry);
+	const { entries } = parseConfigArguments({ global: configArguments }, registry);
 	builder.setConfigArguments(entries);
 	return builder;
 }
+
+describe('configArguments schema', () => {
+	it('rejects prototype-polluting keys', () => {
+		// zod itself drops `__proto__` record keys; the others are rejected by the key schema.
+		expect(
+			Object.keys(configArgumentsSchema.parse({ ['__proto__']: { type: '0x2::sui::SUI' } })),
+		).toEqual([]);
+		expect(() =>
+			configArgumentsSchema.parse({ constructor: { type: '0x2::sui::SUI' } }),
+		).toThrowError(/prototype property names/);
+		expect(() =>
+			configArgumentsSchema.parse({ prototype: { type: '0x2::sui::SUI' } }),
+		).toThrowError(/prototype property names/);
+	});
+
+	it('rejects matchers mixing type and package', () => {
+		expect(() =>
+			configArgumentsSchema.parse({ both: { type: '0x2::sui::SUI', package: '@x/y' } }),
+		).toThrowError();
+	});
+});
 
 describe('parseConfigArguments', () => {
 	it('parses type, instantiated type, and package matchers', async () => {
@@ -148,9 +187,11 @@ describe('parseConfigArguments', () => {
 
 		const { entries, unresolvedKeys } = parseConfigArguments(
 			{
-				pool: { type: 'testpkg::pools::Pool' },
-				suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
-				pkg: { package: '@test/testpkg' },
+				global: {
+					pool: { type: 'testpkg::pools::Pool' },
+					suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+					pkg: { package: '@test/testpkg' },
+				},
 			},
 			registry,
 		);
@@ -160,6 +201,7 @@ describe('parseConfigArguments', () => {
 			{
 				kind: 'type',
 				key: 'pool',
+				source: 'global',
 				module: 'pools',
 				name: 'Pool',
 				typeArguments: null,
@@ -184,7 +226,36 @@ describe('parseConfigArguments', () => {
 		]);
 	});
 
-	it('reports matchers for types that are not in the summaries as unresolved', async () => {
+	it('merges package-scoped entries over global entries per key', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		const { entries } = parseConfigArguments(
+			{
+				global: {
+					pool: { type: 'testpkg::pools::Pool' },
+					coin: { type: 'testpkg::pools::Coin' },
+				},
+				package: {
+					pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>' },
+				},
+			},
+			registry,
+		);
+
+		// Map insertion order keeps the global position for overridden keys.
+		expect(entries).toMatchObject([
+			{ key: 'pool', source: 'package', typeArguments: [{ datatype: { name: 'SUI' } }] },
+			{ key: 'coin', source: 'global', typeArguments: [] },
+		]);
+	});
+
+	it('reports global matchers for types that are not in the summaries as unresolved', async () => {
 		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
 		new MoveModuleBuilder({
 			summary: poolsSummary() as any,
@@ -195,9 +266,11 @@ describe('parseConfigArguments', () => {
 
 		const { entries, unresolvedKeys } = parseConfigArguments(
 			{
-				missingType: { type: 'testpkg::pools::DoesNotExist' },
-				missingModule: { type: '0x999::other::Thing' },
-				pool: { type: 'testpkg::pools::Pool' },
+				global: {
+					missingType: { type: 'testpkg::pools::DoesNotExist' },
+					missingModule: { type: '0x999::other::Thing' },
+					pool: { type: 'testpkg::pools::Pool' },
+				},
 			},
 			registry,
 		);
@@ -206,15 +279,68 @@ describe('parseConfigArguments', () => {
 		expect(entries.map((entry) => entry.key)).toEqual(['pool']);
 	});
 
+	it('errors for package-scoped matchers whose type is not in the summaries', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		expect(() =>
+			parseConfigArguments(
+				{ package: { missing: { type: 'testpkg::pools::DoesNotExist' } } },
+				registry,
+			),
+		).toThrowError(/was not found in this package's summaries/);
+	});
+
 	it('rejects malformed matcher types', async () => {
 		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
 
-		expect(() => parseConfigArguments({ bad: { type: 'Pool' } }, registry)).toThrowError(
-			/Expected a fully-qualified Move type/,
+		const parse = (type: string) => parseConfigArguments({ global: { bad: { type } } }, registry);
+
+		expect(() => parse('Pool')).toThrowError(/Expected a fully-qualified Move type/);
+		expect(() => parse('u64')).toThrowError(/must be a Move datatype/);
+		expect(() => parse('testpkg::pools::Pool<0x2::sui::SUI>>')).toThrowError(/unbalanced '>'/);
+		expect(() => parse('testpkg::pools::Pool<0x2::sui::SUI')).toThrowError(/unbalanced '</);
+		expect(() => parse('testpkg::pools::Coin<>')).toThrowError(/empty type argument/);
+		expect(() => parse('testpkg::pools::Pool <0x2::sui::SUI>')).toThrowError(
+			/is not a valid module::type pair/,
 		);
-		expect(() => parseConfigArguments({ bad: { type: 'u64' } }, registry)).toThrowError(
-			/must be a Move datatype/,
+		expect(() => parse('testpkg::pools::Pool<2::sui::SUI>')).toThrowError(/Invalid address "2"/);
+		expect(() => parse('@test/testpkg::pools::Pool')).toThrowError(
+			/MVR names cannot be matched against package summaries/,
 		);
+	});
+
+	it('rejects partially instantiated matchers with a dedicated error', async () => {
+		const registry = new ModuleRegistry(ADDRESS_MAPPINGS);
+		new MoveModuleBuilder({
+			summary: poolsSummary() as any,
+			registry,
+			mvrNameOrAddress: '@test/testpkg',
+			importExtension: '.js',
+		});
+
+		expect(() =>
+			parseConfigArguments({ global: { pool: { type: 'testpkg::pools::Pool<T>' } } }, registry),
+		).toThrowError(/partially instantiated matchers are not supported/);
+
+		// A nested uninstantiated generic is also a partial instantiation.
+		expect(() =>
+			parseConfigArguments(
+				{ global: { pool: { type: 'testpkg::pools::Pool<testpkg::pools::Pool>' } } },
+				registry,
+			),
+		).toThrowError(/Partially instantiated matchers are not supported/);
 	});
 
 	it('rejects instantiated matchers with the wrong arity', async () => {
@@ -228,7 +354,7 @@ describe('parseConfigArguments', () => {
 
 		expect(() =>
 			parseConfigArguments(
-				{ pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI, u64>' } },
+				{ global: { pool: { type: 'testpkg::pools::Pool<0x2::sui::SUI, u64>' } } },
 				registry,
 			),
 		).toThrowError(/expects 1 type argument\(s\), got 2/);
@@ -236,7 +362,7 @@ describe('parseConfigArguments', () => {
 });
 
 describe('config-driven function codegen', () => {
-	it('non-generic matcher: matched parameter becomes optional with a required config slice', async () => {
+	it('non-generic matcher: matched parameter becomes optional with an optional config slice', async () => {
 		const { registry } = await createBuilders({
 			registryObj: { type: 'testpkg::registry::Registry' },
 		});
@@ -261,7 +387,7 @@ describe('config-driven function codegen', () => {
 			        name: RawTransactionArgument<string>,
 			        tags: RawTransactionArgument<Array<string>>
 			    ];
-			    config: {
+			    config?: {
 			        registryObj: ConfigValue;
 			    };
 			}"
@@ -281,13 +407,13 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'register',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "registry", resolve: () => resolveConfigArg(options.config.registryObj, { typeArguments: [] }, "registryObj") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'register', parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
 	});
 
-	it('makes arguments optional when every parameter is config-matched', async () => {
+	it('makes arguments optional and the tuple suffix optional when every parameter is config-matched', async () => {
 		const { registry } = await createBuilders({
 			registryObj: { type: 'testpkg::registry::Registry' },
 		});
@@ -299,9 +425,9 @@ describe('config-driven function codegen', () => {
 			"export interface LookupOptions {
 			    package?: string;
 			    arguments?: LookupArguments | [
-			        registry: RawTransactionArgument<string> | undefined
+			        registry?: RawTransactionArgument<string>
 			    ];
-			    config: {
+			    config?: {
 			        registryObj: ConfigValue;
 			    };
 			}"
@@ -319,7 +445,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'lookup',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "registry", resolve: () => resolveConfigArg(options.config.registryObj, { typeArguments: [] }, "registryObj") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "registry", resolve: () => resolveConfigArgument(options.config?.registryObj, { typeArguments: [], packageAddress, moduleName: 'registry', functionName: 'lookup', parameterName: "registry" }, "registryObj") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
@@ -337,9 +463,9 @@ describe('config-driven function codegen', () => {
 			"export interface ContainerSizeOptions {
 			    package?: string;
 			    arguments?: ContainerSizeArguments | [
-			        container: RawTransactionArgument<string> | undefined
+			        container?: RawTransactionArgument<string>
 			    ];
-			    config: {
+			    config?: {
 			        container: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 			    };
 			    typeArguments: [
@@ -360,7 +486,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'registry',
 			        function: 'container_size',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "container", resolve: () => resolveConfigArg(options.config.container, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "container") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "container", resolve: () => resolveConfigArgument(options.config?.container, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'registry', functionName: 'container_size', parameterName: "container" }, "container") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -385,7 +511,7 @@ describe('config-driven function codegen', () => {
 			        pool: RawTransactionArgument<string> | undefined,
 			        amount: RawTransactionArgument<number | bigint>
 			    ];
-			    config: {
+			    config?: {
 			        suiPool: ConfigValue;
 			    };
 			}"
@@ -404,7 +530,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'use_concrete',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArg(options.config.suiPool, { typeArguments: ['0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'] }, "suiPool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.suiPool, { typeArguments: ['0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI'], packageAddress, moduleName: 'pools', functionName: 'use_concrete', parameterName: "pool" }, "suiPool") }]), argumentsTypes, parameterNames),
 			    });
 			}"
 		`);
@@ -419,7 +545,7 @@ describe('config-driven function codegen', () => {
 			        pool: RawTransactionArgument<string> | undefined,
 			        amount: RawTransactionArgument<number | bigint>
 			    ];
-			    config: {
+			    config?: {
 			        pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 			    };
 			    typeArguments: [
@@ -441,14 +567,38 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'use_generic',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArg(options.config.pool, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "pool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, name: "pool", resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic', parameterName: "pool" }, "pool") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
 		`);
 	});
 
-	it('errors when a bare matcher hits two parameters in one signature', async () => {
+	it('resolver context tags for own-package types use the package name, not the placeholder address', async () => {
+		const builder = createPoolsBuilder({
+			pool: { type: 'testpkg::pools::Pool' },
+		});
+		builder.includeFunctions(['use_own_coin']);
+		const output = await render(builder);
+
+		const fnBody = output.match(/export function useOwnCoin[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain("typeArguments: ['@test/testpkg::pools::Coin']");
+	});
+
+	it('resolver context tags use origin addresses for upgraded packages', async () => {
+		const ORIGIN_V1 = '0x000000000000000000000000000000000000000000000000000000000000aaaa';
+		const builder = createPoolsBuilder(
+			{ pool: { type: 'testpkg::pools::Pool' } },
+			{ typeOrigins: { Coin: ORIGIN_V1 } },
+		);
+		builder.includeFunctions(['use_own_coin']);
+		const output = await render(builder);
+
+		const fnBody = output.match(/export function useOwnCoin[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toContain(`typeArguments: ['${ORIGIN_V1}::pools::Coin']`);
+	});
+
+	it('errors when a bare matcher hits two named parameters in one signature', async () => {
 		const builder = createPoolsBuilder({
 			pool: { type: 'testpkg::pools::Pool' },
 		});
@@ -459,10 +609,75 @@ describe('config-driven function codegen', () => {
 		);
 	});
 
+	it('warns and skips config mapping when a bare matcher hits two nameless parameters', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			const builder = createPoolsBuilder(
+				{ pool: { type: 'testpkg::pools::Pool' } },
+				{ parameterNames: false },
+			);
+			builder.includeFunctions(['swap']);
+			const output = await render(builder);
+
+			expect(warn).toHaveBeenCalledWith(
+				expect.stringContaining('configArguments.pool matches multiple parameters'),
+			);
+			// swap is still generated, without config mapping.
+			const optionsInterface = output.match(/export interface SwapOptions[\s\S]*?^}/m);
+			expect(optionsInterface?.[0]).not.toContain('config');
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it('generates tuple-only bindings for nameless summaries with a matched parameter', async () => {
+		const builder = createPoolsBuilder(
+			{ pool: { type: 'testpkg::pools::Pool' } },
+			{ parameterNames: false },
+		);
+		builder.includeFunctions(['use_generic']);
+		const output = await render(builder);
+
+		const optionsInterface = output.match(/export interface UseGenericOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toMatchInlineSnapshot(`
+			"export interface UseGenericOptions {
+			    package?: string;
+			    arguments: [
+			        RawTransactionArgument<string> | undefined,
+			        RawTransactionArgument<number | bigint>
+			    ];
+			    config?: {
+			        pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+			    };
+			    typeArguments: [
+			        string
+			    ];
+			}"
+		`);
+
+		const fnBody = output.match(/export function useGeneric[\s\S]*?^}/m);
+		expect(fnBody?.[0]).toMatchInlineSnapshot(`
+			"export function useGeneric(options: UseGenericOptions) {
+			    const packageAddress = options.package ?? '@test/testpkg';
+			    const argumentsTypes = [
+			        null,
+			        'u64'
+			    ] satisfies (string | null)[];
+			    return (tx: Transaction) => tx.moveCall({
+			        package: packageAddress,
+			        module: 'pools',
+			        function: 'use_generic',
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments, [{ index: 0, resolve: () => resolveConfigArgument(options.config?.pool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'use_generic' }, "pool") }]), argumentsTypes),
+			        typeArguments: options.typeArguments
+			    });
+			}"
+		`);
+	});
+
 	it('name refinement disambiguates two parameters of the same type', async () => {
 		const builder = createPoolsBuilder({
-			basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' },
-			quotePool: { type: 'testpkg::pools::Pool', name: 'quote_pool' },
+			basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
+			quotePool: { type: 'testpkg::pools::Pool', parameterName: 'quote_pool' },
 		});
 		builder.includeFunctions(['swap']);
 		const output = await render(builder);
@@ -472,10 +687,10 @@ describe('config-driven function codegen', () => {
 			"export interface SwapOptions {
 			    package?: string;
 			    arguments?: SwapArguments | [
-			        basePool: RawTransactionArgument<string> | undefined,
-			        quotePool: RawTransactionArgument<string> | undefined
+			        basePool?: RawTransactionArgument<string>,
+			        quotePool?: RawTransactionArgument<string>
 			    ];
-			    config: {
+			    config?: {
 			        basePool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 			        quotePool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 			    };
@@ -499,7 +714,7 @@ describe('config-driven function codegen', () => {
 			        package: packageAddress,
 			        module: 'pools',
 			        function: 'swap',
-			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "basePool", resolve: () => resolveConfigArg(options.config.basePool, { typeArguments: [\`\${options.typeArguments[0]}\`] }, "basePool") }, { index: 1, name: "quotePool", resolve: () => resolveConfigArg(options.config.quotePool, { typeArguments: [\`\${options.typeArguments[1]}\`] }, "quotePool") }]), argumentsTypes, parameterNames),
+			        arguments: normalizeMoveArguments(applyConfigArguments(options.arguments ?? {}, [{ index: 0, name: "basePool", resolve: () => resolveConfigArgument(options.config?.basePool, { typeArguments: [\`\${options.typeArguments[0]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterName: "base_pool" }, "basePool") }, { index: 1, name: "quotePool", resolve: () => resolveConfigArgument(options.config?.quotePool, { typeArguments: [\`\${options.typeArguments[1]}\`], packageAddress, moduleName: 'pools', functionName: 'swap', parameterName: "quote_pool" }, "quotePool") }]), argumentsTypes, parameterNames),
 			        typeArguments: options.typeArguments
 			    });
 			}"
@@ -509,8 +724,8 @@ describe('config-driven function codegen', () => {
 	it('name-refined matchers win over a bare matcher for the same type', async () => {
 		const builder = createPoolsBuilder({
 			pool: { type: 'testpkg::pools::Pool' },
-			basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' },
-			quotePool: { type: 'testpkg::pools::Pool', name: 'quote_pool' },
+			basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
+			quotePool: { type: 'testpkg::pools::Pool', parameterName: 'quote_pool' },
 		});
 		builder.includeFunctions(['swap', 'use_generic']);
 		const output = await render(builder);
@@ -537,16 +752,47 @@ describe('config-driven function codegen', () => {
 		);
 	});
 
-	it('errors when a name matcher targets a summary without parameter names', async () => {
+	it('errors when a name matcher would apply to a nameless parameter and nothing else matches', async () => {
 		const builder = createPoolsBuilder(
-			{ basePool: { type: 'testpkg::pools::Pool', name: 'base_pool' } },
+			{ basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' } },
 			{ parameterNames: false },
 		);
 		builder.includeFunctions(['swap']);
 
 		await expect(render(builder)).rejects.toThrowError(
-			/parameters of testpkg::pools::swap have no names/,
+			/parameters have no names \(bytecode summaries do not include parameter names\)/,
 		);
+	});
+
+	it('does not error for a name matcher whose instantiation cannot match the nameless parameter', async () => {
+		// The instantiated+named matcher targets Pool<SUI>; use_own_coin's parameter is
+		// Pool<Coin>, so the matcher is filtered by instantiation before the nameless check.
+		const builder = createPoolsBuilder(
+			{
+				suiPool: { type: 'testpkg::pools::Pool<0x2::sui::SUI>', parameterName: 'sui_pool' },
+			},
+			{ parameterNames: false },
+		);
+		builder.includeFunctions(['use_own_coin']);
+		const output = await render(builder);
+
+		const optionsInterface = output.match(/export interface UseOwnCoinOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).not.toContain('config');
+	});
+
+	it('falls back to a bare matcher instead of erroring when a name matcher hits a nameless parameter', async () => {
+		const builder = createPoolsBuilder(
+			{
+				pool: { type: 'testpkg::pools::Pool' },
+				basePool: { type: 'testpkg::pools::Pool', parameterName: 'base_pool' },
+			},
+			{ parameterNames: false },
+		);
+		builder.includeFunctions(['use_generic']);
+		const output = await render(builder);
+
+		const optionsInterface = output.match(/export interface UseGenericOptions[\s\S]*?^}/m);
+		expect(optionsInterface?.[0]).toContain('pool:');
 	});
 
 	it('package entries are added to the package-address precedence chain', async () => {
@@ -562,7 +808,7 @@ describe('config-driven function codegen', () => {
 
 		const fnBody = output.match(/export function lookup[\s\S]*?^}/m);
 		expect(fnBody?.[0]).toContain(
-			"const packageAddress = options.package ?? options.config.testpkgAddress ?? '@test/testpkg';",
+			"const packageAddress = options.package ?? options.config?.testpkgAddress ?? '@test/testpkg';",
 		);
 	});
 
@@ -606,8 +852,10 @@ describe('config-driven function codegen', () => {
 		);
 		const { entries } = parseConfigArguments(
 			{
-				registryObj: { type: 'testpkg::registry::Registry' },
-				testpkgAddress: { package: '@test/testpkg' },
+				global: {
+					registryObj: { type: 'testpkg::registry::Registry' },
+					testpkgAddress: { package: '@test/testpkg' },
+				},
 			},
 			registry,
 		);
@@ -620,7 +868,7 @@ describe('config-driven function codegen', () => {
 		// BCS type names keep the origin address; the call package comes from the config chain.
 		expect(output).toContain(`name: \`${ORIGIN_V1}::registry::Registry\``);
 		expect(output).toContain(
-			"const packageAddress = options.package ?? options.config.testpkgAddress ?? '@test/testpkg';",
+			"const packageAddress = options.package ?? options.config?.testpkgAddress ?? '@test/testpkg';",
 		);
 	});
 });
@@ -636,31 +884,38 @@ describe('generateFromPackageSummary with configArguments', () => {
 
 	async function generate() {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-		await generateFromPackageSummary({
+		const result = await generateFromPackageSummary({
 			package: {
 				package: '@test/testpkg',
 				path: FIXTURE_PATH,
-				configArguments: {
-					registryObj: { type: 'testpkg::registry::Registry' },
-					container: { type: 'testpkg::registry::Container' },
-					testpkgAddress: { package: '@test/testpkg' },
-					missing: { type: 'testpkg::registry::DoesNotExist' },
-				},
 			},
 			prune: true,
 			outputDir: GENERATED_DIR,
+			configArguments: {
+				registryObj: { type: 'testpkg::registry::Registry' },
+				container: { type: 'testpkg::registry::Container' },
+				testpkgAddress: { package: '@test/testpkg' },
+				missing: { type: 'testpkg::registry::DoesNotExist' },
+				unusedEntry: { type: 'testpkg::registry::Entry' },
+			},
 		});
-		return warn;
+		return { warn, result };
 	}
 
-	it('emits config-args.ts and config-driven bindings, warning on unresolved keys', async () => {
-		const warn = await generate();
+	it('emits config-arguments.ts and config-driven bindings, reporting unresolved and unused keys', async () => {
+		const { warn, result } = await generate();
 
 		expect(warn).toHaveBeenCalledWith(
 			'configArguments keys not resolvable in @test/testpkg (skipped): missing',
 		);
+		expect(result.unresolvedConfigKeys).toEqual(['missing']);
+		// Entry is a plain store struct that no generated function takes as a parameter.
+		expect(result.unusedConfigKeys).toEqual(['unusedEntry']);
 
-		const configArgs = await readFile(join(GENERATED_DIR, 'testpkg', 'config-args.ts'), 'utf-8');
+		const configArgs = await readFile(
+			join(GENERATED_DIR, 'testpkg', 'config-arguments.ts'),
+			'utf-8',
+		);
 		expect(configArgs).toMatchInlineSnapshot(`
 			"/**************************************************************
 			 * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
@@ -671,12 +926,50 @@ describe('generateFromPackageSummary with configArguments', () => {
 			    registryObj: ConfigValue;
 			    container: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 			    testpkgAddress?: string;
+			    unusedEntry: ConfigValue;
 			}"
 		`);
 
 		const registryModule = await readFile(join(GENERATED_DIR, 'testpkg', 'registry.ts'), 'utf-8');
 		expect(registryModule).toContain('applyConfigArguments');
-		expect(registryModule).toContain('resolveConfigArg');
+		expect(registryModule).toContain('resolveConfigArgument');
+	});
+
+	it('errors for unresolved keys in a package-scoped block', async () => {
+		await expect(
+			generateFromPackageSummary({
+				package: {
+					package: '@test/testpkg',
+					path: FIXTURE_PATH,
+					configArguments: {
+						missing: { type: 'testpkg::registry::DoesNotExist' },
+					},
+				},
+				prune: true,
+				outputDir: GENERATED_DIR,
+			}),
+		).rejects.toThrowError(/was not found in this package's summaries/);
+	});
+
+	it('warns for unused keys in a package-scoped block', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		await generateFromPackageSummary({
+			package: {
+				package: '@test/testpkg',
+				path: FIXTURE_PATH,
+				configArguments: {
+					unusedEntry: { type: 'testpkg::registry::Entry' },
+				},
+			},
+			prune: true,
+			outputDir: GENERATED_DIR,
+		});
+
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'configArguments keys that matched no generated function parameters in @test/testpkg: unusedEntry',
+			),
+		);
 	});
 
 	it('generated output typechecks under strict settings', { timeout: 60_000 }, async () => {
@@ -744,7 +1037,7 @@ describe('generateFromPackageSummary with configArguments', () => {
 		expect(json.inputs).toEqual([{ UnresolvedObject: { objectId: REGISTRY_ID } }]);
 		expect(json.commands[0].MoveCall.package).toBe(PACKAGE_ID);
 
-		// An explicitly passed argument overrides config resolution.
+		// An explicitly passed argument overrides config resolution (object form).
 		const OVERRIDE_ID = '0x0000000000000000000000000000000000000000000000000000000000000456';
 		const tx2 = new Transaction();
 		tx2.add(
@@ -760,9 +1053,46 @@ describe('generateFromPackageSummary with configArguments', () => {
 		);
 		const json2 = JSON.parse(await tx2.toJSON());
 		expect(json2.inputs).toEqual([{ UnresolvedObject: { objectId: OVERRIDE_ID } }]);
+
+		// Tuple form: an empty tuple resolves from config, an explicit tuple element overrides.
+		const tx3 = new Transaction();
+		tx3.add(
+			mod.lookup({
+				arguments: [],
+				config: { registryObj: REGISTRY_ID, testpkgAddress: PACKAGE_ID },
+			}),
+		);
+		const json3 = JSON.parse(await tx3.toJSON());
+		expect(json3.inputs).toEqual([{ UnresolvedObject: { objectId: REGISTRY_ID } }]);
+
+		const tx4 = new Transaction();
+		tx4.add(
+			mod.lookup({
+				arguments: [OVERRIDE_ID],
+				config: {
+					registryObj: () => {
+						throw new Error('should not be called');
+					},
+					testpkgAddress: PACKAGE_ID,
+				},
+			}),
+		);
+		const json4 = JSON.parse(await tx4.toJSON());
+		expect(json4.inputs).toEqual([{ UnresolvedObject: { objectId: OVERRIDE_ID } }]);
 	});
 
-	it('resolvers receive the matched parameter instantiation at runtime', async () => {
+	it('omitting both the argument and the config value fails with a descriptive error', async () => {
+		await generate();
+
+		const mod = await import(join(GENERATED_DIR, 'testpkg', 'registry.js'));
+		const tx = new Transaction();
+
+		expect(() => tx.add(mod.lookup({}))).toThrowError(
+			'Missing config value for "registryObj": pass it explicitly in arguments, or include it in the config object',
+		);
+	});
+
+	it('resolvers receive the normalized matched parameter instantiation and call-site metadata', async () => {
 		await generate();
 
 		const mod = await import(join(GENERATED_DIR, 'testpkg', 'registry.js'));
@@ -785,7 +1115,17 @@ describe('generateFromPackageSummary with configArguments', () => {
 		);
 		const json = JSON.parse(await tx.toJSON());
 
-		expect(contexts).toEqual([{ typeArguments: ['0x2::sui::SUI'] }]);
+		expect(contexts).toEqual([
+			{
+				typeArguments: [
+					'0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+				],
+				packageAddress: PACKAGE_ID,
+				moduleName: 'registry',
+				functionName: 'container_size',
+				parameterName: 'container',
+			},
+		]);
 		expect(json.inputs).toEqual([{ UnresolvedObject: { objectId: CONTAINER_ID } }]);
 	});
 });

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -13,7 +13,20 @@ let normalizeMoveArguments: (
 	argTypes: readonly (string | null)[],
 	parameterNames?: string[],
 ) => any;
-let resolveConfigArg: (value: unknown, ctx: { typeArguments: string[] }, name: string) => unknown;
+interface TestResolverContext {
+	typeArguments: string[];
+	packageAddress: string;
+	moduleName: string;
+	functionName: string;
+	parameterName?: string;
+}
+const TEST_CTX: TestResolverContext = {
+	typeArguments: [],
+	packageAddress: '0x0',
+	moduleName: 'test',
+	functionName: 'test',
+};
+let resolveConfigArgument: (value: unknown, ctx: TestResolverContext, name: string) => unknown;
 let applyConfigArguments: (
 	args: unknown[] | object,
 	defaults: readonly { index: number; name?: string; resolve: () => unknown }[],
@@ -25,7 +38,7 @@ beforeAll(async () => {
 	const modPath = join(GENERATED_DIR, 'utils', 'index.js');
 	const mod = await import(modPath);
 	normalizeMoveArguments = mod.normalizeMoveArguments;
-	resolveConfigArg = mod.resolveConfigArg;
+	resolveConfigArgument = mod.resolveConfigArgument;
 	applyConfigArguments = mod.applyConfigArguments;
 });
 
@@ -431,25 +444,52 @@ describe('well-known AccumulatorRoot injection', () => {
 	});
 });
 
-describe('resolveConfigArg', () => {
+describe('resolveConfigArgument', () => {
 	it('returns plain values as-is', () => {
-		expect(resolveConfigArg('0x123', { typeArguments: [] }, 'pool')).toBe('0x123');
+		expect(resolveConfigArgument('0x123', TEST_CTX, 'pool')).toBe('0x123');
 	});
 
-	it('invokes resolver functions with the context', () => {
+	it('invokes resolver functions with the context, normalizing hex struct tags', () => {
 		const contexts: unknown[] = [];
 		const value = (ctx: unknown) => {
 			contexts.push(ctx);
 			return '0x456';
 		};
 
-		expect(resolveConfigArg(value, { typeArguments: ['0x2::sui::SUI'] }, 'pool')).toBe('0x456');
-		expect(contexts).toEqual([{ typeArguments: ['0x2::sui::SUI'] }]);
+		expect(
+			resolveConfigArgument(
+				value,
+				{ ...TEST_CTX, typeArguments: ['0x2::sui::SUI', '@mvr/name::a::B', 'u64'] },
+				'pool',
+			),
+		).toBe('0x456');
+		expect(contexts).toEqual([
+			{
+				...TEST_CTX,
+				typeArguments: [
+					'0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+					'@mvr/name::a::B',
+					'u64',
+				],
+			},
+		]);
 	});
 
 	it('throws a descriptive error for missing values', () => {
-		expect(() => resolveConfigArg(undefined, { typeArguments: [] }, 'pool')).toThrowError(
+		expect(() => resolveConfigArgument(undefined, TEST_CTX, 'pool')).toThrowError(
 			'Missing config value for "pool": pass it explicitly in arguments, or include it in the config object',
+		);
+	});
+
+	it('throws a descriptive error when a resolver returns undefined', () => {
+		expect(() =>
+			resolveConfigArgument(
+				() => undefined,
+				{ ...TEST_CTX, typeArguments: ['0x2::sui::SUI'] },
+				'pool',
+			),
+		).toThrowError(
+			'Config resolver for "pool" returned undefined (test::test, typeArguments: [0x2::sui::SUI])',
 		);
 	});
 });
@@ -502,5 +542,60 @@ describe('applyConfigArguments', () => {
 		);
 
 		expect(result).toEqual([42n, '0x123']);
+	});
+
+	it('rejects array arguments with holes at non-matched positions', () => {
+		// Filling a trailing matched position must not mask an omitted required middle argument.
+		expect(() =>
+			applyConfigArguments(['0xaa'], [{ index: 2, name: 'pool', resolve: () => '0x123' }]),
+		).toThrowError('Missing argument at position 1');
+	});
+
+	it('does not treat inherited object properties as explicitly passed arguments', () => {
+		// `constructor` is a valid Move identifier; the inherited Object.prototype.constructor
+		// must not be mistaken for an explicit argument.
+		const result = applyConfigArguments({ amount: 1n }, [
+			{ index: 0, name: 'constructor', resolve: () => '0x123' },
+		]);
+
+		expect((result as Record<string, unknown>)['constructor']).toBe('0x123');
+	});
+});
+
+describe('well-known and config-matched parameters combined', () => {
+	it('aligns config-filled positions with well-known injection at runtime', async () => {
+		// Mimics a generated body for `fn(registry: &Registry, clock: &Clock, amount: u64)`:
+		// clock is elided from arguments, so the config-matched registry is index 0 and amount is
+		// index 1 while argumentsTypes still includes the clock tag between them.
+		const tx = new Transaction();
+		tx.moveCall({
+			target: '0x0::test::test',
+			arguments: normalizeMoveArguments(
+				applyConfigArguments({ amount: 42 }, [
+					{ index: 0, name: 'registry', resolve: () => '0x123' },
+				]),
+				[null, '0x2::clock::Clock', 'u32'],
+				['registry', 'amount'],
+			),
+		});
+
+		const json = JSON.parse(await tx.toJSON());
+		expect(json.inputs).toEqual([
+			{
+				UnresolvedObject: {
+					objectId: '0x0000000000000000000000000000000000000000000000000000000000000123',
+				},
+			},
+			{
+				Object: {
+					SharedObject: {
+						objectId: '0x0000000000000000000000000000000000000000000000000000000000000006',
+						initialSharedVersion: 1,
+						mutable: false,
+					},
+				},
+			},
+			{ Pure: { bytes: 'KgAAAA==' } },
+		]);
 	});
 });

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -19,12 +19,14 @@ interface TestResolverContext {
 	moduleName: string;
 	functionName: string;
 	parameterName?: string;
+	parameterIndex: number;
 }
 const TEST_CTX: TestResolverContext = {
 	typeArguments: [],
 	packageAddress: '0x0',
 	moduleName: 'test',
 	functionName: 'test',
+	parameterIndex: 0,
 };
 let resolveConfigArgument: (value: unknown, ctx: TestResolverContext, name: string) => unknown;
 let applyConfigArguments: (

--- a/packages/codegen/tests/utils.test.ts
+++ b/packages/codegen/tests/utils.test.ts
@@ -13,6 +13,11 @@ let normalizeMoveArguments: (
 	argTypes: readonly (string | null)[],
 	parameterNames?: string[],
 ) => any;
+let resolveConfigArg: (value: unknown, ctx: { typeArguments: string[] }, name: string) => unknown;
+let applyConfigArguments: (
+	args: unknown[] | object,
+	defaults: readonly { index: number; name?: string; resolve: () => unknown }[],
+) => unknown[] | object;
 
 beforeAll(async () => {
 	await mkdir(join(GENERATED_DIR, 'utils'), { recursive: true });
@@ -20,6 +25,8 @@ beforeAll(async () => {
 	const modPath = join(GENERATED_DIR, 'utils', 'index.js');
 	const mod = await import(modPath);
 	normalizeMoveArguments = mod.normalizeMoveArguments;
+	resolveConfigArg = mod.resolveConfigArg;
+	applyConfigArguments = mod.applyConfigArguments;
 });
 
 afterAll(async () => {
@@ -397,5 +404,103 @@ describe('normalizeMoveArguments', () => {
 				},
 			},
 		]);
+	});
+});
+
+describe('well-known AccumulatorRoot injection', () => {
+	it('injects the accumulator root object without consuming arguments', async () => {
+		const tx = new Transaction();
+		tx.moveCall({
+			target: '0x0::test::test',
+			arguments: normalizeMoveArguments(
+				{ arbitraryValue: 42 },
+				['u32', '0x2::accumulator::AccumulatorRoot'],
+				['arbitraryValue'],
+			),
+		});
+
+		const json = JSON.parse(await tx.toJSON());
+		expect(json.inputs).toEqual([
+			{ Pure: { bytes: 'KgAAAA==' } },
+			{
+				UnresolvedObject: {
+					objectId: '0x0000000000000000000000000000000000000000000000000000000000000acc',
+				},
+			},
+		]);
+	});
+});
+
+describe('resolveConfigArg', () => {
+	it('returns plain values as-is', () => {
+		expect(resolveConfigArg('0x123', { typeArguments: [] }, 'pool')).toBe('0x123');
+	});
+
+	it('invokes resolver functions with the context', () => {
+		const contexts: unknown[] = [];
+		const value = (ctx: unknown) => {
+			contexts.push(ctx);
+			return '0x456';
+		};
+
+		expect(resolveConfigArg(value, { typeArguments: ['0x2::sui::SUI'] }, 'pool')).toBe('0x456');
+		expect(contexts).toEqual([{ typeArguments: ['0x2::sui::SUI'] }]);
+	});
+
+	it('throws a descriptive error for missing values', () => {
+		expect(() => resolveConfigArg(undefined, { typeArguments: [] }, 'pool')).toThrowError(
+			'Missing config value for "pool": pass it explicitly in arguments, or include it in the config object',
+		);
+	});
+});
+
+describe('applyConfigArguments', () => {
+	it('fills missing named arguments and leaves explicit ones untouched', () => {
+		const resolved: string[] = [];
+		const result = applyConfigArguments({ amount: 42n }, [
+			{
+				index: 0,
+				name: 'pool',
+				resolve: () => {
+					resolved.push('pool');
+					return '0x123';
+				},
+			},
+		]);
+
+		expect(result).toEqual({ amount: 42n, pool: '0x123' });
+		expect(resolved).toEqual(['pool']);
+	});
+
+	it('does not invoke resolvers for explicitly passed arguments', () => {
+		const result = applyConfigArguments({ pool: '0xabc', amount: 42n }, [
+			{
+				index: 0,
+				name: 'pool',
+				resolve: () => {
+					throw new Error('should not be called');
+				},
+			},
+		]);
+
+		expect(result).toEqual({ pool: '0xabc', amount: 42n });
+	});
+
+	it('fills undefined positions in array arguments', () => {
+		const result = applyConfigArguments(
+			[undefined, 42n],
+			[{ index: 0, name: 'pool', resolve: () => '0x123' }],
+		);
+
+		expect(result).toEqual(['0x123', 42n]);
+	});
+
+	it('fills trailing omitted positions in array arguments', () => {
+		const result = applyConfigArguments(
+			[42n],
+			[{ index: 1, name: 'pool', resolve: () => '0x123' }],
+		);
+
+		expect(result).toEqual([42n, '0x123']);
 	});
 });

--- a/packages/create-dapp/templates/react-e2e-counter/src/contracts/utils/index.ts
+++ b/packages/create-dapp/templates/react-e2e-counter/src/contracts/utils/index.ts
@@ -9,7 +9,10 @@ import {
 } from "@mysten/sui/bcs";
 import { normalizeSuiAddress } from "@mysten/sui/utils";
 import { type TransactionArgument, isArgument } from "@mysten/sui/transactions";
-import { type ClientWithCoreApi, type SuiClientTypes } from "@mysten/sui/client";
+import {
+  type ClientWithCoreApi,
+  type SuiClientTypes,
+} from "@mysten/sui/client";
 
 const MOVE_STDLIB_ADDRESS = normalizeSuiAddress("0x1");
 const SUI_FRAMEWORK_ADDRESS = normalizeSuiAddress("0x2");

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -297,7 +297,9 @@ declare which Move types (or package addresses) come from a config object, and t
 functions accept that config object directly instead of requiring those arguments on every call.
 
 `configArguments` maps author-chosen keys to matchers. It can be declared globally (shared by all
-packages) or per package entry (merged over the global block, per key):
+packages) or per package entry (merged over the global block, per key). Because codegen output is
+network-agnostic, matchers never contain package addresses: types are identified by
+`module::TypeName`, qualified with the package identifier you already use in the `packages` config:
 
 ```typescript
 const config: SuiCodegenConfig = {
@@ -307,33 +309,44 @@ const config: SuiCodegenConfig = {
 			package: '@myapp/core',
 			path: './move/core',
 			configArguments: {
+				// In a package's own block, a bare module::Type refers to that package's type.
 				// Non-generic type: parameters of this type resolve from `config.registry`
-				registry: { type: '0x...::registry::Registry' },
+				registry: { type: 'registry::Registry' },
 				// Generic type without type arguments: matches every instantiation, and the
 				// config value must be a resolver function
-				pool: { type: '0x...::pool::Pool' },
+				pool: { type: 'pool::Pool' },
 				// Fully instantiated generic: only matches parameters concretely typed with
-				// this exact instantiation in the Move signature
-				suiPool: { type: '0x...::pool::Pool<0x2::sui::SUI>' },
+				// this exact instantiation in the Move signature. Framework packages (0x1-0x3)
+				// have chain-stable addresses and can be referenced directly.
+				suiPool: { type: 'pool::Pool<0x2::sui::SUI>' },
 				// Package entry (keyed by the `package` value of a `packages` entry): adds an
 				// optional config key that overrides the package address used for calls
 				corePackageId: { package: '@myapp/core' },
+			},
+		},
+		{
+			package: '@myapp/vaults',
+			path: './move/vaults',
+			configArguments: {
+				// Types from other packages in the run are referenced by their identifier.
+				vaultPool: { type: '@myapp/core::pool::Pool' },
 			},
 		},
 	],
 };
 ```
 
-Matcher addresses are resolved through the package's address mapping, so named addresses (for
-example, `myapp::registry::Registry`) also work. Partially instantiated matchers (for example,
+In the global `configArguments` block there is no ambient package, so type matchers there must be
+package-qualified (`@myapp/core::pool::Pool`). Partially instantiated matchers (for example,
 `Pool<T>` or a nested uninstantiated generic) are not supported. Use an uninstantiated matcher with
 a resolver function instead.
 
-Misconfigured matchers are surfaced at generation time: malformed types, wrong arity, and
-package-scoped matchers whose type isn't in the package's summaries are hard errors. Global-block
-matchers that don't resolve in a package are skipped with a warning (a shared global block may span
-multiple packages in one run), and the CLI errors if a global key resolves in no package at all.
-Keys that resolve but never match any generated parameter produce a warning.
+Misconfiguration is surfaced at generation time: malformed types, wrong arity, unknown package
+identifiers, and non-framework package addresses are hard errors, and every matcher's type is
+checked for existence when the package it references is part of the generated package's dependency
+closure. Matchers referencing run packages outside that closure can't match anything there and are
+skipped (they are validated when their own package is generated). Keys that never match any
+generated parameter of their own package produce a warning.
 
 ### Generated output
 
@@ -422,8 +435,8 @@ Refine the matchers with the Move parameter names:
 
 ```typescript
 configArguments: {
-	basePool: { type: '0x...::pool::Pool', parameterName: 'base_pool' },
-	quotePool: { type: '0x...::pool::Pool', parameterName: 'quote_pool' },
+	basePool: { type: 'pool::Pool', parameterName: 'base_pool' },
+	quotePool: { type: 'pool::Pool', parameterName: 'quote_pool' },
 },
 ```
 

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -319,6 +319,14 @@ const config: SuiCodegenConfig = {
 				// this exact instantiation in the Move signature. Framework packages (0x1-0x3)
 				// have chain-stable addresses and can be referenced directly.
 				suiPool: { type: 'pool::Pool<0x2::sui::SUI>' },
+				// Function matcher: configure one function's parameter directly (opt-in).
+				// The type is derived from the signature. Use parameterIndex for onchain
+				// packages without parameter names; omit both when the function has exactly
+				// one argument.
+				adminCap: { function: 'admin::set_fees', parameterName: 'cap' },
+				// One key may declare several matchers. It then resolves multiple types, so
+				// its config value must be a resolver function.
+				registries: [{ type: 'registry::Registry' }, { type: 'config::GlobalConfig' }],
 				// Package entry (keyed by the `package` value of a `packages` entry): adds an
 				// optional config key that overrides the package address used for calls
 				corePackageId: { package: '@myapp/core' },
@@ -390,6 +398,7 @@ export interface ConfigResolverContext {
 	moduleName: string;
 	functionName: string;
 	parameterName?: string; // Move parameter name, when the summary includes names
+	parameterIndex: number; // position in the generated function's arguments
 }
 ```
 
@@ -430,8 +439,9 @@ const myConfig = { ... } satisfies CoreConfig & MarginConfig;
 ### Name refinement
 
 When a signature has two parameters of the same matched type (for example, `base_pool` and
-`quote_pool`, both `Pool<T>`), a bare type matcher is ambiguous and codegen fails with an error.
-Refine the matchers with the Move parameter names:
+`quote_pool`, both `Pool<T>`), a bare type matcher matches both: the key's config value must then be
+a resolver function, which receives each parameter's own context. To give each parameter its own
+config key instead, refine the matchers with the Move parameter names:
 
 ```typescript
 configArguments: {
@@ -443,9 +453,8 @@ configArguments: {
 Parameter names are only available in summaries generated from local packages. A `parameterName`
 matcher never matches a parameter without a name; if such a matcher would otherwise apply to a
 nameless parameter (same type and instantiation) and nothing else matches it, codegen fails with a
-clear error. When a bare matcher hits two parameters of a nameless (onchain bytecode) signature,
-where refinement is impossible, config mapping is skipped for that function with a warning instead
-of failing the run.
+clear error. For nameless (onchain bytecode) signatures, use function matchers with `parameterIndex`
+to target individual parameters.
 
 ### Package address precedence
 

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -326,7 +326,7 @@ const config: SuiCodegenConfig = {
 
 Matcher addresses are resolved through the package's address mapping, so named addresses (for
 example, `myapp::registry::Registry`) also work. Partially instantiated matchers (for example,
-`Pool<T>` or a nested uninstantiated generic) are not supported — use an uninstantiated matcher with
+`Pool<T>` or a nested uninstantiated generic) are not supported. Use an uninstantiated matcher with
 a resolver function instead.
 
 Misconfigured matchers are surfaced at generation time: malformed types, wrong arity, and
@@ -339,7 +339,7 @@ Keys that resolve but never match any generated parameter produce a warning.
 
 For each function with matched parameters, the generated options gain an optional `config` property
 typed as the minimal slice of keys that function actually uses. Matched parameters become optional
-in `arguments` — passing one explicitly overrides config resolution, and resolvers are only invoked
+in `arguments`. Passing one explicitly overrides config resolution, and resolvers are only invoked
 for arguments the caller did not pass. If a matched argument is omitted and no config value is
 available, the call fails with a descriptive runtime error:
 
@@ -361,11 +361,11 @@ export interface BorrowOptions {
 ```
 
 In the tuple form of `arguments`, a matched position followed by a required one accepts an explicit
-`undefined`; a matched suffix (the common case — registry-style objects last) becomes genuinely
+`undefined`; a matched suffix (the common case, with registry-style objects last) becomes genuinely
 optional trailing elements.
 
 Config values can be a plain object ID, a transaction argument, or a resolver function. Any function
-value is treated as a resolver — to provide a transaction-callback object argument dynamically,
+value is treated as a resolver. To provide a transaction-callback object argument dynamically,
 return it from a resolver: `(ctx) => (tx) => ...`. Resolvers receive the matched parameter's own
 instantiated type arguments (not the whole function's type argument tuple), plus static call-site
 metadata:
@@ -398,8 +398,8 @@ tx.add(
 );
 ```
 
-For generic types matched without type arguments, a resolver function is required — a static ID
-can't be correct across instantiations. A parameter typed with the function's own type parameter
+For generic types matched without type arguments, a resolver function is required, because a static
+ID can't be correct across instantiations. A parameter typed with the function's own type parameter
 (for example, `Pool<T>`) always binds to the uninstantiated matcher, even when a fully instantiated
 matcher also exists; only parameters concretely instantiated in the Move signature bind to
 instantiated matchers.
@@ -430,8 +430,8 @@ configArguments: {
 Parameter names are only available in summaries generated from local packages. A `parameterName`
 matcher never matches a parameter without a name; if such a matcher would otherwise apply to a
 nameless parameter (same type and instantiation) and nothing else matches it, codegen fails with a
-clear error. When a bare matcher hits two parameters of a nameless (onchain bytecode) signature —
-where refinement is impossible — config mapping is skipped for that function with a warning instead
+clear error. When a bare matcher hits two parameters of a nameless (onchain bytecode) signature,
+where refinement is impossible, config mapping is skipped for that function with a warning instead
 of failing the run.
 
 ### Package address precedence
@@ -442,10 +442,10 @@ For package entries, the address used for a generated call is resolved in this o
 2. The config key declared by the package entry (for example, `config.corePackageId`)
 3. The generated default (the package's MVR name or address)
 
-On mainnet with MVR names the config entry can be omitted entirely; on networks where the MVR name
+On Mainnet with MVR names the config entry can be omitted entirely; on networks where the MVR name
 doesn't resolve, supply the deployed package ID through the config object. Two caveats: package
 entries only apply to the main package's generated modules (dependency modules under `deps/` never
-consult them), and they only apply where a generated default address exists — for packages generated
+consult them), and they only apply where a generated default address exists. For packages generated
 without an MVR name or address, `package` stays required and always takes precedence. The CLI
 validates that every package entry references a package that is part of the codegen run.
 

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -324,8 +324,9 @@ const config: SuiCodegenConfig = {
 				// packages without parameter names; omit both when the function has exactly
 				// one argument.
 				adminCap: { function: 'admin::set_fees', parameterName: 'cap' },
-				// One key may declare several matchers. It then resolves multiple types, so
-				// its config value must be a resolver function.
+				// One key may declare several matchers. If they all bind the same concrete
+				// type, a plain value still works; if they span multiple types, the config
+				// value must be a resolver function.
 				registries: [{ type: 'registry::Registry' }, { type: 'config::GlobalConfig' }],
 				// Package entry (keyed by the `package` value of a `packages` entry): adds an
 				// optional config key that overrides the package address used for calls

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -92,6 +92,7 @@ The `SuiCodegenConfig` type supports the following options:
 | `prune`                        | `boolean`              | `true`  | When enabled, only generates code for the main package and omits dependency modules (dependency types referenced by included types are still generated under `deps/`) |
 | `generateSummaries`            | `boolean`              | `true`  | Automatically run `sui move summary` before generating code. Creates a `package_summaries` directory in your Move package which can be added to `.gitignore`          |
 | `generate`                     | `GenerateOptions`      | -       | Default [generate options](#the-generate-option) (types, functions) for all packages                                                                                  |
+| `configArguments`              | `ConfigArguments`      | -       | Map function parameters and package addresses to a [runtime config object](#the-configarguments-option), shared by all packages                                       |
 | `importExtension`              | `'.js' \| '.ts' \| ''` | `'.js'` | File extension used in generated import statements                                                                                                                    |
 | `includePhantomTypeParameters` | `boolean`              | `false` | Include [phantom type parameters](#phantom-types) as function arguments in generated BCS types                                                                        |
 
@@ -102,12 +103,13 @@ local (from source) or onchain (fetched from a network).
 
 #### Local packages
 
-| Option        | Type                     | Required | Description                                               |
-| ------------- | ------------------------ | -------- | --------------------------------------------------------- |
-| `package`     | `string`                 | yes      | Package identifier (for example, `@local-pkg/my-package`) |
-| `path`        | `string`                 | yes      | Path to the Move package directory                        |
-| `packageName` | `string`                 | no       | Custom name for generated code directory                  |
-| `generate`    | `PackageGenerateOptions` | no       | Control what gets generated from this package             |
+| Option            | Type                     | Required | Description                                                            |
+| ----------------- | ------------------------ | -------- | ---------------------------------------------------------------------- |
+| `package`         | `string`                 | yes      | Package identifier (for example, `@local-pkg/my-package`)              |
+| `path`            | `string`                 | yes      | Path to the Move package directory                                     |
+| `packageName`     | `string`                 | no       | Custom name for generated code directory                               |
+| `generate`        | `PackageGenerateOptions` | no       | Control what gets generated from this package                          |
+| `configArguments` | `ConfigArguments`        | no       | Package-scoped [config argument matchers](#the-configarguments-option) |
 
 ```typescript
 {
@@ -121,12 +123,13 @@ local (from source) or onchain (fetched from a network).
 For packages already deployed onchain, generate code directly from a package ID or MVR name without
 needing local source code:
 
-| Option        | Type                     | Required | Description                                   |
-| ------------- | ------------------------ | -------- | --------------------------------------------- |
-| `package`     | `string`                 | yes      | Package ID or MVR name                        |
-| `packageName` | `string`                 | yes      | Name for the generated code directory         |
-| `network`     | `'mainnet' \| 'testnet'` | yes      | Network to fetch the package from             |
-| `generate`    | `PackageGenerateOptions` | no       | Control what gets generated from this package |
+| Option            | Type                     | Required | Description                                                            |
+| ----------------- | ------------------------ | -------- | ---------------------------------------------------------------------- |
+| `package`         | `string`                 | yes      | Package ID or MVR name                                                 |
+| `packageName`     | `string`                 | yes      | Name for the generated code directory                                  |
+| `network`         | `'mainnet' \| 'testnet'` | yes      | Network to fetch the package from                                      |
+| `generate`        | `PackageGenerateOptions` | no       | Control what gets generated from this package                          |
+| `configArguments` | `ConfigArguments`        | no       | Package-scoped [config argument matchers](#the-configarguments-option) |
 
 ```typescript
 {
@@ -284,6 +287,126 @@ src/contracts/
 ```
 
 Set `prune: false` to generate all dependency modules with their full types and functions.
+
+## The `configArguments` option
+
+Many SDKs built on generated bindings spend most of their wrapper code mapping values from a
+per-network config object (package IDs, registry or treasury object IDs, pool addresses) into
+arguments of generated functions. The `configArguments` option moves that plumbing into codegen: you
+declare which Move types (or package addresses) come from a config object, and the generated
+functions accept that config object directly instead of requiring those arguments on every call.
+
+`configArguments` maps author-chosen keys to matchers. It can be declared globally (shared by all
+packages) or per package entry (merged over the global block):
+
+```typescript
+const config: SuiCodegenConfig = {
+	output: './src/contracts',
+	packages: [
+		{
+			package: '@myapp/core',
+			path: './move/core',
+			configArguments: {
+				// Non-generic type: parameters of this type resolve from `config.registry`
+				registry: { type: '0x...::registry::Registry' },
+				// Generic type without type arguments: matches every instantiation, and the
+				// config value must be a resolver function
+				pool: { type: '0x...::pool::Pool' },
+				// Fully instantiated generic: only matches parameters concretely typed with
+				// this exact instantiation in the Move signature
+				suiPool: { type: '0x...::pool::Pool<0x2::sui::SUI>' },
+				// Package entry (keyed by the `package` value of a `packages` entry): adds an
+				// optional config key that overrides the package address used for calls
+				corePackageId: { package: '@myapp/core' },
+			},
+		},
+	],
+};
+```
+
+Matcher addresses are resolved through the package's address mapping, so named addresses (for
+example, `myapp::registry::Registry`) also work.
+
+### Generated output
+
+For each function with matched parameters, the generated options gain a `config` property typed as
+the minimal slice of keys that function actually uses. Matched parameters become optional in
+`arguments` — passing one explicitly overrides config resolution:
+
+```typescript
+export interface BorrowOptions {
+	package?: string;
+	arguments:
+		| BorrowArguments
+		| [
+				pool: RawTransactionArgument<string> | undefined,
+				amount: RawTransactionArgument<number | bigint>,
+		  ];
+	config: {
+		pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
+		corePackageId?: string;
+	};
+	typeArguments: [string];
+}
+```
+
+Config values can be a plain object ID, a transaction argument, or a resolver function. Resolver
+functions receive the matched parameter's own instantiated type arguments (not the whole function's
+type argument tuple), which makes them reusable across functions that use the type in different
+positions:
+
+```typescript
+const myConfig = {
+	registry: '0x123...',
+	pool: (ctx: ConfigResolverContext) => poolsByCoinType[ctx.typeArguments[0]],
+	corePackageId: '0xabc...',
+} satisfies MyappCoreConfig;
+
+tx.add(
+	borrow({
+		arguments: { amount: 100n },
+		config: myConfig,
+		typeArguments: ['0x2::sui::SUI'],
+	}),
+);
+```
+
+For generic types matched without type arguments, a resolver function is required — a static ID
+can't be correct across instantiations. A parameter typed with the function's own type parameter
+(for example, `Pool<T>`) always binds to the uninstantiated matcher, even when a fully instantiated
+matcher also exists; only parameters concretely instantiated in the Move signature bind to
+instantiated matchers.
+
+Each package output also includes a `config-args.ts` file with an interface covering every declared
+key (named after the package, for example `MyappCoreConfig`), for use with `satisfies` when defining
+your config object.
+
+### Name refinement
+
+When a signature has two parameters of the same matched type (for example, `base_pool` and
+`quote_pool`, both `Pool<T>`), a bare type matcher is ambiguous and codegen fails with an error.
+Refine the matchers with the Move parameter names:
+
+```typescript
+configArguments: {
+	basePool: { type: '0x...::pool::Pool', name: 'base_pool' },
+	quotePool: { type: '0x...::pool::Pool', name: 'quote_pool' },
+},
+```
+
+Parameter names are only available in summaries generated from local packages — using a `name`
+matcher against an onchain package's bytecode summary is a generation-time error.
+
+### Package address precedence
+
+For package entries, the address used for a generated call is resolved in this order:
+
+1. An explicit `options.package` argument
+2. The config key declared by the package entry (for example, `config.corePackageId`)
+3. The generated default (the package's MVR name or address)
+
+On mainnet with MVR names the config entry can be omitted entirely; on networks where the MVR name
+doesn't resolve, supply the deployed package ID through the config object.
 
 ## Phantom types
 

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -297,7 +297,7 @@ declare which Move types (or package addresses) come from a config object, and t
 functions accept that config object directly instead of requiring those arguments on every call.
 
 `configArguments` maps author-chosen keys to matchers. It can be declared globally (shared by all
-packages) or per package entry (merged over the global block):
+packages) or per package entry (merged over the global block, per key):
 
 ```typescript
 const config: SuiCodegenConfig = {
@@ -325,13 +325,23 @@ const config: SuiCodegenConfig = {
 ```
 
 Matcher addresses are resolved through the package's address mapping, so named addresses (for
-example, `myapp::registry::Registry`) also work.
+example, `myapp::registry::Registry`) also work. Partially instantiated matchers (for example,
+`Pool<T>` or a nested uninstantiated generic) are not supported — use an uninstantiated matcher with
+a resolver function instead.
+
+Misconfigured matchers are surfaced at generation time: malformed types, wrong arity, and
+package-scoped matchers whose type isn't in the package's summaries are hard errors. Global-block
+matchers that don't resolve in a package are skipped with a warning (a shared global block may span
+multiple packages in one run), and the CLI errors if a global key resolves in no package at all.
+Keys that resolve but never match any generated parameter produce a warning.
 
 ### Generated output
 
-For each function with matched parameters, the generated options gain a `config` property typed as
-the minimal slice of keys that function actually uses. Matched parameters become optional in
-`arguments` — passing one explicitly overrides config resolution:
+For each function with matched parameters, the generated options gain an optional `config` property
+typed as the minimal slice of keys that function actually uses. Matched parameters become optional
+in `arguments` — passing one explicitly overrides config resolution, and resolvers are only invoked
+for arguments the caller did not pass. If a matched argument is omitted and no config value is
+available, the call fails with a descriptive runtime error:
 
 ```typescript
 export interface BorrowOptions {
@@ -342,7 +352,7 @@ export interface BorrowOptions {
 				pool: RawTransactionArgument<string> | undefined,
 				amount: RawTransactionArgument<number | bigint>,
 		  ];
-	config: {
+	config?: {
 		pool: (ctx: ConfigResolverContext) => string | TransactionObjectArgument;
 		corePackageId?: string;
 	};
@@ -350,17 +360,34 @@ export interface BorrowOptions {
 }
 ```
 
-Config values can be a plain object ID, a transaction argument, or a resolver function. Resolver
-functions receive the matched parameter's own instantiated type arguments (not the whole function's
-type argument tuple), which makes them reusable across functions that use the type in different
-positions:
+In the tuple form of `arguments`, a matched position followed by a required one accepts an explicit
+`undefined`; a matched suffix (the common case — registry-style objects last) becomes genuinely
+optional trailing elements.
+
+Config values can be a plain object ID, a transaction argument, or a resolver function. Any function
+value is treated as a resolver — to provide a transaction-callback object argument dynamically,
+return it from a resolver: `(ctx) => (tx) => ...`. Resolvers receive the matched parameter's own
+instantiated type arguments (not the whole function's type argument tuple), plus static call-site
+metadata:
+
+```typescript
+export interface ConfigResolverContext {
+	typeArguments: string[]; // hex-addressed struct tags are normalized to their long form
+	packageAddress: string;
+	moduleName: string;
+	functionName: string;
+	parameterName?: string; // Move parameter name, when the summary includes names
+}
+```
+
+This makes resolvers reusable across functions that use the type in different positions:
 
 ```typescript
 const myConfig = {
 	registry: '0x123...',
 	pool: (ctx: ConfigResolverContext) => poolsByCoinType[ctx.typeArguments[0]],
 	corePackageId: '0xabc...',
-} satisfies MyappCoreConfig;
+} satisfies CoreConfig;
 
 tx.add(
 	borrow({
@@ -377,9 +404,15 @@ can't be correct across instantiations. A parameter typed with the function's ow
 matcher also exists; only parameters concretely instantiated in the Move signature bind to
 instantiated matchers.
 
-Each package output also includes a `config-args.ts` file with an interface covering every declared
-key (named after the package, for example `MyappCoreConfig`), for use with `satisfies` when defining
-your config object.
+Each package output also includes a `config-arguments.ts` file with an interface covering the
+package's resolvable keys and its own package-address key, for use with `satisfies` when defining
+your config object. The interface is named after the package's `packageName` (for example,
+`packageName: 'core'` produces `CoreConfig`). When a global block spans multiple packages, define
+one shared config object and check it against the intersection of the per-package interfaces:
+
+```typescript
+const myConfig = { ... } satisfies CoreConfig & MarginConfig;
+```
 
 ### Name refinement
 
@@ -389,13 +422,17 @@ Refine the matchers with the Move parameter names:
 
 ```typescript
 configArguments: {
-	basePool: { type: '0x...::pool::Pool', name: 'base_pool' },
-	quotePool: { type: '0x...::pool::Pool', name: 'quote_pool' },
+	basePool: { type: '0x...::pool::Pool', parameterName: 'base_pool' },
+	quotePool: { type: '0x...::pool::Pool', parameterName: 'quote_pool' },
 },
 ```
 
-Parameter names are only available in summaries generated from local packages — using a `name`
-matcher against an onchain package's bytecode summary is a generation-time error.
+Parameter names are only available in summaries generated from local packages. A `parameterName`
+matcher never matches a parameter without a name; if such a matcher would otherwise apply to a
+nameless parameter (same type and instantiation) and nothing else matches it, codegen fails with a
+clear error. When a bare matcher hits two parameters of a nameless (onchain bytecode) signature —
+where refinement is impossible — config mapping is skipped for that function with a warning instead
+of failing the run.
 
 ### Package address precedence
 
@@ -406,7 +443,11 @@ For package entries, the address used for a generated call is resolved in this o
 3. The generated default (the package's MVR name or address)
 
 On mainnet with MVR names the config entry can be omitted entirely; on networks where the MVR name
-doesn't resolve, supply the deployed package ID through the config object.
+doesn't resolve, supply the deployed package ID through the config object. Two caveats: package
+entries only apply to the main package's generated modules (dependency modules under `deps/` never
+consult them), and they only apply where a generated default address exists — for packages generated
+without an MVR name or address, `package` stays required and always takes precedence. The CLI
+validates that every package entry references a package that is part of the codegen run.
 
 ## Phantom types
 

--- a/packages/kiosk/src/contracts/utils/index.ts
+++ b/packages/kiosk/src/contracts/utils/index.ts
@@ -8,7 +8,11 @@ import {
 	BcsTuple,
 } from '@mysten/sui/bcs';
 import { normalizeStructTag, normalizeSuiAddress } from '@mysten/sui/utils';
-import { type TransactionArgument, isArgument } from '@mysten/sui/transactions';
+import {
+	type TransactionArgument,
+	type TransactionObjectArgument,
+	isArgument,
+} from '@mysten/sui/transactions';
 import { type ClientWithCoreApi, type SuiClientTypes } from '@mysten/sui/client';
 
 const MOVE_STDLIB_ADDRESS = normalizeSuiAddress('0x1');
@@ -106,6 +110,12 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
+		if (argType === '0x2::accumulator::AccumulatorRoot') {
+			// Chain-wide shared singleton at a fixed address (SUI_ACCUMULATOR_ROOT_OBJECT_ID).
+			normalizedArgs.push((tx) => tx.object('0xacc'));
+			continue;
+		}
+
 		if (argType === '0x3::sui_system::SuiSystemState') {
 			normalizedArgs.push((tx) => tx.object.system());
 			continue;
@@ -124,7 +134,10 @@ export function normalizeMoveArguments(
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
 			const name = parameterNames[index];
-			arg = args[name as keyof typeof args];
+			arg =
+				name !== undefined && Object.prototype.hasOwnProperty.call(args, name)
+					? args[name as keyof typeof args]
+					: undefined;
 
 			if (arg === undefined) {
 				throw new Error(`Parameter ${name} is required`);
@@ -155,6 +168,129 @@ export function normalizeMoveArguments(
 	}
 
 	return normalizedArgs;
+}
+
+/* -------------------------- Config-mapped arguments -------------------------- */
+
+/** Context passed to config resolver functions. */
+export interface ConfigResolverContext {
+	/**
+	 * The matched parameter's own instantiated type arguments (not the whole function's type
+	 * argument tuple), as fully-qualified type tags. Hex-addressed struct tags are normalized to
+	 * their long form before the resolver is invoked; MVR-named tags are passed through unchanged.
+	 */
+	typeArguments: string[];
+	/** The package address the generated call will be sent to. */
+	packageAddress: string;
+	/** The Move module of the generated call. */
+	moduleName: string;
+	/** The Move function of the generated call. */
+	functionName: string;
+	/** The Move name of the matched parameter, when the summary includes parameter names. */
+	parameterName?: string;
+	/** The matched parameter's position in the generated function's arguments. */
+	parameterIndex: number;
+}
+
+/**
+ * A value in a generated config object: a plain object id/argument, or a resolver function.
+ *
+ * Any function is treated as a resolver and called with a `ConfigResolverContext`. To provide a
+ * transaction-callback object argument dynamically, return it from a resolver:
+ * `(ctx) => (tx) => ...`.
+ */
+export type ConfigValue =
+	| string
+	| Exclude<TransactionObjectArgument, (...args: never[]) => unknown>
+	| ((ctx: ConfigResolverContext) => string | TransactionObjectArgument);
+
+/** Normalize a hex-addressed struct tag to its long form; pass anything else through. */
+function normalizeConfigTypeTag(tag: string): string {
+	if (/[@/]/.test(tag) || !tag.includes('::')) {
+		return tag;
+	}
+	try {
+		return normalizeStructTag(tag);
+	} catch {
+		return tag;
+	}
+}
+
+export function resolveConfigArgument(
+	value: ConfigValue | undefined,
+	ctx: ConfigResolverContext,
+	name: string,
+): string | TransactionObjectArgument {
+	if (value == null) {
+		throw new Error(
+			`Missing config value for "${name}": pass it explicitly in arguments, or include it in the config object`,
+		);
+	}
+
+	if (typeof value !== 'function') {
+		return value;
+	}
+
+	const resolved = value({
+		...ctx,
+		typeArguments: ctx.typeArguments.map(normalizeConfigTypeTag),
+	});
+
+	if (resolved == null) {
+		throw new Error(
+			`Config resolver for "${name}" returned ${resolved} (${ctx.moduleName}::${ctx.functionName}, typeArguments: [${ctx.typeArguments.join(', ')}])`,
+		);
+	}
+
+	return resolved;
+}
+
+/**
+ * Fill unset config-mapped positions in an arguments array/object with their resolved config
+ * values. Resolvers are only invoked for positions the caller did not pass explicitly.
+ */
+export function applyConfigArguments<T extends object | unknown[]>(
+	args: T,
+	defaults: readonly { index: number; name?: string; resolve: () => unknown }[],
+): T {
+	if (Array.isArray(args)) {
+		const result = [...args];
+		const matchedIndexes = new Set(defaults.map((entry) => entry.index));
+		for (const entry of defaults) {
+			if (result[entry.index] === undefined) {
+				result[entry.index] = entry.resolve();
+			}
+		}
+		// Filling a trailing config-mapped position can extend the array past positions the
+		// caller omitted; catch those holes here rather than failing deep inside serialization.
+		for (let i = 0; i < result.length; i++) {
+			if (result[i] === undefined && !matchedIndexes.has(i)) {
+				throw new Error(`Missing argument at position ${i}`);
+			}
+		}
+		return result as T;
+	}
+
+	const result: Record<string, unknown> = { ...args };
+	for (const entry of defaults) {
+		if (entry.name === undefined) {
+			continue;
+		}
+		// Own-property check so inherited properties (e.g. a key named "constructor") are never
+		// mistaken for explicitly passed arguments.
+		if (
+			!Object.prototype.hasOwnProperty.call(result, entry.name) ||
+			result[entry.name] === undefined
+		) {
+			Object.defineProperty(result, entry.name, {
+				value: entry.resolve(),
+				enumerable: true,
+				writable: true,
+				configurable: true,
+			});
+		}
+	}
+	return result as T;
 }
 
 /* -------------------------- Move type tags -------------------------- */


### PR DESCRIPTION
## Description

Refreshes Kiosk generated utility bindings on top of the codegen `configArguments` branch.

Kiosk does not materially adopt generated config arguments in this follow-up: its base rule package IDs are distinct public constants, while the generated package override would only provide one package key for the local package. The remaining generated object parameters are user, kiosk, policy, item, or transfer-request specific and should stay explicit.

## Test plan

- `pnpm install --frozen-lockfile`
- `pnpm turbo build --filter=@mysten/codegen`
- `pnpm --filter @mysten/kiosk codegen`
- `pnpm --filter @mysten/kiosk build`
- `pnpm --filter @mysten/kiosk lint`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
