### PR TITLE
fix(sui): enable gas selection when simulating resolved transactions

### DIFF
--- a/.changeset/pretty-donkeys-shave.md
+++ b/.changeset/pretty-donkeys-shave.md
@@ -2,4 +2,4 @@
 '@mysten/sui': minor
 ---
 
-Enable gas selection in `core.simulateTransaction` for the gRPC and GraphQL clients when simulating built transaction bytes, or a `Transaction` with an explicitly set gas payment. This ensures transactions with an empty gas payment (`[]`) are simulated using the sender's address balance for gas rather than a mocked gas coin. The default can be overridden by passing `doGasSelection` to `simulateTransaction` on `SuiGrpcClient` and `SuiGraphQLClient`.
+Enable gas selection in `core.simulateTransaction` for the gRPC and GraphQL clients when the transaction's gas payment is explicitly set to an empty list (`[]`). This ensures transactions paying gas from the sender's address balance are simulated with real gas selection rather than a mocked gas coin. Transactions with gas coins set are simulated as-is, and transactions without a gas payment keep the mocked gas coin behavior. The default can be overridden by passing `doGasSelection` to `simulateTransaction` on `SuiGrpcClient` and `SuiGraphQLClient`.

--- a/.changeset/pretty-donkeys-shave.md
+++ b/.changeset/pretty-donkeys-shave.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/sui': patch
+'@mysten/sui': minor
 ---
 
-Enable gas selection in `core.simulateTransaction` for the gRPC and GraphQL clients when simulating built transaction bytes, or a `Transaction` with an explicitly set gas payment. This ensures transactions with an empty gas payment (`[]`) are simulated using the sender's address balance for gas rather than a mocked gas coin.
+Enable gas selection in `core.simulateTransaction` for the gRPC and GraphQL clients when simulating built transaction bytes, or a `Transaction` with an explicitly set gas payment. This ensures transactions with an empty gas payment (`[]`) are simulated using the sender's address balance for gas rather than a mocked gas coin. The default can be overridden by passing `doGasSelection` to `simulateTransaction` on `SuiGrpcClient` and `SuiGraphQLClient`.

--- a/.changeset/pretty-donkeys-shave.md
+++ b/.changeset/pretty-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Enable gas selection in `core.simulateTransaction` for the gRPC and GraphQL clients when simulating built transaction bytes, or a `Transaction` with an explicitly set gas payment. This ensures transactions with an empty gas payment (`[]`) are simulated using the sender's address balance for gas rather than a mocked gas coin.

--- a/packages/sui/src/client/core-resolver.ts
+++ b/packages/sui/src/client/core-resolver.ts
@@ -169,7 +169,11 @@ async function setGasBudget(
 			},
 		}),
 		include: { effects: true },
-	});
+		// The empty payment above is a placeholder for budget estimation, not a real address
+		// balance payment, so the server must simulate with a mocked gas coin rather than
+		// selecting gas. gRPC and GraphQL support this option, and JSON-RPC always mocks gas.
+		doGasSelection: false,
+	} as SuiClientTypes.SimulateTransactionOptions<{ effects: true }> & { doGasSelection: boolean });
 
 	if (simulateResult.$kind === 'FailedTransaction') {
 		const executionError = simulateResult.FailedTransaction.status.error ?? undefined;

--- a/packages/sui/src/client/utils.ts
+++ b/packages/sui/src/client/utils.ts
@@ -402,6 +402,19 @@ export function parseTransactionBcs(
 }
 
 /**
+ * Checks whether serialized transaction bytes have a gas payment explicitly set to an empty
+ * list, which indicates gas is paid from the sender's address balance. Returns false for
+ * bytes that can't be parsed as `TransactionData`, leaving validation to the server.
+ */
+export function transactionBytesHaveEmptyGasPayment(bytes: Uint8Array): boolean {
+	try {
+		return bcs.TransactionData.parse(bytes).V1?.gasData.payment?.length === 0;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Extracts just the status from transaction effects BCS without fully parsing.
  * This is optimized for cases where we only need the status (success/failure)
  * without parsing the entire effects structure.

--- a/packages/sui/src/graphql/client.ts
+++ b/packages/sui/src/graphql/client.ts
@@ -70,6 +70,20 @@ export function isSuiGraphQLClient(client: unknown): client is SuiGraphQLClient 
 	);
 }
 
+export interface GraphQLSimulateTransactionOptions<
+	Include extends SuiClientTypes.SimulateTransactionInclude = {},
+> extends SuiClientTypes.SimulateTransactionOptions<Include> {
+	/**
+	 * Overrides whether the server selects gas payment during simulation.
+	 *
+	 * When not set, gas selection is enabled for built transaction bytes and for transactions with
+	 * an explicitly set gas payment, so transactions with an empty gas payment (`[]`) are simulated
+	 * using the sender's address balance. Transactions without a gas payment are simulated with a
+	 * mocked gas coin.
+	 */
+	doGasSelection?: boolean;
+}
+
 export interface DynamicFieldInclude {
 	value?: boolean;
 }
@@ -230,7 +244,7 @@ export class SuiGraphQLClient<Queries extends Record<string, GraphQLDocument> = 
 	}
 
 	simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
-		input: SuiClientTypes.SimulateTransactionOptions<Include>,
+		input: GraphQLSimulateTransactionOptions<Include>,
 	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
 		return this.core.simulateTransaction(input);
 	}

--- a/packages/sui/src/graphql/client.ts
+++ b/packages/sui/src/graphql/client.ts
@@ -76,10 +76,10 @@ export interface GraphQLSimulateTransactionOptions<
 	/**
 	 * Overrides whether the server selects gas payment during simulation.
 	 *
-	 * When not set, gas selection is enabled for built transaction bytes and for transactions with
-	 * an explicitly set gas payment, so transactions with an empty gas payment (`[]`) are simulated
-	 * using the sender's address balance. Transactions without a gas payment are simulated with a
-	 * mocked gas coin.
+	 * When not set, gas selection is enabled only when the transaction's gas payment is explicitly
+	 * set to an empty list (`[]`), which indicates gas is paid from the sender's address balance.
+	 * Transactions with gas coins set are simulated as-is, and transactions without a gas payment
+	 * are simulated with a mocked gas coin.
 	 */
 	doGasSelection?: boolean;
 }

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -394,7 +394,7 @@ export class GraphQLCoreClient extends CoreClient {
 		return parseTransaction(result.effects?.transaction!, options.include);
 	}
 	async simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
-		options: SuiClientTypes.SimulateTransactionOptions<Include>,
+		options: SuiClientTypes.SimulateTransactionOptions<Include> & { doGasSelection?: boolean },
 	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
 		if (!(options.transaction instanceof Uint8Array)) {
 			await options.transaction.prepareForSerialization({ client: this });
@@ -404,8 +404,9 @@ export class GraphQLCoreClient extends CoreClient {
 		// resolved, so an empty payment means gas is paid from the sender's address balance rather
 		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
 		const doGasSelection =
-			options.transaction instanceof Uint8Array ||
-			options.transaction.getData().gasData.payment != null;
+			options.doGasSelection ??
+			(options.transaction instanceof Uint8Array ||
+				options.transaction.getData().gasData.payment != null);
 
 		const result = await this.#graphqlQuery(
 			{

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -50,6 +50,7 @@ import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../cli
 import { BalanceChange as BalanceChangeType } from '../grpc/proto/sui/rpc/v2/balance_change.js';
 import { TransactionEffects as TransactionEffectsType } from '../grpc/proto/sui/rpc/v2/effects.js';
 import { Transaction as GrpcTransactionType } from '../grpc/proto/sui/rpc/v2/transaction.js';
+import { bcs } from '../bcs/index.js';
 import { TransactionDataBuilder } from '../transactions/TransactionData.js';
 import type { BuildTransactionOptions } from '../transactions/index.js';
 import {
@@ -400,13 +401,14 @@ export class GraphQLCoreClient extends CoreClient {
 			await options.transaction.prepareForSerialization({ client: this });
 		}
 
-		// Built transaction bytes and transactions with an explicitly set gas payment are fully
-		// resolved, so an empty payment means gas is paid from the sender's address balance rather
-		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
+		// A gas payment explicitly set to an empty list means gas is paid from the sender's
+		// address balance, so the server needs to perform gas selection rather than simulating
+		// with a mocked gas coin.
 		const doGasSelection =
 			options.doGasSelection ??
-			(options.transaction instanceof Uint8Array ||
-				options.transaction.getData().gasData.payment != null);
+			(options.transaction instanceof Uint8Array
+				? bcs.TransactionData.parse(options.transaction).V1?.gasData.payment?.length === 0
+				: options.transaction.getData().gasData.payment?.length === 0);
 
 		const result = await this.#graphqlQuery(
 			{

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -39,7 +39,11 @@ import {
 import { ObjectError, SimulationError } from '../client/errors.js';
 import { chunk, fromBase64, toBase64 } from '@mysten/utils';
 import { normalizeStructTag, normalizeSuiAddress } from '../utils/sui-types.js';
-import { formatMoveAbortMessage, parseTransactionEffectsBcs } from '../client/utils.js';
+import {
+	formatMoveAbortMessage,
+	parseTransactionEffectsBcs,
+	transactionBytesHaveEmptyGasPayment,
+} from '../client/utils.js';
 import type { OpenMoveTypeSignatureBody, OpenMoveTypeSignature } from './types.js';
 import {
 	transactionDataToGrpcTransaction,
@@ -50,7 +54,6 @@ import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../cli
 import { BalanceChange as BalanceChangeType } from '../grpc/proto/sui/rpc/v2/balance_change.js';
 import { TransactionEffects as TransactionEffectsType } from '../grpc/proto/sui/rpc/v2/effects.js';
 import { Transaction as GrpcTransactionType } from '../grpc/proto/sui/rpc/v2/transaction.js';
-import { bcs } from '../bcs/index.js';
 import { TransactionDataBuilder } from '../transactions/TransactionData.js';
 import type { BuildTransactionOptions } from '../transactions/index.js';
 import {
@@ -407,7 +410,7 @@ export class GraphQLCoreClient extends CoreClient {
 		const doGasSelection =
 			options.doGasSelection ??
 			(options.transaction instanceof Uint8Array
-				? bcs.TransactionData.parse(options.transaction).V1?.gasData.payment?.length === 0
+				? transactionBytesHaveEmptyGasPayment(options.transaction)
 				: options.transaction.getData().gasData.payment?.length === 0);
 
 		const result = await this.#graphqlQuery(

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -400,6 +400,13 @@ export class GraphQLCoreClient extends CoreClient {
 			await options.transaction.prepareForSerialization({ client: this });
 		}
 
+		// Built transaction bytes and transactions with an explicitly set gas payment are fully
+		// resolved, so an empty payment means gas is paid from the sender's address balance rather
+		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
+		const doGasSelection =
+			options.transaction instanceof Uint8Array ||
+			options.transaction.getData().gasData.payment != null;
+
 		const result = await this.#graphqlQuery(
 			{
 				query: SimulateTransactionDocument,
@@ -419,6 +426,7 @@ export class GraphQLCoreClient extends CoreClient {
 					includeObjectTypes: options.include?.objectTypes ?? false,
 					includeCommandResults: options.include?.commandResults ?? false,
 					includeBcs: options.include?.bcs ?? false,
+					doGasSelection,
 					checksEnabled: options.checksEnabled ?? true,
 				},
 			},

--- a/packages/sui/src/graphql/index.ts
+++ b/packages/sui/src/graphql/index.ts
@@ -6,6 +6,7 @@ export {
 	type GraphQLQueryOptions,
 	type GraphQLQueryResult,
 	type GraphQLResponseErrors,
+	type GraphQLSimulateTransactionOptions,
 	type SuiGraphQLClientOptions,
 	SuiGraphQLClient,
 	SuiGraphQLRequestError,

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -130,10 +130,10 @@ export interface GrpcSimulateTransactionOptions<
 	/**
 	 * Overrides whether the server selects gas payment during simulation.
 	 *
-	 * When not set, gas selection is enabled for built transaction bytes and for transactions with
-	 * an explicitly set gas payment, so transactions with an empty gas payment (`[]`) are simulated
-	 * using the sender's address balance. Transactions without a gas payment are simulated with a
-	 * mocked gas coin.
+	 * When not set, gas selection is enabled only when the transaction's gas payment is explicitly
+	 * set to an empty list (`[]`), which indicates gas is paid from the sender's address balance.
+	 * Transactions with gas coins set are simulated as-is, and transactions without a gas payment
+	 * are simulated with a mocked gas coin.
 	 */
 	doGasSelection?: boolean;
 }

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -127,6 +127,15 @@ export interface GrpcSimulateTransactionOptions<
 	Include extends GrpcSimulateTransactionInclude = {},
 > extends SuiClientTypes.SimulateTransactionOptions<Include> {
 	include?: Include & GrpcSimulateTransactionInclude;
+	/**
+	 * Overrides whether the server selects gas payment during simulation.
+	 *
+	 * When not set, gas selection is enabled for built transaction bytes and for transactions with
+	 * an explicitly set gas payment, so transactions with an empty gas payment (`[]`) are simulated
+	 * using the sender's address balance. Transactions without a gas payment are simulated with a
+	 * mocked gas coin.
+	 */
+	doGasSelection?: boolean;
 }
 
 export class SuiGrpcClient extends BaseClient implements SuiClientTypes.TransportMethods {

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -44,6 +44,7 @@ import {
 	grpcTransactionToTransactionData,
 } from '../client/transaction-resolver.js';
 import { setAddressBalanceTransactionExpirationFromSimulatedEpoch } from '../client/address-balance-transaction-expiration.js';
+import { transactionBytesHaveEmptyGasPayment } from '../client/utils.js';
 import { Value } from './proto/google/protobuf/struct.js';
 import { ExecutedTransaction } from './proto/sui/rpc/v2/executed_transaction.js';
 import {
@@ -415,7 +416,7 @@ export class GrpcCoreClient extends CoreClient {
 		const doGasSelection =
 			options.doGasSelection ??
 			(options.transaction instanceof Uint8Array
-				? bcs.TransactionData.parse(options.transaction).V1?.gasData.payment?.length === 0
+				? transactionBytesHaveEmptyGasPayment(options.transaction)
 				: options.transaction.getData().gasData.payment?.length === 0);
 
 		const { response } = await this.#client.transactionExecutionService.simulateTransaction(

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -409,6 +409,13 @@ export class GrpcCoreClient extends CoreClient {
 			await options.transaction.prepareForSerialization({ client: this });
 		}
 
+		// Built transaction bytes and transactions with an explicitly set gas payment are fully
+		// resolved, so an empty payment means gas is paid from the sender's address balance rather
+		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
+		const doGasSelection =
+			options.transaction instanceof Uint8Array ||
+			options.transaction.getData().gasData.payment != null;
+
 		const { response } = await this.#client.transactionExecutionService.simulateTransaction(
 			{
 				transaction:
@@ -422,7 +429,7 @@ export class GrpcCoreClient extends CoreClient {
 				readMask: {
 					paths,
 				},
-				doGasSelection: false,
+				doGasSelection,
 				checks:
 					options.checksEnabled === false
 						? SimulateTransactionRequest_TransactionChecks.DISABLED

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -409,13 +409,14 @@ export class GrpcCoreClient extends CoreClient {
 			await options.transaction.prepareForSerialization({ client: this });
 		}
 
-		// Built transaction bytes and transactions with an explicitly set gas payment are fully
-		// resolved, so an empty payment means gas is paid from the sender's address balance rather
-		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
+		// A gas payment explicitly set to an empty list means gas is paid from the sender's
+		// address balance, so the server needs to perform gas selection rather than simulating
+		// with a mocked gas coin.
 		const doGasSelection =
 			options.doGasSelection ??
-			(options.transaction instanceof Uint8Array ||
-				options.transaction.getData().gasData.payment != null);
+			(options.transaction instanceof Uint8Array
+				? bcs.TransactionData.parse(options.transaction).V1?.gasData.payment?.length === 0
+				: options.transaction.getData().gasData.payment?.length === 0);
 
 		const { response } = await this.#client.transactionExecutionService.simulateTransaction(
 			{

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -397,7 +397,7 @@ export class GrpcCoreClient extends CoreClient {
 		);
 	}
 	async simulateTransaction<Include extends SuiClientTypes.SimulateTransactionInclude = {}>(
-		options: SuiClientTypes.SimulateTransactionOptions<Include>,
+		options: SuiClientTypes.SimulateTransactionOptions<Include> & { doGasSelection?: boolean },
 	): Promise<SuiClientTypes.SimulateTransactionResult<Include>> {
 		// The simulated transaction is nested one level deeper in the response
 		const paths = transactionReadMaskPaths(options.include, 'transaction.');
@@ -413,8 +413,9 @@ export class GrpcCoreClient extends CoreClient {
 		// resolved, so an empty payment means gas is paid from the sender's address balance rather
 		// than a mocked gas coin. Gas selection is a noop when the payment covers the budget.
 		const doGasSelection =
-			options.transaction instanceof Uint8Array ||
-			options.transaction.getData().gasData.payment != null;
+			options.doGasSelection ??
+			(options.transaction instanceof Uint8Array ||
+				options.transaction.getData().gasData.payment != null);
 
 		const { response } = await this.#client.transactionExecutionService.simulateTransaction(
 			{

--- a/packages/sui/test/e2e/clients/core/transactions.test.ts
+++ b/packages/sui/test/e2e/clients/core/transactions.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeAll, describe, expect, it } from 'vitest';
-import { setup, TestToolbox, createTestWithAllClients } from '../../utils/setup.js';
+import {
+	setup,
+	TestToolbox,
+	createTestWithAllClients,
+	getRandomAddresses,
+} from '../../utils/setup.js';
 import { Transaction } from '../../../../src/transactions/index.js';
 import { SUI_TYPE_ARG } from '../../../../src/utils/index.js';
 import { Ed25519Keypair } from '../../../../src/keypairs/ed25519/keypair.js';
@@ -1444,6 +1449,208 @@ describe('Core API - Transactions', () => {
 				expect(result.commandResults).toBeDefined();
 			},
 		);
+	});
+
+	describe('simulateTransaction - gas selection', () => {
+		testWithAllClients(
+			'should simulate built bytes paying gas from an address balance',
+			async (client) => {
+				// Sender's SUI is held entirely in an address balance (no coin objects), and the
+				// transaction deposits into a fresh recipient's address balance, so it has a real
+				// storage cost with no rebate. Before gas selection was enabled for built bytes,
+				// the empty gas payment was simulated as a mocked gas coin and this failed with
+				// InsufficientGas.
+				const { address } = await toolbox.getSigner({ addressBalance: 500_000_000n });
+				const [recipient] = getRandomAddresses(1);
+
+				const tx = new Transaction();
+				const withdrawal = tx.withdrawal({ amount: 100_000_000n, type: SUI_TYPE_ARG });
+				const balance = tx.moveCall({
+					target: '0x2::balance::redeem_funds',
+					typeArguments: [SUI_TYPE_ARG],
+					arguments: [withdrawal],
+				});
+				const coin = tx.moveCall({
+					target: '0x2::coin::from_balance',
+					typeArguments: [SUI_TYPE_ARG],
+					arguments: [balance],
+				});
+				tx.moveCall({
+					target: '0x2::coin::send_funds',
+					typeArguments: [SUI_TYPE_ARG],
+					arguments: [coin, tx.pure.address(recipient)],
+				});
+				tx.setSender(address);
+				tx.setGasPayment([]);
+
+				const bytes = await tx.build({ client });
+
+				const result = await client.core.simulateTransaction({
+					transaction: bytes,
+					include: { effects: true, transaction: true },
+				});
+
+				if (result.$kind !== 'Transaction') {
+					throw new Error(
+						`Expected simulation to succeed: ${
+							result.FailedTransaction.status.error?.message ?? 'unknown error'
+						}`,
+					);
+				}
+
+				expect(result.Transaction.effects?.status.success).toBe(true);
+				expect(result.Transaction.transaction?.gasData.payment).toEqual([]);
+			},
+			{ skip: ['jsonrpc'] },
+		);
+
+		testWithAllClients(
+			'should not overwrite explicit gas payment when simulating built bytes',
+			async (client) => {
+				const coins = await client.core.listCoins({ owner: testAddress, coinType: SUI_TYPE_ARG });
+				const explicitGasCoin = coins.objects[0];
+
+				const tx = new Transaction();
+				tx.transferObjects([tx.splitCoins(tx.gas, [1000])], tx.pure.address(testAddress));
+				tx.setSender(testAddress);
+				tx.setGasPayment([
+					{
+						objectId: explicitGasCoin.objectId,
+						version: explicitGasCoin.version,
+						digest: explicitGasCoin.digest,
+					},
+				]);
+
+				const bytes = await tx.build({ client });
+
+				const result = await client.core.simulateTransaction({
+					transaction: bytes,
+					include: { effects: true, transaction: true },
+				});
+
+				expect(result.Transaction!.effects?.status.success).toBe(true);
+				expect(result.Transaction!.transaction?.gasData.payment).toEqual([
+					{
+						objectId: explicitGasCoin.objectId,
+						version: explicitGasCoin.version,
+						digest: explicitGasCoin.digest,
+					},
+				]);
+			},
+		);
+
+		testWithAllClients(
+			'should simulate Transaction instance with explicitly empty gas payment',
+			async (client) => {
+				const { address } = await toolbox.getSigner({ addressBalance: 500_000_000n });
+
+				const tx = new Transaction();
+				const withdrawal = tx.withdrawal({ amount: 100_000_000n, type: SUI_TYPE_ARG });
+				const balance = tx.moveCall({
+					target: '0x2::balance::redeem_funds',
+					typeArguments: [SUI_TYPE_ARG],
+					arguments: [withdrawal],
+				});
+				const coin = tx.moveCall({
+					target: '0x2::coin::from_balance',
+					typeArguments: [SUI_TYPE_ARG],
+					arguments: [balance],
+				});
+				tx.transferObjects([coin], tx.pure.address(address));
+				tx.setSender(address);
+				tx.setGasPayment([]);
+
+				const result = await client.core.simulateTransaction({
+					transaction: tx,
+					include: { effects: true },
+				});
+
+				if (result.$kind !== 'Transaction') {
+					throw new Error(
+						`Expected simulation to succeed: ${
+							result.FailedTransaction.status.error?.message ?? 'unknown error'
+						}`,
+					);
+				}
+
+				expect(result.Transaction.effects?.status.success).toBe(true);
+			},
+			{ skip: ['jsonrpc'] },
+		);
+
+		testWithAllClients(
+			'should simulate Transaction instance without gas payment using a mocked gas coin',
+			async (client) => {
+				// An unfunded sender can't pay for gas, so a successful simulation requires the
+				// server to mock a gas coin. Transactions without an explicit gas payment must keep
+				// this behavior rather than opting into gas selection.
+				const [sender] = getRandomAddresses(1);
+
+				const tx = new Transaction();
+				tx.moveCall({
+					target: '0x2::clock::timestamp_ms',
+					arguments: [
+						tx.sharedObjectRef({ objectId: '0x6', initialSharedVersion: '1', mutable: false }),
+					],
+				});
+				tx.setSender(sender);
+
+				const result = await client.core.simulateTransaction({
+					transaction: tx,
+					include: { effects: true },
+				});
+
+				if (result.$kind !== 'Transaction') {
+					throw new Error(
+						`Expected simulation to succeed: ${
+							result.FailedTransaction.status.error?.message ?? 'unknown error'
+						}`,
+					);
+				}
+
+				expect(result.Transaction.effects?.status.success).toBe(true);
+			},
+			{ skip: ['jsonrpc'] },
+		);
+
+		// An unfunded sender simulates successfully with the default mocked gas coin, but
+		// forcing gas selection fails because the sender has nothing to pay gas with.
+		function unfundedSenderTx() {
+			const [sender] = getRandomAddresses(1);
+
+			const tx = new Transaction();
+			tx.moveCall({
+				target: '0x2::clock::timestamp_ms',
+				arguments: [
+					tx.sharedObjectRef({ objectId: '0x6', initialSharedVersion: '1', mutable: false }),
+				],
+			});
+			tx.setSender(sender);
+
+			return tx;
+		}
+
+		it('[gRPC] should allow overriding gas selection on the client', async () => {
+			const tx = unfundedSenderTx();
+
+			const defaultResult = await toolbox.grpcClient.simulateTransaction({ transaction: tx });
+			expect(defaultResult.$kind).toBe('Transaction');
+
+			await expect(
+				toolbox.grpcClient.simulateTransaction({ transaction: tx, doGasSelection: true }),
+			).rejects.toThrow();
+		});
+
+		it('[GraphQL] should allow overriding gas selection on the client', async () => {
+			const tx = unfundedSenderTx();
+
+			const defaultResult = await toolbox.graphqlClient.simulateTransaction({ transaction: tx });
+			expect(defaultResult.$kind).toBe('Transaction');
+
+			await expect(
+				toolbox.graphqlClient.simulateTransaction({ transaction: tx, doGasSelection: true }),
+			).rejects.toThrow();
+		});
 	});
 
 	describe('build with onlyTransactionKind', () => {


### PR DESCRIPTION
## Description

`core.simulateTransaction` in the gRPC and GraphQL clients previously hardcoded `doGasSelection: false`. The server interprets an empty gas payment (`[]`) with gas selection disabled as "use a mocked gas coin", which conflates two cases: a transaction that hasn't had gas resolved yet, and a fully built transaction that pays gas from the sender's address balance. This caused simulation of address-balance-funded transactions (e.g. wallet sends where the entire SUI balance is an address balance) to fail with `InsufficientGas` even though the sender had plenty of SUI.

This PR sets `doGasSelection: true` when the transaction's gas payment is explicitly set to an empty list (`[]`) — parsed from the BCS bytes for `Uint8Array` input, or read off the `Transaction` instance. In that case an empty payment unambiguously means address-balance gas. Transactions with gas coins set are simulated as-is, and transactions with no gas payment set keep the previous mocked-gas-coin behavior, so unfunded senders can still simulate.

The default can be overridden via a new `doGasSelection` option on `simulateTransaction` for `SuiGrpcClient` (`GrpcSimulateTransactionOptions`) and `SuiGraphQLClient` (`GraphQLSimulateTransactionOptions`). The core API does not expose the option. The internal core-resolver gas budget estimation (which simulates placeholder bytes with `payment: []` and `MAX_GAS`) explicitly opts out with `doGasSelection: false` to keep mocked-gas-coin budget estimation.

JSON-RPC is unchanged (dry run has no gas-selection option).

Based on #1137 (merge target) to build on its client/test patterns.

## Test plan

New e2e tests in `test/e2e/clients/core/transactions.test.ts` (`simulateTransaction - gas selection`):

- simulating built bytes paying gas from an address balance (deposit into a fresh recipient's address balance, sender funded only via address balance)
- explicit gas payment is not overwritten (all three transports)
- `Transaction` instance with explicitly empty gas payment simulates via address balance
- `Transaction` instance without gas payment keeps the mocked-gas-coin behavior (unfunded sender)
- client-level `doGasSelection: true` override fails for an unfunded sender on both gRPC and GraphQL, while the default mocked-coin path succeeds

Full local e2e suite passes against localnet (51 files, 892 tests), including the parallel executor suites that exercise the internal budget-estimation opt-out. `tsc --noEmit` (src + tests), oxlint, and prettier pass.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSMWomHMbiLhd1c8EH9A7N