### PR TITLE
fix(sui): return null effects.gasObject for transactions without a gas object

### DIFF
--- a/.changeset/thick-donuts-repeat.md
+++ b/.changeset/thick-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': patch
+---
+
+Fix `effects.gasObject` being populated with an invalid all-null object for transactions that have no gas object (system transactions, or transactions paying gas from an address balance). The gRPC transport and the JSON-RPC simulation path now return `null`, matching the declared `TransactionEffects` type and the BCS-based effects parsing used by the other code paths.

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -1392,18 +1392,22 @@ export function parseTransactionEffects({
 			nonRefundableStorageFee: effects.gasUsed?.nonRefundableStorageFee?.toString()!,
 		},
 		transactionDigest: effects.transactionDigest!,
-		gasObject: {
-			objectId: effects.gasObject?.objectId!,
-			inputState: mapInputObjectState(effects.gasObject?.inputState)!,
-			inputVersion: effects.gasObject?.inputVersion?.toString() ?? null,
-			inputDigest: effects.gasObject?.inputDigest ?? null,
-			inputOwner: mapOwner(effects.gasObject?.inputOwner),
-			outputState: mapOutputObjectState(effects.gasObject?.outputState)!,
-			outputVersion: effects.gasObject?.outputVersion?.toString() ?? null,
-			outputDigest: effects.gasObject?.outputDigest ?? null,
-			outputOwner: mapOwner(effects.gasObject?.outputOwner),
-			idOperation: mapIdOperation(effects.gasObject?.idOperation)!,
-		},
+		// gas_object is unset when the transaction has no gas object (system
+		// transactions, or gas paid from an address balance)
+		gasObject: effects.gasObject
+			? {
+					objectId: effects.gasObject.objectId!,
+					inputState: mapInputObjectState(effects.gasObject.inputState)!,
+					inputVersion: effects.gasObject.inputVersion?.toString() ?? null,
+					inputDigest: effects.gasObject.inputDigest ?? null,
+					inputOwner: mapOwner(effects.gasObject.inputOwner),
+					outputState: mapOutputObjectState(effects.gasObject.outputState)!,
+					outputVersion: effects.gasObject.outputVersion?.toString() ?? null,
+					outputDigest: effects.gasObject.outputDigest ?? null,
+					outputOwner: mapOwner(effects.gasObject.outputOwner),
+					idOperation: mapIdOperation(effects.gasObject.idOperation)!,
+				}
+			: null,
 		eventsDigest: effects.eventsDigest ?? null,
 		dependencies: effects.dependencies,
 		lamportVersion: effects.lamportVersion?.toString() ?? null,

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -1182,7 +1182,7 @@ function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}
 			};
 }
 
-function parseTransactionEffectsJson({
+export function parseTransactionEffectsJson({
 	bytes,
 	effects,
 	objectChanges,
@@ -1302,6 +1302,28 @@ function parseTransactionEffectsJson({
 		}
 	});
 
+	// When the transaction has no gas object (system transactions, or gas paid
+	// from an address balance), the RPC substitutes a placeholder ref with the
+	// 0x0 object id rather than omitting the field.
+	const hasGasObject =
+		normalizeSuiAddress(effects.gasObject.reference.objectId) !== normalizeSuiAddress('0x0');
+
+	let lamportVersion: string | null = null;
+	if (hasGasObject) {
+		lamportVersion = effects.gasObject.reference.version;
+	} else {
+		// Written objects are all assigned the lamport version, so recover it
+		// from the changed objects when the gas object can't provide it.
+		for (const change of changedObjects) {
+			if (
+				change.outputVersion &&
+				(lamportVersion === null || BigInt(change.outputVersion) > BigInt(lamportVersion))
+			) {
+				lamportVersion = change.outputVersion;
+			}
+		}
+	}
+
 	return {
 		objectTypes,
 		effects: {
@@ -1310,21 +1332,23 @@ function parseTransactionEffectsJson({
 			status: parseJsonRpcExecutionStatus(effects.status, effects.abortError),
 			gasUsed: effects.gasUsed,
 			transactionDigest: effects.transactionDigest,
-			gasObject: {
-				objectId: effects.gasObject?.reference.objectId,
-				inputState: 'Exists',
-				inputVersion: null,
-				inputDigest: null,
-				inputOwner: null,
-				outputState: 'ObjectWrite',
-				outputVersion: effects.gasObject.reference.version,
-				outputDigest: effects.gasObject.reference.digest,
-				outputOwner: parseOwner(effects.gasObject.owner),
-				idOperation: 'None',
-			},
+			gasObject: hasGasObject
+				? {
+						objectId: effects.gasObject.reference.objectId,
+						inputState: 'Exists',
+						inputVersion: null,
+						inputDigest: null,
+						inputOwner: null,
+						outputState: 'ObjectWrite',
+						outputVersion: effects.gasObject.reference.version,
+						outputDigest: effects.gasObject.reference.digest,
+						outputOwner: parseOwner(effects.gasObject.owner),
+						idOperation: 'None',
+					}
+				: null,
 			eventsDigest: effects.eventsDigest ?? null,
 			dependencies: effects.dependencies ?? [],
-			lamportVersion: effects.gasObject.reference.version,
+			lamportVersion,
 			changedObjects,
 			unchangedConsensusObjects,
 			auxiliaryDataDigest: null,

--- a/packages/sui/test/e2e/clients/core/transactions.test.ts
+++ b/packages/sui/test/e2e/clients/core/transactions.test.ts
@@ -105,6 +105,46 @@ describe('Core API - Transactions', () => {
 		testWithAllClients('should throw error for invalid digest format', async (client) => {
 			await expect(client.core.getTransaction({ digest: 'invalid' })).rejects.toThrow();
 		});
+
+		// The first transaction on the chain is the genesis transaction, a system
+		// transaction that has no gas object. Fetched over JSON-RPC because the
+		// localnet image does not serve the gRPC ListTransactions RPC yet.
+		async function getGenesisDigest() {
+			const { transactions } = await toolbox.jsonRpcClient.core.listTransactions({
+				limit: 1,
+				order: 'ascending',
+			});
+			return transactions[0].Transaction!.digest;
+		}
+
+		it('all clients return same data: transaction without a gas object', async () => {
+			const genesisDigest = await getGenesisDigest();
+
+			await toolbox.expectAllClientsReturnSameData(
+				(client) =>
+					client.core.getTransaction({
+						digest: genesisDigest,
+						include: { effects: true },
+					}),
+				// Transports disagree on whether the genesis transaction has a
+				// placeholder signature, which is unrelated to effects parity
+				(result) =>
+					result.$kind === 'Transaction'
+						? { ...result, Transaction: { ...result.Transaction, signatures: [] } }
+						: result,
+			);
+		});
+
+		testWithAllClients('should return null gas object for system transactions', async (client) => {
+			const genesisDigest = await getGenesisDigest();
+
+			const result = await client.core.getTransaction({
+				digest: genesisDigest,
+				include: { effects: true },
+			});
+
+			expect(result.Transaction!.effects!.gasObject).toBeNull();
+		});
 	});
 
 	describe('executeTransaction', () => {

--- a/packages/sui/test/unit/client/parse-effects-gas-object.test.ts
+++ b/packages/sui/test/unit/client/parse-effects-gas-object.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { parseTransactionEffects } from '../../../src/grpc/core.js';
+import { parseTransactionEffectsJson } from '../../../src/jsonRpc/core.js';
+import type { TransactionEffects as GrpcTransactionEffects } from '../../../src/grpc/proto/sui/rpc/v2/effects.js';
+import {
+	ChangedObject_IdOperation,
+	ChangedObject_InputObjectState,
+	ChangedObject_OutputObjectState,
+} from '../../../src/grpc/proto/sui/rpc/v2/effects.js';
+import type { TransactionEffects as JsonRpcTransactionEffects } from '../../../src/jsonRpc/types/generated.js';
+import { normalizeSuiAddress } from '../../../src/utils/index.js';
+
+const SENDER = '0x000000000000000000000000000000000000000000000000000000000000000a';
+const GAS_OBJECT_ID = '0x00000000000000000000000000000000000000000000000000000000000000c0';
+
+describe('gRPC parseTransactionEffects gasObject', () => {
+	function grpcEffects(
+		gasObject: Partial<GrpcTransactionEffects['gasObject']> | undefined,
+	): GrpcTransactionEffects {
+		return {
+			status: { success: true },
+			gasUsed: {
+				computationCost: 100n,
+				storageCost: 200n,
+				storageRebate: 300n,
+				nonRefundableStorageFee: 0n,
+			},
+			transactionDigest: 'tx-digest',
+			gasObject,
+			dependencies: [],
+			lamportVersion: 5n,
+			changedObjects: [],
+			unchangedConsensusObjects: [],
+		} as unknown as GrpcTransactionEffects;
+	}
+
+	it('returns null when the node reports no gas object', () => {
+		// Gas paid from an address balance settles against the accumulator, so
+		// the node leaves gas_object unset.
+		const effects = parseTransactionEffects({ effects: grpcEffects(undefined) });
+
+		expect(effects?.gasObject).toBeNull();
+	});
+
+	it('maps the gas object when the node reports one', () => {
+		const effects = parseTransactionEffects({
+			effects: grpcEffects({
+				objectId: GAS_OBJECT_ID,
+				inputState: ChangedObject_InputObjectState.EXISTS,
+				inputVersion: 4n,
+				inputDigest: 'input-digest',
+				outputState: ChangedObject_OutputObjectState.OBJECT_WRITE,
+				outputVersion: 5n,
+				outputDigest: 'output-digest',
+				idOperation: ChangedObject_IdOperation.NONE,
+			}),
+		});
+
+		expect(effects?.gasObject).toEqual({
+			objectId: GAS_OBJECT_ID,
+			inputState: 'Exists',
+			inputVersion: '4',
+			inputDigest: 'input-digest',
+			inputOwner: null,
+			outputState: 'ObjectWrite',
+			outputVersion: '5',
+			outputDigest: 'output-digest',
+			outputOwner: null,
+			idOperation: 'None',
+		});
+	});
+});
+
+describe('JSON-RPC parseTransactionEffectsJson gasObject', () => {
+	function jsonRpcEffects(gasObject: JsonRpcTransactionEffects['gasObject']) {
+		return {
+			messageVersion: 'v1',
+			status: { status: 'success' },
+			executedEpoch: '0',
+			gasUsed: {
+				computationCost: '100',
+				storageCost: '200',
+				storageRebate: '300',
+				nonRefundableStorageFee: '0',
+			},
+			transactionDigest: 'tx-digest',
+			gasObject,
+			dependencies: [],
+		} as unknown as JsonRpcTransactionEffects;
+	}
+
+	it('maps the placeholder 0x0 gas object to null', () => {
+		// When the transaction has no gas object the RPC substitutes a
+		// placeholder ref instead of omitting the field.
+		const { effects } = parseTransactionEffectsJson({
+			effects: jsonRpcEffects({
+				owner: { AddressOwner: normalizeSuiAddress('0x0') },
+				reference: {
+					objectId: normalizeSuiAddress('0x0'),
+					version: '0',
+					digest: '11111111111111111111111111111111',
+				},
+			}),
+			objectChanges: [
+				{
+					type: 'mutated',
+					sender: SENDER,
+					owner: { AddressOwner: SENDER },
+					objectType: '0x2::coin::Coin<0x2::sui::SUI>',
+					objectId: GAS_OBJECT_ID,
+					version: '9',
+					previousVersion: '8',
+					digest: 'object-digest',
+				},
+			],
+		});
+
+		expect(effects.gasObject).toBeNull();
+		// The lamport version can no longer come from the gas object, so it is
+		// recovered from the written objects.
+		expect(effects.lamportVersion).toBe('9');
+	});
+
+	it('maps a real gas object', () => {
+		const { effects } = parseTransactionEffectsJson({
+			effects: jsonRpcEffects({
+				owner: { AddressOwner: SENDER },
+				reference: { objectId: GAS_OBJECT_ID, version: '5', digest: 'gas-digest' },
+			}),
+			objectChanges: [],
+		});
+
+		expect(effects.gasObject).toEqual({
+			objectId: GAS_OBJECT_ID,
+			inputState: 'Exists',
+			inputVersion: null,
+			inputDigest: null,
+			inputOwner: null,
+			outputState: 'ObjectWrite',
+			outputVersion: '5',
+			outputDigest: 'gas-digest',
+			outputOwner: { $kind: 'AddressOwner', AddressOwner: SENDER },
+			idOperation: 'None',
+		});
+		expect(effects.lamportVersion).toBe('5');
+	});
+});


### PR DESCRIPTION
## Description

The unified `TransactionEffects` type declares `gasObject: ChangedObject | null`, but two transports never returned `null` for transactions that have no gas object (system transactions, or transactions paying gas from an address balance, where gas settles against the accumulator):

- **gRPC**: `parseTransactionEffects` unconditionally materialized `gasObject`, so when the node leaves `gas_object` unset it produced an invalid object with `objectId: undefined` and every other field null. Downstream truthiness checks (`effects.gasObject ? … : null`) never trip on this, which broke dApp transaction previews in Slush (MystenLabs/slush#3689).
- **JSON-RPC (simulation path)**: the node substitutes a placeholder gas ref (`0x0` object id, version 0, minimum digest) instead of omitting the field. `parseTransactionEffectsJson` mapped it as a real gas object, and the placeholder's version 0 also leaked into `lamportVersion`. The placeholder is now detected and mapped to `null`, with `lamportVersion` recovered from the written objects' versions.

The shared BCS effects parser (used by GraphQL everywhere, and by JSON-RPC for executed transactions) already handled this correctly via `gasObjectIndex === null`, so all three transports now agree.

## Test plan

- New unit tests (`test/unit/client/parse-effects-gas-object.test.ts`) cover both parsers for the no-gas-object and normal-gas-object cases.
- New e2e tests in `test/e2e/clients/core/transactions.test.ts` use the genesis transaction (a system transaction with no gas object) to assert all three clients return `gasObject: null` and identical effects via `expectAllClientsReturnSameData`. The genesis digest is fetched over JSON-RPC because the current localnet image does not serve the gRPC `ListTransactions` RPC (same exclusion as `queries.test.ts`), and genesis signatures are normalized out of the parity comparison (transports disagree on genesis placeholder signatures — a pre-existing, unrelated divergence).
- Full unit suite (458 tests) and the transactions e2e suite pass locally against a Docker localnet.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)