### PR TITLE
feat(kiosk): support gRPC and refresh client migration docs

### DIFF
--- a/.changeset/green-kiosks-grpc.md
+++ b/.changeset/green-kiosks-grpc.md
@@ -1,0 +1,6 @@
+---
+'@mysten/kiosk': minor
+---
+
+Add support for `SuiGrpcClient` and other `ClientWithCoreApi` implementations to the Kiosk SDK, and
+use the shared Core API object owner type for transfer policies.

--- a/.changeset/green-kiosks-grpc.md
+++ b/.changeset/green-kiosks-grpc.md
@@ -3,4 +3,4 @@
 ---
 
 Add support for `SuiGrpcClient` and other `ClientWithCoreApi` implementations to the Kiosk SDK, and
-query objects and all transfer policy event pages through the shared Core API.
+query objects and transfer policy events through the shared Core API.

--- a/.changeset/green-kiosks-grpc.md
+++ b/.changeset/green-kiosks-grpc.md
@@ -1,9 +1,6 @@
 ---
 '@mysten/kiosk': minor
-'@mysten/sui': patch
 ---
 
 Add support for `SuiGrpcClient` and other `ClientWithCoreApi` implementations to the Kiosk SDK, and
 query objects and all transfer policy event pages through the shared Core API.
-
-Preserve JSON-RPC Display rendering errors when mapping object responses to the Core API.

--- a/.changeset/green-kiosks-grpc.md
+++ b/.changeset/green-kiosks-grpc.md
@@ -1,6 +1,9 @@
 ---
 '@mysten/kiosk': minor
+'@mysten/sui': patch
 ---
 
 Add support for `SuiGrpcClient` and other `ClientWithCoreApi` implementations to the Kiosk SDK, and
-use the shared Core API object owner type for transfer policies.
+query objects and transfer policy events through the shared Core API.
+
+Preserve JSON-RPC Display rendering errors when mapping object responses to the Core API.

--- a/.changeset/green-kiosks-grpc.md
+++ b/.changeset/green-kiosks-grpc.md
@@ -4,6 +4,6 @@
 ---
 
 Add support for `SuiGrpcClient` and other `ClientWithCoreApi` implementations to the Kiosk SDK, and
-query objects and transfer policy events through the shared Core API.
+query objects and all transfer policy event pages through the shared Core API.
 
 Preserve JSON-RPC Display rendering errors when mapping object responses to the Core API.

--- a/packages/docs/content/dapp-kit/getting-started/react.mdx
+++ b/packages/docs/content/dapp-kit/getting-started/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: React
-description: Set up dApp Kit in a React application.
+description: Set up dApp Kit in a React application
 keywords: [React, dApp Kit, getting started, Vite, TypeScript, wallet connection, Sui]
 ---
 
@@ -159,7 +159,7 @@ function TransferButton() {
 | [`useCurrentAccount`](/dapp-kit/react/hooks/use-current-account)     | Currently selected account               |
 | [`useCurrentWallet`](/dapp-kit/react/hooks/use-current-wallet)       | Currently connected wallet               |
 | [`useCurrentNetwork`](/dapp-kit/react/hooks/use-current-network)     | Current network                          |
-| [`useCurrentClient`](/dapp-kit/react/hooks/use-current-client)       | SuiClient for current network            |
+| [`useCurrentClient`](/dapp-kit/react/hooks/use-current-client)       | Current Sui client instance              |
 | [`useWallets`](/dapp-kit/react/hooks/use-wallets)                    | List of available wallets                |
 
 ## Components

--- a/packages/docs/content/dapp-kit/getting-started/vue.mdx
+++ b/packages/docs/content/dapp-kit/getting-started/vue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vue
-description: Set up dApp Kit in a Vue application.
+description: Set up dApp Kit in a Vue application
 keywords: [Vue, dApp Kit, web components, nanostores, Sui, TypeScript, wallet connection]
 ---
 
@@ -190,7 +190,7 @@ Access these stores through `dAppKit.stores`:
 | ----------------- | ------------------------------------------------- |
 | `$connection`     | Connection state with wallet, account, and status |
 | `$currentNetwork` | Current network string                            |
-| `$currentClient`  | SuiClient for current network                     |
+| `$currentClient`  | Current Sui client instance                       |
 | `$wallets`        | List of available wallets                         |
 
 See [State Management](/dapp-kit/state) for full documentation.

--- a/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
+++ b/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: useCurrentClient
-description: React hook to get the current Sui client instance for the active network.
+description: React hook to get the current Sui client instance for the active network
 keywords:
   [useCurrentClient, React hook, Sui client, blockchain client, dApp Kit, network, TypeScript]
 ---
@@ -9,9 +9,9 @@ The `useCurrentClient` hook provides access to the blockchain client instance fo
 network.
 
 <Callout type="info">
-	By default, this returns a `SuiClient` instance when using the standard setup. However, the dApp
-	Kit supports any client that implements the Sui core API, making it flexible for different
-	blockchain implementations.
+	With the standard setup, this returns the `SuiGrpcClient` instance created by `createClient`. More
+	generally, it returns whatever client type your dApp Kit instance creates, as long as that client
+	implements the Sui Core API.
 </Callout>
 
 <Callout type="warn">
@@ -41,5 +41,5 @@ export function MyComponent() {
 ## Return value
 
 ```tsx
-SuiClient;
+ReturnType<typeof dAppKit.getClient>;
 ```

--- a/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
+++ b/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
@@ -11,7 +11,8 @@ network.
 <Callout type="info">
 	With the standard setup, this returns the `SuiGrpcClient` instance created by `createClient`. More
 	generally, it returns whatever client type your dApp Kit instance creates, as long as that client
-	implements the Sui Core API.
+	implements the Sui Core API. Application code should call the concrete client's top-level methods
+	directly.
 </Callout>
 
 <Callout type="warn">
@@ -28,7 +29,7 @@ export function MyComponent() {
 	const client = useCurrentClient();
 
 	const handleQuery = async () => {
-		const balance = await client.core.getBalance({
+		const balance = await client.getBalance({
 			owner: '0x...',
 		});
 		console.log(balance);

--- a/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
+++ b/packages/docs/content/dapp-kit/react/hooks/use-current-client.mdx
@@ -28,7 +28,7 @@ export function MyComponent() {
 	const client = useCurrentClient();
 
 	const handleQuery = async () => {
-		const balance = await client.getBalance({
+		const balance = await client.core.getBalance({
 			owner: '0x...',
 		});
 		console.log(balance);

--- a/packages/docs/content/dapp-kit/state.mdx
+++ b/packages/docs/content/dapp-kit/state.mdx
@@ -110,7 +110,7 @@ Contains the Sui client instance for the current network:
 const client = dAppKit.stores.$currentClient.get();
 
 // Use the client to query the blockchain
-const balance = await client.core.getBalance({
+const balance = await client.getBalance({
 	owner: '0x...',
 });
 ```

--- a/packages/docs/content/dapp-kit/state.mdx
+++ b/packages/docs/content/dapp-kit/state.mdx
@@ -1,6 +1,6 @@
 ---
 title: State
-description: Access and subscribe to wallet connection state in dApp Kit.
+description: Access and subscribe to wallet connection state in dApp Kit
 keywords:
   [state management, nanostores, wallet state, dApp Kit, reactive stores, Sui, framework-agnostic]
 ---
@@ -104,7 +104,7 @@ This store is read-only. Use `dAppKit.switchNetwork()` to change networks.
 
 ### Current client store (`$currentClient`)
 
-Contains the SuiClient instance for the current network:
+Contains the Sui client instance for the current network:
 
 ```typescript
 const client = dAppKit.stores.$currentClient.get();

--- a/packages/docs/content/dapp-kit/state.mdx
+++ b/packages/docs/content/dapp-kit/state.mdx
@@ -110,7 +110,7 @@ Contains the Sui client instance for the current network:
 const client = dAppKit.stores.$currentClient.get();
 
 // Use the client to query the blockchain
-const balance = await client.getBalance({
+const balance = await client.core.getBalance({
 	owner: '0x...',
 });
 ```

--- a/packages/docs/content/kiosk/advanced-examples.mdx
+++ b/packages/docs/content/kiosk/advanced-examples.mdx
@@ -9,8 +9,9 @@ keywords: [Kiosk SDK, advanced examples, transfer policy, purchase, listing, Sui
 For these examples, assume you have the following data and functions available:
 
 ```typescript
-import { kiosk, KioskTransaction } from '@mysten/kiosk';
+import { kiosk, KioskTransaction, type KioskOwnerCap } from '@mysten/kiosk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 // a constant for bullshark's type.
 const bullsharkType = `${packageId}::suifrens::SuiFren<${packageId}::bullshark::Bullshark>`;

--- a/packages/docs/content/kiosk/advanced-examples.mdx
+++ b/packages/docs/content/kiosk/advanced-examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: Advanced Examples
-description: Advanced Kiosk SDK usage patterns and code examples for complex scenarios.
+description: Advanced Kiosk SDK usage patterns and code examples for complex scenarios
 keywords: [Kiosk SDK, advanced examples, transfer policy, purchase, listing, Sui, TypeScript]
 ---
 
@@ -10,7 +10,7 @@ For these examples, assume you have the following data and functions available:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 // a constant for bullshark's type.
 const bullsharkType = `${packageId}::suifrens::SuiFren<${packageId}::bullshark::Bullshark>`;
@@ -18,8 +18,8 @@ const bullsharkType = `${packageId}::suifrens::SuiFren<${packageId}::bullshark::
 const capyType = `${packageId}::suifrens::SuiFren<${packageId}::capy::Capy>`;
 
 // initialize the client with the kiosk extension.
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 }).$extend(kiosk());
 ```

--- a/packages/docs/content/kiosk/advanced-examples.mdx
+++ b/packages/docs/content/kiosk/advanced-examples.mdx
@@ -10,7 +10,7 @@ For these examples, assume you have the following data and functions available:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // a constant for bullshark's type.
 const bullsharkType = `${packageId}::suifrens::SuiFren<${packageId}::bullshark::Bullshark>`;
@@ -18,8 +18,8 @@ const bullsharkType = `${packageId}::suifrens::SuiFren<${packageId}::bullshark::
 const capyType = `${packageId}::suifrens::SuiFren<${packageId}::capy::Capy>`;
 
 // initialize the client with the kiosk extension.
-const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(kiosk());
 ```

--- a/packages/docs/content/kiosk/from-v1.mdx
+++ b/packages/docs/content/kiosk/from-v1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating from Kiosk SDK V1
-description: Migrate from Kiosk SDK v1 to the current version with the builder-pattern API.
+description: Migrate from Kiosk SDK v1 to the current version with the builder-pattern API
 keywords: [Kiosk SDK, migration, v1, upgrade, builder pattern, Personal Kiosk, Sui]
 ---
 
@@ -49,11 +49,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -105,11 +105,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -208,11 +208,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -309,11 +309,11 @@ On the new SDK, the same transaction can be built as follows:
 
 ```typescript
 import { kiosk, TransferPolicyTransaction, percentageToBasisPoints } from '@mysten/kiosk';
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 }).$extend(kiosk());
 

--- a/packages/docs/content/kiosk/from-v1.mdx
+++ b/packages/docs/content/kiosk/from-v1.mdx
@@ -49,11 +49,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -105,11 +105,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -208,11 +208,11 @@ Using the new SDK, you can build the same transaction as follows:
 
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(kiosk());
 
@@ -309,11 +309,11 @@ On the new SDK, the same transaction can be built as follows:
 
 ```typescript
 import { kiosk, TransferPolicyTransaction, percentageToBasisPoints } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // You need to do this only once and re-use it in the application.
-const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(kiosk());
 

--- a/packages/docs/content/kiosk/from-v1.mdx
+++ b/packages/docs/content/kiosk/from-v1.mdx
@@ -50,6 +50,7 @@ Using the new SDK, you can build the same transaction as follows:
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 // You need to do this only once and re-use it in the application.
 const client = new SuiGrpcClient({
@@ -106,6 +107,7 @@ Using the new SDK, you can build the same transaction as follows:
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 // You need to do this only once and re-use it in the application.
 const client = new SuiGrpcClient({
@@ -138,6 +140,7 @@ import {
 	testnetEnvironment,
 } from '@mysten/kiosk';
 import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 const client = new SuiJsonRpcClient({
 	url: 'https://fullnode.testnet.sui.io:443',
@@ -209,6 +212,7 @@ Using the new SDK, you can build the same transaction as follows:
 ```typescript
 import { kiosk, KioskTransaction } from '@mysten/kiosk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 // You need to do this only once and re-use it in the application.
 const client = new SuiGrpcClient({
@@ -310,6 +314,7 @@ On the new SDK, the same transaction can be built as follows:
 ```typescript
 import { kiosk, TransferPolicyTransaction, percentageToBasisPoints } from '@mysten/kiosk';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { Transaction } from '@mysten/sui/transactions';
 
 // You need to do this only once and re-use it in the application.
 const client = new SuiGrpcClient({

--- a/packages/docs/content/kiosk/index.mdx
+++ b/packages/docs/content/kiosk/index.mdx
@@ -21,4 +21,9 @@ using `$extend(kiosk())` to access kiosk functionality through `client.kiosk`.
 The Kiosk extension accepts any Sui client that implements `ClientWithCoreApi`. Use `SuiGrpcClient`
 for new Kiosk code; `SuiGraphQLClient` and the deprecated `SuiJsonRpcClient` are also compatible.
 
+<Callout type="info">
+	The gRPC object API returns Display v2 metadata. Use GraphQL or JSON-RPC when reading objects
+	whose types still rely on legacy Display metadata.
+</Callout>
+
 - [Read more about setting up the Kiosk client extension](/kiosk/kiosk-client/introduction)

--- a/packages/docs/content/kiosk/index.mdx
+++ b/packages/docs/content/kiosk/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kiosk SDK
-description: TypeScript SDK for interacting with Sui Kiosk onchain commerce.
+description: TypeScript SDK for interacting with Sui Kiosk onchain commerce
 keywords: [Kiosk SDK, Sui, onchain commerce, NFT, marketplace, TypeScript, mysten/kiosk]
 ---
 
@@ -18,7 +18,7 @@ npm i @mysten/kiosk
 The Kiosk SDK exports a client extension that integrates with Sui clients. Add it to your client
 using `$extend(kiosk())` to access kiosk functionality through `client.kiosk`.
 
-> The Kiosk SDK requires `SuiJsonRpcClient` or `SuiGraphQLClient`. It does not work with
-> `SuiGrpcClient` because it uses event queries that are not available in gRPC.
+> The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
+> `SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
 
 - [Read more about setting up the Kiosk client extension](/kiosk/kiosk-client/introduction)

--- a/packages/docs/content/kiosk/index.mdx
+++ b/packages/docs/content/kiosk/index.mdx
@@ -18,7 +18,7 @@ npm i @mysten/kiosk
 The Kiosk SDK exports a client extension that integrates with Sui clients. Add it to your client
 using `$extend(kiosk())` to access kiosk functionality through `client.kiosk`.
 
-> The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
-> `SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
+The Kiosk extension accepts any Sui client that implements `ClientWithCoreApi`. Use `SuiGrpcClient`
+for new Kiosk code; `SuiGraphQLClient` and the deprecated `SuiJsonRpcClient` are also compatible.
 
 - [Read more about setting up the Kiosk client extension](/kiosk/kiosk-client/introduction)

--- a/packages/docs/content/kiosk/kiosk-client/introduction.mdx
+++ b/packages/docs/content/kiosk/kiosk-client/introduction.mdx
@@ -12,6 +12,11 @@ The Kiosk SDK exports a client extension that provides all Kiosk functionality.
 The Kiosk extension accepts any Sui client that implements `ClientWithCoreApi`. Use `SuiGrpcClient`
 for new Kiosk code; `SuiGraphQLClient` and the deprecated `SuiJsonRpcClient` are also compatible.
 
+<Callout type="info">
+	The gRPC object API returns Display v2 metadata. Use GraphQL or JSON-RPC when reading objects
+	whose types still rely on legacy Display metadata.
+</Callout>
+
 ## Setting up the kiosk extension
 
 Add the kiosk extension to your Sui client using `$extend()`. The extension currently supports

--- a/packages/docs/content/kiosk/kiosk-client/introduction.mdx
+++ b/packages/docs/content/kiosk/kiosk-client/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kiosk Client
-description: Introduction to the KioskClient extension for querying and managing kiosks on Sui.
+description: Introduction to the KioskClient extension for querying and managing kiosks on Sui
 keywords: [KioskClient, kiosk extension, $extend, Sui client, setup, mainnet, testnet]
 ---
 
@@ -9,8 +9,8 @@ The Kiosk SDK exports a client extension that provides all Kiosk functionality.
 > We recommend you keep only one client instance throughout your app or script. For example, in
 > React, you'd use a context to provide the client.
 
-> The Kiosk SDK requires `SuiJsonRpcClient` or `SuiGraphQLClient`. It does not work with
-> `SuiGrpcClient` because it uses event queries that are not available in gRPC.
+> The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
+> `SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
 
 ## Setting up the kiosk extension
 
@@ -22,10 +22,10 @@ require constantly changing the package IDs).
 
 ```typescript
 import { kiosk } from '@mysten/kiosk';
-import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('testnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://graphql.testnet.sui.io/graphql',
 	network: 'testnet',
 }).$extend(kiosk());
 
@@ -40,10 +40,10 @@ for the rules and extensions you want to use.
 
 ```typescript
 import { kiosk } from '@mysten/kiosk';
-import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('devnet'),
+const client = new SuiGraphQLClient({
+	url: 'https://graphql.devnet.sui.io/graphql',
 	network: 'devnet',
 }).$extend(
 	kiosk({

--- a/packages/docs/content/kiosk/kiosk-client/introduction.mdx
+++ b/packages/docs/content/kiosk/kiosk-client/introduction.mdx
@@ -9,8 +9,8 @@ The Kiosk SDK exports a client extension that provides all Kiosk functionality.
 > We recommend you keep only one client instance throughout your app or script. For example, in
 > React, you'd use a context to provide the client.
 
-> The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
-> `SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
+The Kiosk extension accepts any Sui client that implements `ClientWithCoreApi`. Use `SuiGrpcClient`
+for new Kiosk code; `SuiGraphQLClient` and the deprecated `SuiJsonRpcClient` are also compatible.
 
 ## Setting up the kiosk extension
 
@@ -22,10 +22,10 @@ require constantly changing the package IDs).
 
 ```typescript
 import { kiosk } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-const client = new SuiGraphQLClient({
-	url: 'https://graphql.testnet.sui.io/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
 	network: 'testnet',
 }).$extend(kiosk());
 
@@ -40,10 +40,10 @@ for the rules and extensions you want to use.
 
 ```typescript
 import { kiosk } from '@mysten/kiosk';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-const client = new SuiGraphQLClient({
-	url: 'https://graphql.devnet.sui.io/graphql',
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.devnet.sui.io:443',
 	network: 'devnet',
 }).$extend(
 	kiosk({

--- a/packages/docs/content/sui/clients/core.mdx
+++ b/packages/docs/content/sui/clients/core.mdx
@@ -101,9 +101,7 @@ List objects owned by an address.
 ```typescript
 const result = await client.core.listOwnedObjects({
 	owner: '0xabc...',
-	filter: {
-		StructType: '0x2::coin::Coin<0x2::sui::SUI>',
-	},
+	type: '0x2::coin::Coin<0x2::sui::SUI>',
 	limit: 10,
 });
 
@@ -367,9 +365,12 @@ const result = await client.core.simulateTransaction({
 	},
 });
 
+const simulatedTransaction =
+	result.$kind === 'Transaction' ? result.Transaction : result.FailedTransaction;
+
 // Check simulated effects before signing
-console.log(result.effects);
-console.log(result.balanceChanges);
+console.log(simulatedTransaction.effects);
+console.log(simulatedTransaction.balanceChanges);
 ```
 
 #### Disabling checks

--- a/packages/docs/content/sui/clients/core.mdx
+++ b/packages/docs/content/sui/clients/core.mdx
@@ -1,6 +1,6 @@
 ---
 title: Core API
-description: Transport-agnostic Core API shared by all Sui clients.
+description: Transport-agnostic Core API shared by Sui clients
 keywords:
   [
     Core API,
@@ -14,9 +14,14 @@ keywords:
   ]
 ---
 
-The Core API is the transport-agnostic interface that all Sui clients implement. It provides a
-consistent set of methods for interacting with the Sui blockchain, regardless of whether you're
-using gRPC, GraphQL, or JSON-RPC.
+The Core API is the transport-agnostic interface shared by Sui clients. It provides a consistent set
+of methods for interacting with the Sui blockchain across `SuiGrpcClient`, `SuiGraphQLClient`, and
+the deprecated `SuiJsonRpcClient`.
+
+For application code, prefer the top-level methods on the concrete client you instantiate, such as
+`grpcClient.getObject()` or `graphqlClient.listTransactions()`. Those methods match the Core API for
+common operations and may expose transport-specific additions. Use `client.core` when writing SDKs,
+libraries, or helpers that accept any `ClientWithCoreApi`.
 
 ## `ClientWithCoreApi`
 

--- a/packages/docs/content/sui/clients/graphql.mdx
+++ b/packages/docs/content/sui/clients/graphql.mdx
@@ -1,6 +1,6 @@
 ---
 title: SuiGraphQLClient
-description: Connect to Sui through GraphQL with SuiGraphQLClient.
+description: Connect to Sui through GraphQL with SuiGraphQLClient
 keywords:
   [
     SuiGraphQLClient,
@@ -19,7 +19,13 @@ The `SuiGraphQLClient` enables type-safe GraphQL queries against the Sui GraphQL
 For more details on the Sui GraphQL API, see the
 [GraphQL reference](https://docs.sui.io/references/sui-graphql).
 
-The `SuiGraphQLClient` implements all the the [Core API](/sui/clients/core) methods:
+Use `SuiGraphQLClient` when an app needs indexed GraphQL data, historical queries, or custom
+selection sets that are not exposed by the gRPC top-level API.
+
+## Using top-level methods
+
+`SuiGraphQLClient` exposes top-level methods for the same common operations as the
+[Core API](/sui/clients/core). Use them directly in application code:
 
 ```typescript
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
@@ -29,12 +35,39 @@ const client = new SuiGraphQLClient({
 	network: 'mainnet',
 });
 
-const { object } = await client.getObject({ objectId: '0x...' });
+const { object } = await client.getObject({
+	objectId: '0x...',
+	include: { content: true },
+});
+
+const txs = await client.listTransactions({
+	filter: { sender: '0x...' },
+	order: 'descending',
+	limit: 10,
+});
 ```
+
+The same methods are available through `client.core` when SDK code needs the transport-agnostic
+`ClientWithCoreApi` contract.
+
+Common top-level methods:
+
+| Category       | Methods                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
+| Simulation     | `simulateTransaction`                                                                     |
+| Queries        | `listTransactions`, `listEvents`                                                          |
+| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
+| Verification   | `verifyZkLoginSignature`                                                                  |
+
+GraphQL-specific top-level options include `doGasSelection` on `simulateTransaction` and
+`include: { value: true }` on `listDynamicFields`.
 
 ## Custom GraphQL queries
 
-To query anything no in the Core API, you can use the `query` method to execute custom GraphQL
+To query anything not in the top-level API, use the `query` method to execute custom GraphQL
 queries.
 
 We'll start by creating our client, and executing a very basic query:
@@ -102,6 +135,7 @@ work with the majority of popular GraphQL clients to provide queries that are au
 
 ```typescript
 import { useQuery } from '@apollo/client';
+import { graphql } from '@mysten/sui/graphql/schema';
 
 const chainIdentifierQuery = graphql(`
 	query {
@@ -110,7 +144,7 @@ const chainIdentifierQuery = graphql(`
 `);
 
 function ChainIdentifier() {
-	const { loading, error, data } = useQuery(getPokemonsQuery);
+	const { loading, error, data } = useQuery(chainIdentifierQuery);
 
 	return <div>{data?.chainIdentifier}</div>;
 }

--- a/packages/docs/content/sui/clients/graphql.mdx
+++ b/packages/docs/content/sui/clients/graphql.mdx
@@ -31,7 +31,7 @@ selection sets that are not exposed by the gRPC top-level API.
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 const client = new SuiGraphQLClient({
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+	url: 'https://graphql.mainnet.sui.io/graphql',
 	network: 'mainnet',
 });
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -1,6 +1,6 @@
 ---
 title: SuiGrpcClient
-description: Connect to Sui through gRPC with SuiGrpcClient.
+description: Connect to Sui through gRPC with the recommended SuiGrpcClient
 keywords:
   [
     SuiGrpcClient,
@@ -14,7 +14,8 @@ keywords:
   ]
 ---
 
-The `SuiGrpcClient` provides access to the Full Node gRPC API.
+The `SuiGrpcClient` provides access to the Full Node gRPC API. It is the recommended default client
+for application code and SDK integrations.
 
 For more complete details on what is available through this API see the
 [gRPC API docs](https://docs.sui.io/develop/accessing-data/grpc/what-is-grpc).
@@ -40,6 +41,75 @@ const grpcClient = new SuiGrpcClient({
 	baseUrl: 'http://127.0.0.1:9000',
 });
 ```
+
+## Using top-level methods
+
+Use top-level methods for most application code. These methods match the shared
+[Core API](/sui/clients/core) option and response shapes, so the same calls can also be written as
+`grpcClient.core.<method>()` when SDK code needs the transport-agnostic `ClientWithCoreApi`
+contract.
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const grpcClient = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://fullnode.testnet.sui.io:443',
+});
+
+const { balance } = await grpcClient.getBalance({
+	owner: '<OWNER_ADDRESS>',
+});
+
+const { object } = await grpcClient.getObject({
+	objectId: '<OBJECT_ID>',
+	include: { content: true, display: true },
+});
+
+const coins = await grpcClient.listCoins({
+	owner: '<OWNER_ADDRESS>',
+	coinType: '0x2::sui::SUI',
+});
+```
+
+Common top-level methods:
+
+| Category       | Methods                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
+| Simulation     | `simulateTransaction`                                                                     |
+| Queries        | `listTransactions`, `listEvents`                                                          |
+| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
+| Verification   | `verifyZkLoginSignature`                                                                  |
+
+### gRPC-specific top-level data
+
+Top-level gRPC methods are a superset of the shared Core API where the transport can expose useful
+gRPC data directly:
+
+```typescript
+const result = await grpcClient.getTransaction({
+	digest: '<TRANSACTION_DIGEST>',
+	include: {
+		effects: true,
+		protoJson: true,
+	},
+});
+
+const tx = result.Transaction ?? result.FailedTransaction;
+console.log(tx.digest, result.protoJson);
+```
+
+gRPC-specific options include:
+
+| Option                     | Methods                                                                                   |
+| -------------------------- | ----------------------------------------------------------------------------------------- |
+| `include.protoJson`        | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
+| `include.protoJson`        | `simulateTransaction`                                                                     |
+| `doGasSelection`           | `simulateTransaction`                                                                     |
+| `include: { value: true }` | `listDynamicFields`                                                                       |
 
 ## Transport options
 
@@ -124,23 +194,25 @@ service clients are generated using [protobuf-ts](https://github.com/timostamm/p
 provides type-safe gRPC clients for TypeScript. For more details on how to use gRPC with Sui, see
 the [gRPC overview](https://docs.sui.io/develop/accessing-data/grpc/what-is-grpc).
 
-### With the core API
+### Prefer top-level methods first
 
-The gRPC client implements all the [`core`](./core) API methods:
+For common operations, call the top-level method before reaching for raw service clients:
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+
 const grpcClient = new SuiGrpcClient({
 	network: 'testnet',
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
-// Get coins owned by an address
-await grpcClient.getCoins({
+
+await grpcClient.listCoins({
 	owner: '<OWNER_ADDRESS>',
 });
 ```
 
-To query additional data not available in the core API, you can use the service clients directly:
+Use the generated service clients directly when you need gRPC methods, read masks, streaming
+behavior, or filters that are not exposed by the top-level API.
 
 ### Transaction execution service
 

--- a/packages/docs/content/sui/clients/index.mdx
+++ b/packages/docs/content/sui/clients/index.mdx
@@ -1,31 +1,33 @@
 ---
 title: Sui Clients
-description: 'Choose and configure gRPC, GraphQL, or JSON-RPC clients for the Sui network.'
+description: Choose and configure SuiGrpcClient, SuiGraphQLClient, and legacy JSON-RPC clients
 keywords:
   [Sui client, gRPC, GraphQL, JSON-RPC, SuiGrpcClient, SuiGraphQLClient, SuiJsonRpcClient, Core API]
 ---
 
 The Sui TypeScript SDK provides multiple client implementations for interacting with the Sui
-network. Each client connects to a different API but provides two levels of access:
+network. For application code, choose one client for your transport and use its top-level methods
+for common reads, writes, and queries. `SuiGrpcClient` is the recommended default.
 
-- Native API: Full access to everything the underlying API offers
-- [Core API](/sui/clients/core): A consistent interface across all clients for common operations
+Each client exposes three useful surfaces:
+
+- Top-level methods: the main application API, matching the Core API for common operations
+- [Core API](/sui/clients/core): the shared `client.core` contract used by SDKs and libraries
+- Native API: direct access to transport-specific features when the common methods are not enough
 
 ## Available clients
 
-| Client                                                   | API                                                                |
-| -------------------------------------------------------- | ------------------------------------------------------------------ |
-| [`SuiGrpcClient`](/sui/clients/grpc) (recommended)       | [Full Node gRPC](https://docs.sui.io/references/fullnode-protocol) |
-| [`SuiGraphQLClient`](/sui/clients/graphql)               | [GraphQL](https://docs.sui.io/references/sui-graphql)              |
-| [`SuiJsonRpcClient`](/sui/clients/json-rpc) (deprecated) | [JSON-RPC (deprecated)](https://docs.sui.io/sui-api-ref)           |
+| Client                                                   | Use For                                                                 |
+| -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [`SuiGrpcClient`](/sui/clients/grpc) (recommended)       | Most application and SDK operations, full node data, execution, streams |
+| [`SuiGraphQLClient`](/sui/clients/graphql)               | Indexed queries, historical data, or custom GraphQL selection sets      |
+| [`SuiJsonRpcClient`](/sui/clients/json-rpc) (deprecated) | Maintaining legacy JSON-RPC code while migrating to gRPC or GraphQL     |
 
-All clients are compatible with Mysten SDKs like `@mysten/walrus`, `@mysten/seal` and
-`@mysten/suins`.
-
-For most application gRPC is a good default. The JSON RPC API has been deprecated and will be
-decommissioned soon. The GraphQL can be used for more advanced query patterns that can not be
-supported directly on full nodes (for example, querying for transactions or events with various
-filters).
+All active Mysten SDKs are designed to accept clients that implement the Core API. `SuiGrpcClient`
+is the default choice for most apps because it uses the full node gRPC API and has the most complete
+top-level SDK surface. Use `SuiGraphQLClient` when the code needs GraphQL-specific indexed queries
+or a custom query shape. JSON-RPC APIs are deprecated in the Sui TypeScript SDK; migrate legacy
+JSON-RPC code to gRPC or GraphQL.
 
 ## Quick start
 
@@ -37,28 +39,85 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 });
 
-// Use the native API for full access to transport-specific features
-const { response } = await client.ledgerService.getTransaction({ digest: '0x...' });
-
-// Use the Core API for transport-agnostic operations
-const { object } = await client.core.getObject({ objectId: '0x...' });
+const { balance } = await client.getBalance({ owner: '0x...' });
+const { object } = await client.getObject({
+	objectId: '0x...',
+	include: { content: true },
+});
 ```
 
-## Native vs core API
+## Top-level, core, and native APIs
+
+### Top-level methods
+
+Use top-level methods when writing app code against a concrete client like `SuiGrpcClient` or
+`SuiGraphQLClient`. These methods use the same option and response shapes as the Core API, and a
+transport can add narrowly scoped fields where it has extra native data.
+
+```typescript
+const { objects } = await client.listOwnedObjects({
+	owner: '0x...',
+	include: { display: true },
+});
+
+const result = await client.signAndExecuteTransaction({
+	transaction,
+	signer,
+	include: { effects: true, balanceChanges: true },
+});
+```
+
+Common top-level methods include:
+
+| Category       | Methods                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
+| Simulation     | `simulateTransaction`                                                                     |
+| Queries        | `listTransactions`, `listEvents`                                                          |
+| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
+| Verification   | `verifyZkLoginSignature`                                                                  |
+
+### Core API
+
+Use `client.core` when building SDKs or libraries that accept any client implementing
+`ClientWithCoreApi`. The Core API is the shared contract that `SuiGrpcClient`, `SuiGraphQLClient`,
+and the deprecated `SuiJsonRpcClient` implement.
+
+```typescript
+import type { ClientWithCoreApi } from '@mysten/sui/client';
+
+export async function fetchResource(client: ClientWithCoreApi, objectId: string) {
+	return client.core.getObject({
+		objectId,
+		include: { content: true },
+	});
+}
+```
 
 ### Native API
 
 Each client exposes the full capabilities of its underlying transport. Use the native API when you
-need transport-specific features or want maximum control:
+need transport-specific features or want maximum control.
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
 import { graphql } from '@mysten/sui/graphql/schema';
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+
+const grpcClient = new SuiGrpcClient({
+	network: 'mainnet',
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
+});
 
 // gRPC - access various service clients to call any gRPC method
 const { response } = await grpcClient.stateService.listOwnedObjects({ owner: '0x...' });
+
+const graphqlClient = new SuiGraphQLClient({
+	network: 'mainnet',
+	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+});
 
 // GraphQL - write type-safe custom queries using the graphql function
 const result = await graphqlClient.query({
@@ -68,25 +127,10 @@ const result = await graphqlClient.query({
 		}
 	`),
 });
-
-// JSON-RPC - call any JSON-RPC method
-const coins = await jsonRpcClient.getCoins({ owner: '0x...' });
 ```
 
-### Core API
-
-All clients also implement the [Core API](/sui/clients/core) through `client.core`. This provides a
-consistent interface for common operations that works identically across all transports:
-
-```typescript
-// These methods work the same on any client
-const { object } = await client.core.getObject({ objectId: '0x...' });
-const balance = await client.core.getBalance({ owner: '0x...' });
-await client.core.executeTransaction({ transaction, signatures });
-```
-
-The Core API is essential for [building SDKs](/sui/sdk-building) that work with any client the user
-chooses.
+For legacy JSON-RPC-only code, see the [`SuiJsonRpcClient` page](/sui/clients/json-rpc) and the
+[JSON-RPC migration guide](/sui/migrations/sui-2.0/json-rpc-migration).
 
 ## Client extensions
 

--- a/packages/docs/content/sui/clients/index.mdx
+++ b/packages/docs/content/sui/clients/index.mdx
@@ -9,11 +9,14 @@ The Sui TypeScript SDK provides multiple client implementations for interacting 
 network. For application code, choose one client for your transport and use its top-level methods
 for common reads, writes, and queries. `SuiGrpcClient` is the recommended default.
 
-Each client exposes three useful surfaces:
+The gRPC and GraphQL clients expose three useful surfaces:
 
 - Top-level methods: the main application API, matching the Core API for common operations
 - [Core API](/sui/clients/core): the shared `client.core` contract used by SDKs and libraries
 - Native API: direct access to transport-specific features when the common methods are not enough
+
+The deprecated `SuiJsonRpcClient` also exposes `client.core`, but its top-level methods retain their
+legacy JSON-RPC names and response shapes.
 
 ## Available clients
 
@@ -50,9 +53,10 @@ const { object } = await client.getObject({
 
 ### Top-level methods
 
-Use top-level methods when writing app code against a concrete client like `SuiGrpcClient` or
-`SuiGraphQLClient`. These methods use the same option and response shapes as the Core API, and a
-transport can add narrowly scoped fields where it has extra native data.
+Use top-level methods when writing app code against `SuiGrpcClient` or `SuiGraphQLClient`. These
+methods use the same option and response shapes as the Core API, and a transport can add narrowly
+scoped fields where it has extra native data. For `SuiJsonRpcClient`, use `client.core` for these
+shapes or migrate its legacy top-level calls to gRPC or GraphQL.
 
 ```typescript
 const { objects } = await client.listOwnedObjects({
@@ -116,7 +120,7 @@ const { response } = await grpcClient.stateService.listOwnedObjects({ owner: '0x
 
 const graphqlClient = new SuiGraphQLClient({
 	network: 'mainnet',
-	url: 'https://sui-mainnet.mystenlabs.com/graphql',
+	url: 'https://graphql.mainnet.sui.io/graphql',
 });
 
 // GraphQL - write type-safe custom queries using the graphql function

--- a/packages/docs/content/sui/clients/json-rpc.mdx
+++ b/packages/docs/content/sui/clients/json-rpc.mdx
@@ -1,6 +1,6 @@
 ---
 title: SuiJsonRpcClient
-description: Connect to Sui through JSON-RPC with SuiJsonRpcClient.
+description: Maintain legacy JSON-RPC code while migrating to SuiGrpcClient or SuiGraphQLClient
 keywords:
   [
     SuiJsonRpcClient,
@@ -15,13 +15,18 @@ keywords:
 ---
 
 <Callout type="warn">
-	The Sui JSON-RPC API has been deprecated. We recommend migration to
-	[`SuiGrpcClient`](/sui/clients/grpc) or [`SuiGraphQLClient`](/sui/clients/graphql) as soon as
-	possible.
+	JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use [`SuiGrpcClient`](/sui/clients/grpc)
+	for most application code, or [`SuiGraphQLClient`](/sui/clients/graphql) for GraphQL-specific
+	indexed queries.
 </Callout>
 
-The `SuiJsonRpcClient` connects to a Sui network's JSON-RPC server. It implements the
-[Core API](/sui/clients/core), so it can be used with any SDK that accepts `ClientWithCoreApi`.
+This page exists for maintaining legacy JSON-RPC code. New code should use
+[`SuiGrpcClient`](/sui/clients/grpc) and its top-level methods by default. See
+[Migrating from JSON-RPC](/sui/migrations/sui-2.0/json-rpc-migration) for replacement examples.
+
+The `SuiJsonRpcClient` connects to a Sui network's JSON-RPC server. It also implements the
+[Core API](/sui/clients/core), so SDKs that accept `ClientWithCoreApi` can support it during a
+migration.
 
 ```typescript
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
@@ -37,9 +42,9 @@ const { object } = await client.core.getObject({ objectId: '0x...' });
 
 ## Connecting to a Sui network
 
-To establish a connection to a network, import `SuiJsonRpcClient` from `@mysten/sui/client` and pass
-the relevant URL to the `url` parameter. The following example establishes a connection to Devnet
-and get all `Coin<coin_type>` objects owned by an address.
+To establish a legacy JSON-RPC connection, import `SuiJsonRpcClient` from `@mysten/sui/jsonRpc` and
+pass the relevant URL to the `url` parameter. The following example establishes a connection to
+Devnet and gets all `Coin<coin_type>` objects owned by an address.
 
 ```typescript
 import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
@@ -90,20 +95,16 @@ For a full list of available RPC methods, see the
 ## Customizing the transport
 
 The `SuiJsonRpcClient` uses a `Transport` class to manage connections to the RPC node. The default
-`SuiHTTPTransport` (alias for `JsonRpcHTTPTransport`) makes both JSON RPC requests, as well as
-websocket requests for subscriptions. You can construct a custom transport instance if you need to
-pass any custom options, such as headers or timeout values.
+`SuiHTTPTransport` alias for `JsonRpcHTTPTransport` makes HTTP JSON-RPC requests. You can construct
+a custom transport instance if you need to pass custom options, such as headers or timeout values.
 
 ```typescript
 import { SuiJsonRpcClient, JsonRpcHTTPTransport } from '@mysten/sui/jsonRpc';
 
 const client = new SuiJsonRpcClient({
+	network: 'devnet',
 	transport: new JsonRpcHTTPTransport({
 		url: 'https://fullnode.devnet.sui.io:443',
-		websocket: {
-			reconnectTimeout: 1000,
-			url: 'wss://fullnode.devnet.sui.io:443',
-		},
 		rpc: {
 			headers: {
 				'x-custom-header': 'custom value',

--- a/packages/docs/content/sui/clients/json-rpc.mdx
+++ b/packages/docs/content/sui/clients/json-rpc.mdx
@@ -84,6 +84,7 @@ import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
 
 const client = new SuiJsonRpcClient({
 	url: 'https://fullnode.devnet.sui.io:443',
+	network: 'devnet',
 });
 // asynchronously call suix_getCommitteeInfo
 const committeeInfo = await client.call('suix_getCommitteeInfo', []);
@@ -94,9 +95,9 @@ For a full list of available RPC methods, see the
 
 ## Customizing the transport
 
-The `SuiJsonRpcClient` uses a `Transport` class to manage connections to the RPC node. The default
-`SuiHTTPTransport` alias for `JsonRpcHTTPTransport` makes HTTP JSON-RPC requests. You can construct
-a custom transport instance if you need to pass custom options, such as headers or timeout values.
+The `SuiJsonRpcClient` uses a transport to manage connections to the RPC node. By default it creates
+a `JsonRpcHTTPTransport` for HTTP JSON-RPC requests. You can construct a custom transport instance
+if you need to pass options such as headers or a custom `fetch` implementation.
 
 ```typescript
 import { SuiJsonRpcClient, JsonRpcHTTPTransport } from '@mysten/sui/jsonRpc';
@@ -169,8 +170,8 @@ const result = await client.executeTransactionBlock({
 
 #### Arguments
 
-- `transactionBlock`: either a Transaction or BCS serialized transaction data bytes as a Uint8Array
-  or as a base-64 encoded string.
+- `transactionBlock`: BCS serialized transaction data bytes as a `Uint8Array` or base64-encoded
+  string.
 - `signature`: A signature, or list of signatures committed to the intent message of the transaction
   data, as a base-64 encoded string.
 - `options`:
@@ -197,15 +198,14 @@ const result = await client.signAndExecuteTransaction({
 });
 
 // IMPORTANT: Always check the transaction status
-if (result.$kind === 'FailedTransaction') {
-	throw new Error(`Transaction failed: ${result.FailedTransaction.status.error?.message}`);
+if (result.effects?.status.status === 'failure') {
+	throw new Error(`Transaction failed: ${result.effects.status.error}`);
 }
 ```
 
 #### Arguments
 
-- `transaction`: BCS serialized transaction data bytes as a Uint8Array or as a base-64 encoded
-  string.
+- `transaction`: A `Transaction` or BCS serialized transaction data bytes as a `Uint8Array`.
 - `signer`: A `Keypair` instance to sign the transaction
 - `options`:
   - `showBalanceChanges`: Whether to show balance_changes. Default to be False
@@ -227,15 +227,18 @@ const tx = new Transaction();
 const result = await client.signAndExecuteTransaction({
 	transaction: tx,
 	signer: keypair,
+	options: {
+		showEffects: true,
+	},
 });
 
 // Check transaction status
-if (result.$kind === 'FailedTransaction') {
-	throw new Error(`Transaction failed: ${result.FailedTransaction.status.error?.message}`);
+if (result.effects?.status.status === 'failure') {
+	throw new Error(`Transaction failed: ${result.effects.status.error}`);
 }
 
 const transaction = await client.waitForTransaction({
-	digest: result.Transaction.digest,
+	digest: result.digest,
 	options: {
 		showEffects: true,
 	},

--- a/packages/docs/content/sui/executors.mdx
+++ b/packages/docs/content/sui/executors.mdx
@@ -42,14 +42,14 @@ transactions to finish before sending the next one.
 
 - `client`: An instance of a Sui client (such as `SuiGrpcClient`) used to execute transactions.
 - `signer`: The signer/keypair used for signed transactions.
-- `defaultBudget`: The default budget for transactions, which will be used if the transaction does
-  not specify a budget (default `50_000_000n`).
+- `defaultGasBudget`: The default budget for transactions, which will be used if the transaction
+  does not specify a budget (default `50_000_000n`).
 - `gasMode`: Either `'coins'` (default) to use owned coins for gas, or `'addressBalance'` to pay gas
   from the sender's address balance.
 
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { SerialTransactionExecutor } from '@mysten/sui/transactions';
+import { SerialTransactionExecutor, Transaction } from '@mysten/sui/transactions';
 
 const client = new SuiGrpcClient({
 	network: 'devnet',
@@ -68,10 +68,18 @@ const tx2 = new Transaction();
 const [coin2] = tx2.splitCoins(tx2.gas, [1]);
 tx2.transferObjects([coin2], address2);
 
-const [{ digest: digest1 }, { digest: digest2 }] = await Promise.all([
+const results = await Promise.all([
 	executor.executeTransaction(tx1),
 	executor.executeTransaction(tx2),
 ]);
+
+const [digest1, digest2] = results.map((result) => {
+	if (result.$kind === 'FailedTransaction') {
+		throw new Error(`Transaction failed: ${result.FailedTransaction.status.error.message}`);
+	}
+
+	return result.Transaction.digest;
+});
 ```
 
 ## `ParallelTransactionExecutor`
@@ -113,20 +121,16 @@ way that avoids conflicts between transactions using the same object ids.
   `200_000_000n`),
 - `minimumCoinBalance`: After executing a transaction, the gasCoin will be reused unless it's
   balance is below this value (default `50_000_000n`),
-- `defaultBudget`: The default budget for transactions, which will be used if the transaction does
-  not specify a budget (default `minimumCoinBalance`),
+- `defaultGasBudget`: The default budget for transactions, which will be used if the transaction
+  does not specify a budget (default `minimumCoinBalance`),
 - `maxPoolSize`: The maximum number of gas coins to keep in the gas pool, which also limits the
   maximum number of concurrent transactions (default 50),
 - `sourceCoins`: An array of coins to use to create the gas pool, defaults to using all coins owned
   by the signer.
-- `epochBoundaryWindow`: Time to wait before or after the expected epoch boundary before re-fetching
-  the gas pool (in milliseconds). Building transactions will be paused for up to 2x this duration
-  around each epoch boundary to ensure the gas price is up-to-date for the next epoch. (default
-  `1000`)
 
 ```ts
 import { SuiGrpcClient } from '@mysten/sui/grpc';
-import { ParallelTransactionExecutor } from '@mysten/sui/transactions';
+import { ParallelTransactionExecutor, Transaction } from '@mysten/sui/transactions';
 
 const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.devnet.sui.io:443',
@@ -145,10 +149,18 @@ const tx2 = new Transaction();
 const [coin2] = tx2.splitCoins(tx2.gas, [1]);
 tx2.transferObjects([coin2], address2);
 
-const [{ digest: digest1 }, { digest: digest2 }] = await Promise.all([
+const results = await Promise.all([
 	executor.executeTransaction(tx1),
 	executor.executeTransaction(tx2),
 ]);
+
+const [digest1, digest2] = results.map((result) => {
+	if (result.$kind === 'FailedTransaction') {
+		throw new Error(`Transaction failed: ${result.FailedTransaction.status.error.message}`);
+	}
+
+	return result.Transaction.digest;
+});
 ```
 
 ## Building and executing transactions with executors

--- a/packages/docs/content/sui/executors.mdx
+++ b/packages/docs/content/sui/executors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Transaction Executors
-description: Manage transaction execution with queuing and parallel strategies.
+description: Manage transaction execution with queuing and parallel strategies
 keywords:
   [
     transaction executor,
@@ -102,7 +102,7 @@ way that avoids conflicts between transactions using the same object ids.
 
 `ParallelTransactionExecutor` can be configured with a number of options:
 
-- `client`: An instance of `SuiJsonRpcClient` used to execute transactions.
+- `client`: A client implementing `ClientWithCoreApi`. `SuiGrpcClient` is the recommended default.
 - `signer`: The signer/keypair used for signed transactions.
 - `gasMode`: Either `'coins'` (default) to use owned coins for gas, or `'addressBalance'` to pay gas
   from the sender's address balance. When using `'addressBalance'`, coin-specific options like
@@ -125,10 +125,13 @@ way that avoids conflicts between transactions using the same object ids.
   `1000`)
 
 ```ts
-import { getJsonRpcFullnodeUrl, SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { ParallelTransactionExecutor } from '@mysten/sui/transactions';
 
-const client = new SuiJsonRpcClient({ url: getJsonRpcFullnodeUrl('devnet'), network: 'devnet' });
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.devnet.sui.io:443',
+	network: 'devnet',
+});
 
 const executor = new ParallelTransactionExecutor({
 	client,

--- a/packages/docs/content/sui/index.mdx
+++ b/packages/docs/content/sui/index.mdx
@@ -139,7 +139,7 @@ const grpcClient = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.devnet.sui.io:443',
 });
 
-const { balance } = await grpcClient.core.getBalance({
+const { balance } = await grpcClient.getBalance({
 	owner: keypair.toSuiAddress(),
 });
 

--- a/packages/docs/content/sui/migrations/sui-2.0/dapp-kit.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/dapp-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/dapp-kit'
-description: Migrate @mysten/dapp-kit to the new dapp-kit-react package in 2.0.
+description: Migrate @mysten/dapp-kit to the new dapp-kit-react package in 2.0
 keywords:
   [
     migration,
@@ -291,7 +291,7 @@ The built-in data fetching hooks have been removed. Use TanStack Query's `useQue
 - 	});
 + 	const { data, isLoading, error } = useQuery({
 + 		queryKey: ['object', objectId],
-+ 		queryFn: () => client.core.getObject({ objectId }),
++ 		queryFn: () => client.getObject({ objectId }),
 + 	});
   	// ...
   }
@@ -312,7 +312,7 @@ export function ExampleComponent({ objectId }: { objectId: string }) {
 	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
-		client.core
+		client
 			.getObject({ objectId })
 			.then((result) => setData(result.object ?? null))
 			.catch((err) => setError(err.message))

--- a/packages/docs/content/sui/migrations/sui-2.0/deepbook-v3.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/deepbook-v3.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/deepbook-v3'
-description: Migrate @mysten/deepbook-v3 to 2.0 with client extension pattern.
+description: Migrate @mysten/deepbook-v3 to 2.0 with client extension pattern
 keywords: [migration, '@mysten/deepbook-v3', DeepBook, 2.0, client extension, DEX, breaking changes]
 ---
 
@@ -9,7 +9,7 @@ This package now exports a client extension that integrates with Sui clients.
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
 - import { DeepBookClient } from '@mysten/deepbook-v3';
-+ import { SuiGrpcClient } from '@mysten/sui/grpc'; // or SuiJsonRpcClient, SuiGraphQLClient
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 + import { deepbook } from '@mysten/deepbook-v3';
 
 - const suiClient = new SuiClient({ url: getFullnodeUrl('mainnet') });

--- a/packages/docs/content/sui/migrations/sui-2.0/index.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: Migrate to 2.0
-description: Migration guide for Sui TypeScript SDK 2.0 covering all @mysten packages.
+description: Migration guide for Sui TypeScript SDK 2.0 covering all @mysten packages
 keywords: [migration, 2.0, upgrade, breaking changes, gRPC, GraphQL, ESM, '@mysten packages']
 ---
 
 This guide covers the breaking changes across the latest release of all the `@mysten/*` packages.
 
-The primary goal of this release is to support the new GRPC and GraphQL APIs across all the mysten
-SDKs. These releases also include removals of deprecated APIs, some renaming for better consistency,
-and significant internal refactoring to improve maintainability. Starting with this release, Mysten
+The primary goal of this release is to support the gRPC and GraphQL APIs across all Mysten SDKs.
+These releases also include removals of deprecated APIs, some renaming for better consistency, and
+significant internal refactoring to improve maintainability. Starting with this release, Mysten
 packages will now be published as ESM only packages.
 
 ## Quick reference
@@ -67,39 +67,44 @@ updates.
 
 ### Client migration
 
-The most common change across all SDKs is migrating from `SuiClient` to `SuiJsonRpcClient`:
+The recommended app migration is to create one `SuiGrpcClient` and use its top-level methods:
 
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
-+ import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 - const client = new SuiClient({ url: getFullnodeUrl('mainnet') });
-+ const client = new SuiJsonRpcClient({
-+   url: getJsonRpcFullnodeUrl('mainnet'),
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.mainnet.sui.io:443',
 +   network: 'mainnet',
 + });
 ```
 
-We also recommend moving from the deprecated JSON RPC APIs to the new gRPC API as soon as possible:
+Then migrate old JSON-RPC method names to the gRPC top-level methods:
 
 ```diff
-- import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-+ import { SuiGrpcClient } from '@mysten/sui/grpc';
+- const coins = await client.getCoins({ owner });
++ const coins = await client.listCoins({ owner });
 
-- const client = new SuiJsonRpcClient({ url, network: 'mainnet' });
-+ const client = new SuiGrpcClient({ baseUrl, network: 'mainnet' });
+- const txs = await client.queryTransactionBlocks({ filter, options });
++ const txs = await client.listTransactions({ filter, include });
 ```
 
-The gRPC runs on full nodes so in most cases you should be able to use the same URLs when migrating
-to gRPC.
+The gRPC API runs on full nodes, so in most cases you can use the same full node host when migrating
+from JSON-RPC to gRPC. Use `SuiGraphQLClient` for indexed or historical queries that are not covered
+by gRPC top-level methods.
+
+`SuiJsonRpcClient` still exists under `@mysten/sui/jsonRpc` for legacy code, but JSON-RPC APIs are
+deprecated in the Sui TypeScript SDK. See
+[Migrating from JSON-RPC](/sui/migrations/sui-2.0/json-rpc-migration) for detailed replacements.
 
 ### Network parameter required
 
 All client constructors now require an explicit `network` parameter:
 
 ```ts
-const client = new SuiJsonRpcClient({
-	url: getJsonRpcFullnodeUrl('mainnet'),
+const grpcClient = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet', // Required
 });
 
@@ -108,26 +113,34 @@ const graphqlClient = new SuiGraphQLClient({
 	network: 'mainnet', // Required
 });
 
-const grpcClient = new SuiGrpcClient({
-	baseUrl: 'https://fullnode.mainnet.sui.io:443',
+const jsonRpcClient = new SuiJsonRpcClient({
+	url: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet', // Required
 });
 ```
 
 ### `ClientWithCoreApi` Interface
 
-Many SDK methods now accept any client implementing `ClientWithCoreApi`, enabling use with JSON-RPC,
-GraphQL, or gRPC transports:
+Many SDK methods now accept any client implementing `ClientWithCoreApi`. SDKs use
+`client.core.<method>()` so they can work across `SuiGrpcClient`, `SuiGraphQLClient`, and the
+deprecated `SuiJsonRpcClient` while apps keep using the top-level methods on their chosen client:
 
 ```ts
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import type { ClientWithCoreApi } from '@mysten/sui/client';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 
-// All of these work with APIs that accept ClientWithCoreApi
-const jsonRpcClient = new SuiJsonRpcClient({ url, network: 'mainnet' });
-const graphqlClient = new SuiGraphQLClient({ url, network: 'mainnet' });
-const grpcClient = new SuiGrpcClient({ baseUrl, network: 'mainnet' });
+const client = new SuiGrpcClient({
+	baseUrl: 'https://fullnode.mainnet.sui.io:443',
+	network: 'mainnet',
+});
+
+// App code: use top-level methods.
+const { balance } = await client.getBalance({ owner });
+
+// SDK code: accept ClientWithCoreApi and use client.core.
+async function readForSdk(client: ClientWithCoreApi, objectId: string) {
+	return client.core.getObject({ objectId });
+}
 ```
 
 ## Package-specific guides

--- a/packages/docs/content/sui/migrations/sui-2.0/index.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/index.mdx
@@ -88,11 +88,18 @@ Then migrate old JSON-RPC method names to the gRPC top-level methods:
 
 - const txs = await client.queryTransactionBlocks({ filter, options });
 + const txs = await client.listTransactions({ filter, include });
+
+- const events = await client.queryEvents({ query, order: 'descending' });
++ const events = await client.listEvents({ filter, order: 'descending' });
+
+- const transaction = await client.getTransactionBlock({ digest, options });
++ const transaction = await client.getTransaction({ digest, include });
 ```
 
 The gRPC API runs on full nodes, so in most cases you can use the same full node host when migrating
-from JSON-RPC to gRPC. Use `SuiGraphQLClient` for indexed or historical queries that are not covered
-by gRPC top-level methods.
+from JSON-RPC to gRPC. Standard transaction and event queries are top-level methods on both
+`SuiGrpcClient` and `SuiGraphQLClient`. Use custom GraphQL queries for indexed data, historical
+object versions, or selection sets that are not covered by the shared methods.
 
 `SuiJsonRpcClient` still exists under `@mysten/sui/jsonRpc` for legacy code, but JSON-RPC APIs are
 deprecated in the Sui TypeScript SDK. See

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating from JSON-RPC
-description: Migrate from JSON-RPC to the new Core API using SuiGrpcClient or SuiGraphQLClient.
+description: Migrate deprecated JSON-RPC code to SuiGrpcClient, with GraphQL for indexed queries
 keywords:
   [
     migration,
@@ -14,25 +14,28 @@ keywords:
   ]
 ---
 
-This guide covers migrating from `SuiJsonRpcClient` to the new client APIs. The JSON-RPC API is
-being deprecated in favor of `SuiGrpcClient` and `SuiGraphQLClient`.
+JSON-RPC APIs are deprecated in the Sui TypeScript SDK. For most application code, migrate from
+`SuiJsonRpcClient` to [`SuiGrpcClient`](/sui/clients/grpc) and call the gRPC client's top-level
+methods. Use [`SuiGraphQLClient`](/sui/clients/graphql) when the code needs indexed data, historical
+object reads, or custom GraphQL selection sets.
 
 <Callout type="info">
-	Use `SuiGrpcClient` for most operations, including filtering transactions and events with the core
-	query API. `SuiGraphQLClient` remains useful for complex queries that aren't covered by the core
-	API.
+	Create one client for the transport you want to use. Application code should usually call
+	top-level methods like `client.getObject()` and `client.listTransactions()`. SDKs and libraries
+	should accept `ClientWithCoreApi` and call `client.core.<method>()`.
 </Callout>
 
-## Choosing a client
+## Choosing a target client
 
-| Client             | Best For                                                             |
-| ------------------ | -------------------------------------------------------------------- |
-| `SuiGrpcClient`    | Most operations, SDK integrations, queries, real-time data           |
-| `SuiGraphQLClient` | Complex queries not covered by the core API, like historical objects |
+| Client             | Use For                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| `SuiGrpcClient`    | Most reads, writes, simulations, transaction/event queries, and streams |
+| `SuiGraphQLClient` | Indexed queries, historical data, staking queries, custom query shapes  |
+| `SuiJsonRpcClient` | Maintaining legacy JSON-RPC code while migrating                        |
 
 ## Quick migration to gRPC
 
-For most use cases, migrate to `SuiGrpcClient`:
+Replace `SuiJsonRpcClient` with `SuiGrpcClient`:
 
 ```diff
 - import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
@@ -48,41 +51,215 @@ For most use cases, migrate to `SuiGrpcClient`:
 + });
 ```
 
-Both clients use the same full node URLs, so you can use the same endpoint when migrating.
+Full node hosts commonly expose both JSON-RPC and gRPC. When migrating, pass the full node endpoint
+as `baseUrl` instead of `url`, and verify the protocol and port used by your node provider.
 
-## Core API methods
+## Use top-level methods in apps
 
-The gRPC client should work with almost all mysten SDKs as a drop in replacement for the JSON-RPC
-client. When using the client directly, the methods and data returned will not be exactly the same
-as what was available in JSON-RPC.
+The gRPC and GraphQL clients expose top-level methods for the common client API. These methods use
+the same options and response shapes as `client.core`, with transport-specific additions where the
+transport can expose more data.
 
-## Methods replaced by core API
+```typescript
+const { object } = await client.getObject({
+	objectId: '0x...',
+	include: { content: true, display: true },
+});
 
-These JSON-RPC methods have direct replacements in the core API:
+const { balance } = await client.getBalance({
+	owner: '0x...',
+});
 
-| JSON-RPC Method              | Core API Replacement                              |
-| ---------------------------- | ------------------------------------------------- |
-| `getCoins`                   | `listCoins`                                       |
-| `getAllCoins`                | `listOwnedObjects` with `type: '0x2::coin::Coin'` |
-| `getAllBalances`             | `listBalances`                                    |
-| `getOwnedObjects`            | `listOwnedObjects`                                |
-| `multiGetObjects`            | `getObjects`                                      |
-| `getDynamicFields`           | `listDynamicFields`                               |
-| `getDynamicFieldObject`      | `getDynamicField`                                 |
-| `devInspectTransactionBlock` | `simulateTransaction` with `checksEnabled: false` |
-| `dryRunTransactionBlock`     | `simulateTransaction`                             |
-| `getNormalizedMoveFunction`  | `getMoveFunction`                                 |
-| `getMoveFunctionArgTypes`    | `getMoveFunction`                                 |
-| `queryTransactionBlocks`     | `listTransactions`                                |
-| `queryEvents`                | `listEvents`                                      |
+const result = await client.signAndExecuteTransaction({
+	transaction,
+	signer,
+	include: { effects: true, balanceChanges: true },
+});
+```
 
-<Callout type="info">
-	The query methods (`listTransactions` and `listEvents`) behave identically on every client,
-	including `SuiJsonRpcClient`. See [Core API query methods](/sui/clients/core#query-methods) for
-	details.
-</Callout>
+For SDKs and shared libraries, accept `ClientWithCoreApi` and use `client.core` so the caller can
+provide `SuiGrpcClient`, `SuiGraphQLClient`, or a legacy `SuiJsonRpcClient` during migration:
 
-### Example: Migrating queryTransactionBlocks
+```typescript
+import type { ClientWithCoreApi } from '@mysten/sui/client';
+
+export async function readObject(client: ClientWithCoreApi, objectId: string) {
+	return client.core.getObject({
+		objectId,
+		include: { content: true },
+	});
+}
+```
+
+## Method replacements
+
+Replace legacy JSON-RPC method names with the gRPC top-level method when one exists. In SDK code,
+use the same replacement under `client.core`.
+
+| JSON-RPC Method              | App Code Replacement                                                           |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| `getObject`                  | `getObject`                                                                    |
+| `multiGetObjects`            | `getObjects`                                                                   |
+| `getOwnedObjects`            | `listOwnedObjects`                                                             |
+| `getCoins`                   | `listCoins`                                                                    |
+| `getAllBalances`             | `listBalances`                                                                 |
+| `getBalance`                 | `getBalance`                                                                   |
+| `getCoinMetadata`            | `getCoinMetadata`                                                              |
+| `getDynamicFields`           | `listDynamicFields`                                                            |
+| `getDynamicFieldObject`      | `getDynamicField` or `client.core.getDynamicObjectField`                       |
+| `executeTransactionBlock`    | `executeTransaction`                                                           |
+| `dryRunTransactionBlock`     | `simulateTransaction`                                                          |
+| `devInspectTransactionBlock` | `simulateTransaction` with `checksEnabled: false`                              |
+| `queryTransactionBlocks`     | `listTransactions`                                                             |
+| `queryEvents`                | `listEvents`                                                                   |
+| `getNormalizedMoveFunction`  | `getMoveFunction`                                                              |
+| `getMoveFunctionArgTypes`    | `getMoveFunction`                                                              |
+| `resolveNameServiceAddress`  | `nameService.lookupName` or GraphQL query                                      |
+| `resolveNameServiceNames`    | `nameService.reverseLookupName`; `defaultNameServiceName` for the default name |
+
+Some composed helpers are currently exposed through `client.core` rather than as top-level gRPC or
+GraphQL methods:
+
+```typescript
+const { protocolConfig } = await client.core.getProtocolConfig();
+const { systemState } = await client.core.getCurrentSystemState();
+const { chainIdentifier } = await client.core.getChainIdentifier();
+```
+
+## Object and coin reads
+
+### Migrating `getOwnedObjects`
+
+```diff
+- const { data } = await jsonRpcClient.getOwnedObjects({
+-   owner: '0xabc...',
+-   filter: { StructType: '0x2::coin::Coin<0x2::sui::SUI>' },
+-   options: { showContent: true },
+- });
++ const { objects } = await client.listOwnedObjects({
++   owner: '0xabc...',
++   type: '0x2::coin::Coin<0x2::sui::SUI>',
++   include: { content: true },
++ });
+```
+
+### Migrating `getCoins`
+
+```diff
+- const coins = await jsonRpcClient.getCoins({
+-   owner: '0xabc...',
+-   coinType: '0x2::sui::SUI',
+- });
++ const coins = await client.listCoins({
++   owner: '0xabc...',
++   coinType: '0x2::sui::SUI',
++ });
+```
+
+### Migrating object include options
+
+```diff
+- const object = await jsonRpcClient.getObject({
+-   id: objectId,
+-   options: {
+-     showBcs: true,
+-     showContent: true,
+-     showDisplay: true,
+-   },
+- });
++ const { object } = await client.getObject({
++   objectId,
++   include: {
++     content: true,
++     json: true,
++     display: true,
++   },
++ });
+```
+
+Use `include.content` for BCS-encoded Move struct bytes. It is the most stable cross-transport shape
+for parsing application data.
+
+## Transaction execution and simulation
+
+### Migrating `executeTransactionBlock`
+
+```diff
+- const result = await jsonRpcClient.executeTransactionBlock({
+-   transactionBlock: bytes,
+-   signature,
+-   options: {
+-     showEffects: true,
+-     showEvents: true,
+-   },
+- });
++ const result = await client.executeTransaction({
++   transaction: bytes,
++   signatures: [signature],
++   include: {
++     effects: true,
++     events: true,
++   },
++ });
+
+- const status = result.effects?.status.status;
++ const tx = result.Transaction ?? result.FailedTransaction;
++ const success = tx.status.success;
+```
+
+### Migrating `signAndExecuteTransaction`
+
+```diff
+- const result = await jsonRpcClient.signAndExecuteTransaction({
+-   transaction,
+-   signer,
+-   options: { showEffects: true },
+- });
++ const result = await client.signAndExecuteTransaction({
++   transaction,
++   signer,
++   include: { effects: true },
++ });
+
++ if (result.$kind === 'FailedTransaction') {
++   throw new Error(result.FailedTransaction.status.error?.message ?? 'Transaction failed');
++ }
+```
+
+### Migrating `dryRunTransactionBlock`
+
+```diff
+- const result = await jsonRpcClient.dryRunTransactionBlock({
+-   transactionBlock: tx,
+- });
++ const result = await client.simulateTransaction({
++   transaction: tx,
++   include: {
++     effects: true,
++     balanceChanges: true,
++   },
++ });
+```
+
+### Migrating `devInspectTransactionBlock`
+
+```diff
+- const result = await jsonRpcClient.devInspectTransactionBlock({
+-   sender: '0xabc...',
+-   transactionBlock: tx,
+- });
+- const returnValues = result.results?.[0]?.returnValues;
++ const result = await client.simulateTransaction({
++   transaction: tx,
++   checksEnabled: false,
++   include: { commandResults: true },
++ });
++ const returnValues = result.commandResults?.[0]?.returnValues;
+```
+
+## Transaction and event queries
+
+### Migrating `queryTransactionBlocks`
 
 ```diff
 - const result = await jsonRpcClient.queryTransactionBlocks({
@@ -91,7 +268,7 @@ These JSON-RPC methods have direct replacements in the core API:
 -   limit: 10,
 - });
 - const digests = result.data.map((tx) => tx.digest);
-+ const result = await client.core.listTransactions({
++ const result = await client.listTransactions({
 +   filter: { sender: '0xabc...' },
 +   include: { effects: true },
 +   limit: 10,
@@ -101,15 +278,15 @@ These JSON-RPC methods have direct replacements in the core API:
 + );
 ```
 
-The core API filters map to the JSON-RPC `TransactionFilter` variants:
+Common transaction filter mappings:
 
-| JSON-RPC filter                                                      | Core API filter predicate                                                                                       |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `FromAddress`                                                        | `sender`                                                                                                        |
-| `MoveFunction`                                                       | `function`                                                                                                      |
-| `ToAddress` / `FromOrToAddress` / `ChangedObject` / `AffectedObject` | No core equivalent. Use raw [gRPC](/sui/clients/grpc#ledger-service) or [GraphQL](/sui/clients/graphql) queries |
+| JSON-RPC Filter                                                   | gRPC/GraphQL Top-Level Filter                         |
+| ----------------------------------------------------------------- | ----------------------------------------------------- |
+| `FromAddress`                                                     | `sender`                                              |
+| `MoveFunction`                                                    | `function`                                            |
+| `ToAddress`, `FromOrToAddress`, `ChangedObject`, `AffectedObject` | Use raw gRPC ledger filters or a custom GraphQL query |
 
-### Example: Migrating queryEvents
+### Migrating `queryEvents`
 
 ```diff
 - const result = await jsonRpcClient.queryEvents({
@@ -117,75 +294,43 @@ The core API filters map to the JSON-RPC `TransactionFilter` variants:
 -   limit: 10,
 -   order: 'descending',
 - });
-+ const result = await client.core.listEvents({
++ const result = await client.listEvents({
 +   filter: { eventType: '0x2::coin::CoinCreated' },
 +   limit: 10,
 +   order: 'descending',
 + });
 ```
 
-The JSON-RPC `EventFilter` variants map to `sender`, `emitModule` (replaces `MoveModule` /
-`MoveEventModule`), and `eventType` (replaces `MoveEventType`). Each returned event includes its
-ledger position (`checkpoint`, `transactionDigest`, and `eventIndex`).
+Common event filter mappings:
 
-### Example: Migrating devInspectTransactionBlock
+| JSON-RPC Filter                 | gRPC/GraphQL Top-Level Filter |
+| ------------------------------- | ----------------------------- |
+| `Sender`                        | `sender`                      |
+| `MoveModule`, `MoveEventModule` | `emitModule`                  |
+| `MoveEventType`                 | `eventType`                   |
 
-```diff
-- const result = await jsonRpcClient.devInspectTransactionBlock({
--   sender: '0xabc...',
--   transactionBlock: tx,
-- });
-- const returnValues = result.results?.[0]?.returnValues;
-+ const result = await client.core.simulateTransaction({
-+   transaction: tx,
-+   checksEnabled: false,
-+   include: { commandResults: true },
-+ });
-+ const returnValues = result.commandResults?.[0]?.returnValues;
-```
+The top-level query methods handle pagination and cursor normalization. For richer filters, such as
+combined predicates, affected addresses, affected objects, or checkpoint ranges, use the raw
+[`ledgerService`](/sui/clients/grpc#ledger-service) on `SuiGrpcClient` or a custom GraphQL query.
 
-### Example: Migrating getOwnedObjects
+## Native gRPC replacements
 
-```diff
-- const { data } = await jsonRpcClient.getOwnedObjects({
--   owner: '0xabc...',
--   options: { showContent: true },
-- });
-+ const { objects } = await grpcClient.listOwnedObjects({
-+   owner: '0xabc...',
-+   include: { content: true },
-+ });
-```
+Some JSON-RPC methods map to gRPC service clients rather than top-level methods:
 
-## Methods replaced by gRPC services
-
-These JSON-RPC methods can be replaced by calling gRPC service clients directly:
-
-| JSON-RPC Method                     | gRPC Service Replacement                                         |
-| ----------------------------------- | ---------------------------------------------------------------- |
-| `getCheckpoint`                     | `ledgerService.getCheckpoint`                                    |
-| `getCheckpoints`                    | `ledgerService.listCheckpoints`                                  |
-| `getLatestCheckpointSequenceNumber` | `ledgerService.getServiceInfo` (read `checkpointHeight`)         |
-| `getCurrentEpoch`                   | `ledgerService.getEpoch` (omit `epoch` for the current)          |
-| `getLatestSuiSystemState`           | `ledgerService.getEpoch` with `system_state` in the read mask    |
-| `getCommitteeInfo`                  | `ledgerService.getEpoch` with `committee` in the read mask       |
-| `getProtocolConfig`                 | `ledgerService.getEpoch` with `protocol_config` in the read mask |
-| `getCoinMetadata`                   | `stateService.getCoinInfo` (response includes `metadata`)        |
-| `getTotalSupply`                    | `stateService.getCoinInfo` (response includes `treasury`)        |
-| `getNormalizedMoveModule`           | `movePackageService.getPackage` (response includes all modules)  |
-| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                  |
-| `getNormalizedMoveStruct`           | `movePackageService.getDatatype`                                 |
-| `resolveNameServiceAddress`         | `nameService.lookupName`                                         |
-| `resolveNameServiceNames`           | `nameService.reverseLookupName`                                  |
-
-<Callout type="warn">
-	`getEpochs` (paginated listing) has no gRPC equivalent. Use the `epochs` GraphQL query instead.
-	`getValidatorsApy` also has no replacement: there is no canonical definition of validator APY, so
-	it must be computed client-side from validator exchange rates (see [Validator APY](#validator-apy)
-	below).
-</Callout>
-
-### Example: using gRPC service clients
+| JSON-RPC Method                     | gRPC Replacement                                                |
+| ----------------------------------- | --------------------------------------------------------------- |
+| `getCheckpoint`                     | `ledgerService.getCheckpoint`                                   |
+| `getCheckpoints`                    | `ledgerService.listCheckpoints`                                 |
+| `getLatestCheckpointSequenceNumber` | `ledgerService.getServiceInfo` and read `checkpointHeight`      |
+| `getCurrentEpoch`                   | `ledgerService.getEpoch` with no `epoch` argument               |
+| `getCommitteeInfo`                  | `ledgerService.getEpoch` with `committee` in the read mask      |
+| `getLatestSuiSystemState`           | `client.core.getCurrentSystemState` or `ledgerService.getEpoch` |
+| `getProtocolConfig`                 | `client.core.getProtocolConfig` or `ledgerService.getEpoch`     |
+| `multiGetTransactionBlocks`         | `ledgerService.batchGetTransactions`                            |
+| `getTotalSupply`                    | `stateService.getCoinInfo` and read `treasury.totalSupply`      |
+| `getNormalizedMoveModule`           | `movePackageService.getPackage`                                 |
+| `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                 |
+| `getNormalizedMoveStruct`           | `movePackageService.getDatatype`                                |
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';
@@ -195,55 +340,23 @@ const client = new SuiGrpcClient({
 	network: 'mainnet',
 });
 
-// Get the latest checkpoint sequence number (replaces getLatestCheckpointSequenceNumber)
 const { response: info } = await client.ledgerService.getServiceInfo({});
 const latestCheckpoint = info.checkpointHeight;
 
-// Get a specific checkpoint by sequence number. `checkpointId` is required (a oneof);
-// the read mask defaults to `sequence_number,digest`, so request more fields as needed.
-const { response } = await client.ledgerService.getCheckpoint({
+const { response: checkpoint } = await client.ledgerService.getCheckpoint({
 	checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: latestCheckpoint },
+	readMask: { paths: ['sequence_number', 'digest', 'timestamp'] },
 });
 
-// Get the current epoch (omit `epoch` for the current one). The system state,
-// committee, and protocol config are NOT returned by default — you must request
-// them via the read mask (the default mask is just `epoch`).
-const { response: epoch } = await client.ledgerService.getEpoch({
-	readMask: { paths: ['epoch', 'system_state', 'committee', 'protocol_config'] },
-});
-const systemState = epoch.epoch?.systemState;
-const committee = epoch.epoch?.committee;
-const protocolConfig = epoch.epoch?.protocolConfig;
-
-// Get coin metadata and total supply in one call
-const { response: coinInfo } = await client.stateService.getCoinInfo({
-	coinType: '0x2::sui::SUI',
-});
-const metadata = coinInfo.metadata;
-const totalSupply = coinInfo.treasury?.totalSupply;
-
-// Get Move package information (includes all modules)
-const { response: pkg } = await client.movePackageService.getPackage({
-	packageId: '0x2',
-});
-
-// Get a specific Move datatype (struct or enum)
-const { response: datatype } = await client.movePackageService.getDatatype({
-	packageId: '0x2',
-	moduleName: 'coin',
-	name: 'Coin',
-});
-
-// Resolve SuiNS name
-const { response: address } = await client.nameService.lookupName({
-	name: 'example.sui',
+const { response: transactions } = await client.ledgerService.batchGetTransactions({
+	digests: ['<TRANSACTION_DIGEST>'],
+	readMask: { paths: ['digest', 'effects', 'events'] },
 });
 ```
 
-## Methods replaced by gRPC subscriptions
+## Subscriptions
 
-Replace the deprecated JSON-RPC websocket subscriptions with the gRPC `subscriptionService`, which
-provides filtered, real-time streams:
+Replace deprecated JSON-RPC websocket subscriptions with the gRPC `subscriptionService`:
 
 | JSON-RPC Method        | gRPC Service Replacement                    |
 | ---------------------- | ------------------------------------------- |
@@ -277,82 +390,53 @@ for await (const frame of stream.responses) {
 }
 ```
 
-Subscriptions always begin at the current tip of the chain. To recover events you missed between
-subscriptions, replay the gap with `client.core.listEvents` using the same filter.
+Subscriptions begin at the current tip of the chain. To recover events missed between connections,
+replay the gap with `client.listEvents()` using the same filter.
 
-## Methods requiring GraphQL
+## When to use GraphQL
 
-Some JSON-RPC methods don't have gRPC equivalents and require using `SuiGraphQLClient` instead:
+Use `SuiGraphQLClient` when the replacement needs indexed data, historical reads, or a custom
+selection set:
 
-| JSON-RPC Method             | GraphQL Alternative                                       |
-| --------------------------- | --------------------------------------------------------- |
-| `multiGetTransactionBlocks` | `multiGetTransactionEffects` query                        |
-| `getEpochs`                 | `epochs` query                                            |
-| `getCoinMetadata`           | `coinMetadata` query (or gRPC `stateService.getCoinInfo`) |
-| `getTotalSupply`            | `coinMetadata` query (or gRPC `stateService.getCoinInfo`) |
-| `getStakes`                 | `address.stakedSuis` query                                |
-| `getStakesByIds`            | `multiGetObjects` query                                   |
-| `tryGetPastObject`          | Historical object queries                                 |
-| `getNetworkMetrics`         | Use indexer                                               |
-| `getAddressMetrics`         | Use indexer                                               |
-| `getMoveCallMetrics`        | Use indexer                                               |
-
-### Setting up GraphQL client
+| JSON-RPC Method      | GraphQL Alternative                                 |
+| -------------------- | --------------------------------------------------- |
+| `getEpochs`          | `epochs` query                                      |
+| `tryGetPastObject`   | `object(address:, version:)` query                  |
+| `getStakes`          | `address.stakedSuis` query                          |
+| `getStakesByIds`     | `multiGetObjects` query                             |
+| `getNetworkMetrics`  | Use an indexer or analytics-specific GraphQL schema |
+| `getAddressMetrics`  | Use an indexer or analytics-specific GraphQL schema |
+| `getMoveCallMetrics` | Use an indexer or analytics-specific GraphQL schema |
 
 ```typescript
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import { graphql } from '@mysten/sui/graphql/schema';
 
 const graphqlClient = new SuiGraphQLClient({
 	url: 'https://sui-mainnet.mystenlabs.com/graphql',
 	network: 'mainnet',
 });
-```
 
-### Fetching multiple transactions
+const historicalObjectQuery = graphql(`
+	query GetObjectAtVersion($id: SuiAddress!, $version: UInt53!) {
+		object(address: $id, version: $version) {
+			address
+			version
+			digest
+			asMoveObject {
+				contents {
+					type {
+						repr
+					}
+					bcs
+				}
+			}
+		}
+	}
+`);
 
-Replace `multiGetTransactionBlocks` with a GraphQL query:
-
-```typescript
 const result = await graphqlClient.query({
-	query: `
-    query MultiGetTransactions($digests: [String!]!) {
-      multiGetTransactionEffects(keys: $digests) {
-        transaction {
-          digest
-          transactionBcs
-        }
-        status
-        epoch { epochId }
-      }
-    }
-  `,
-	variables: {
-		digests: ['digest1', 'digest2', 'digest3'],
-	},
-});
-```
-
-### Querying historical objects
-
-Replace `tryGetPastObject` with a GraphQL query specifying a version:
-
-```typescript
-const result = await graphqlClient.query({
-	query: `
-    query GetObjectAtVersion($id: SuiAddress!, $version: UInt53!) {
-      object(address: $id, version: $version) {
-        address
-        version
-        digest
-        asMoveObject {
-          contents {
-            type { repr }
-            bcs
-          }
-        }
-      }
-    }
-  `,
+	query: historicalObjectQuery,
 	variables: {
 		id: '0x123...',
 		version: 42,
@@ -360,118 +444,61 @@ const result = await graphqlClient.query({
 });
 ```
 
-### Querying coin metadata
-
-Replace `getCoinMetadata` and `getTotalSupply` with a GraphQL query:
-
-```typescript
-const result = await graphqlClient.query({
-	query: `
-    query GetCoinMetadata($coinType: String!) {
-      coinMetadata(coinType: $coinType) {
-        name
-        symbol
-        description
-        decimals
-        iconUrl
-        supply
-      }
-    }
-  `,
-	variables: {
-		coinType: '0x2::sui::SUI',
-	},
-});
-```
-
-### Querying staked SUI
-
-Replace `getStakes` with a GraphQL query:
-
-```typescript
-const result = await graphqlClient.query({
-	query: `
-    query GetStakes($owner: SuiAddress!) {
-      address(address: $owner) {
-        stakedSuis {
-          nodes {
-            principal
-            stakeActivationEpoch
-            estimatedReward
-            contents {
-              bcs
-            }
-          }
-        }
-      }
-    }
-  `,
-	variables: {
-		owner: '0xabc...',
-	},
-});
-```
-
 ## Validator APY
 
-There is **no replacement** for `getValidatorsApy`, and one will not be added. There is no canonical
-definition of validator APY — no other chain's core/general-purpose RPCs offer this endpoint — so it
-must be computed client-side from validator staking-pool exchange rates.
+There is no direct SDK replacement for `getValidatorsApy`. There is no canonical definition of
+validator APY, so compute the metric from validator staking-pool exchange rates or use an
+application-specific indexer.
 
-The general approach: read each validator's `exchangeRates` (a table of `pool_token_amount` /
-`sui_amount` per epoch) and estimate the annualized rate from the change in exchange rate over the
-trailing epochs. Two concrete reference implementations:
+Two reference implementations:
 
 - The `jsonrpc-alt` implementation in
-  [`sui-indexer-alt-jsonrpc`](https://github.com/MystenLabs/sui/blob/31537d4d9235b9f61dc07a3a71b05ed61a2bda7b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs#L422-L440),
-  which is compact and readable.
-- [This GraphQL approach](https://github.com/MystenLabs/sui/issues/23832#issuecomment-4437791087),
-  which fetches the precursor exchange-rate information in a single query.
+  [`sui-indexer-alt-jsonrpc`](https://github.com/MystenLabs/sui/blob/31537d4d9235b9f61dc07a3a71b05ed61a2bda7b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs#L422-L440)
+- [A GraphQL approach](https://github.com/MystenLabs/sui/issues/23832#issuecomment-4437791087)
 
 Treat whichever formula you adopt as _a_ definition of validator APY, not _the_ definition.
 
 ## Response format differences
 
-The gRPC client uses the core API response format, which differs from JSON-RPC responses. See the
-[`@mysten/sui` migration guide](/sui/migrations/sui-2.0/sui#transaction-executors-now-accept-any-client)
-for details on the new response format.
-
-Key differences:
+gRPC and GraphQL top-level methods return the Core API response format, which differs from legacy
+JSON-RPC response shapes.
 
 ```diff
 // Transaction result access
 - const status = result.effects?.status?.status;
 + const tx = result.Transaction ?? result.FailedTransaction;
-+ const status = tx.effects.status.success;
++ const success = tx.status.success;
 
 // Include options
 - { showEffects: true, showEvents: true }
 + { effects: true, events: true }
 ```
 
+See the
+[`@mysten/sui` migration guide](/sui/migrations/sui-2.0/sui#transaction-executors-now-accept-any-client)
+for transaction executor response changes.
+
 ## Client extensions
 
-Client extensions work the same way with both clients:
+Client extensions work with `SuiGrpcClient` and any client that implements `ClientWithCoreApi`:
 
 ```typescript
-import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { deepbook } from '@mysten/deepbook-v3';
 import { suins } from '@mysten/suins';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.mainnet.sui.io:443',
 	network: 'mainnet',
 }).$extend(deepbook({ address: myAddress }), suins());
 
-// Use extended functionality
 await client.deepbook.checkManagerBalance(manager, asset);
 await client.suins.getName('0xabc...');
 ```
 
 ## See also
 
-- [SuiGrpcClient Documentation](/sui/clients/grpc) - Full gRPC client documentation
-- [SuiGraphQLClient Documentation](/sui/clients/graphql) - GraphQL client documentation
-- [Core API](/sui/clients/core) - Transport-agnostic API methods
-- [gRPC Overview](https://docs.sui.io/concepts/data-access/grpc-overview) - Sui gRPC API
-  documentation
+- [SuiGrpcClient](/sui/clients/grpc)
+- [SuiGraphQLClient](/sui/clients/graphql)
+- [Core API](/sui/clients/core)
+- [Building SDKs](/sui/sdk-building)

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrating from JSON-RPC
-description: Migrate deprecated JSON-RPC code to SuiGrpcClient, with GraphQL for indexed queries
+description: Migrate deprecated JSON-RPC code to shared gRPC and GraphQL top-level methods
 keywords:
   [
     migration,
@@ -16,8 +16,9 @@ keywords:
 
 JSON-RPC APIs are deprecated in the Sui TypeScript SDK. For most application code, migrate from
 `SuiJsonRpcClient` to [`SuiGrpcClient`](/sui/clients/grpc) and call the gRPC client's top-level
-methods. Use [`SuiGraphQLClient`](/sui/clients/graphql) when the code needs indexed data, historical
-object reads, or custom GraphQL selection sets.
+methods. Use [`SuiGraphQLClient`](/sui/clients/graphql) when the code needs custom indexed queries,
+historical object versions, or custom GraphQL selection sets. Standard transaction and event queries
+are available directly on both clients.
 
 <Callout type="info">
 	Create one client for the transport you want to use. Application code should usually call
@@ -27,11 +28,11 @@ object reads, or custom GraphQL selection sets.
 
 ## Choosing a target client
 
-| Client             | Use For                                                                 |
-| ------------------ | ----------------------------------------------------------------------- |
-| `SuiGrpcClient`    | Most reads, writes, simulations, transaction/event queries, and streams |
-| `SuiGraphQLClient` | Indexed queries, historical data, staking queries, custom query shapes  |
-| `SuiJsonRpcClient` | Maintaining legacy JSON-RPC code while migrating                        |
+| Client             | Use For                                                                            |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `SuiGrpcClient`    | Standard reads, writes, simulations, transaction/event queries, and streams        |
+| `SuiGraphQLClient` | The same shared methods plus custom indexed queries and historical object versions |
+| `SuiJsonRpcClient` | Maintaining legacy JSON-RPC code while migrating                                   |
 
 ## Quick migration to gRPC
 
@@ -59,6 +60,10 @@ as `baseUrl` instead of `url`, and verify the protocol and port used by your nod
 The gRPC and GraphQL clients expose top-level methods for the common client API. These methods use
 the same options and response shapes as `client.core`, with transport-specific additions where the
 transport can expose more data.
+
+This includes transaction and event methods. Use `getTransaction`, `waitForTransaction`,
+`listTransactions`, and `listEvents` directly instead of dropping down to a raw gRPC service or a
+custom GraphQL query for standard queries.
 
 ```typescript
 const { object } = await client.getObject({
@@ -107,7 +112,10 @@ use the same replacement under `client.core`.
 | `getCoinMetadata`            | `getCoinMetadata`                                                              |
 | `getDynamicFields`           | `listDynamicFields`                                                            |
 | `getDynamicFieldObject`      | `getDynamicField` or `client.core.getDynamicObjectField`                       |
+| `getTransactionBlock`        | `getTransaction`                                                               |
+| `multiGetTransactionBlocks`  | Multiple `getTransaction` calls                                                |
 | `executeTransactionBlock`    | `executeTransaction`                                                           |
+| `waitForTransaction`         | `waitForTransaction`                                                           |
 | `dryRunTransactionBlock`     | `simulateTransaction`                                                          |
 | `devInspectTransactionBlock` | `simulateTransaction` with `checksEnabled: false`                              |
 | `queryTransactionBlocks`     | `listTransactions`                                                             |
@@ -182,6 +190,50 @@ for parsing application data.
 
 ## Transaction execution and simulation
 
+### Migrating `getTransactionBlock`
+
+```diff
+- const result = await jsonRpcClient.getTransactionBlock({
+-   digest,
+-   options: {
+-     showEffects: true,
+-     showEvents: true,
+-     showInput: true,
+-   },
+- });
++ const result = await client.getTransaction({
++   digest,
++   include: {
++     effects: true,
++     events: true,
++     transaction: true,
++   },
++ });
+```
+
+Both `SuiGrpcClient` and `SuiGraphQLClient` expose `getTransaction`. SDKs can make the same request
+through `client.core.getTransaction`.
+
+For multiple digests, call the same top-level method for each transaction:
+
+```diff
+- const results = await jsonRpcClient.multiGetTransactionBlocks({
+-   digests,
+-   options: { showEffects: true },
+- });
++ const results = await Promise.all(
++   digests.map((digest) =>
++     client.getTransaction({
++       digest,
++       include: { effects: true },
++     }),
++   ),
++ );
+```
+
+The raw gRPC `ledgerService.batchGetTransactions` method remains available when an application
+specifically needs the transport's batch wire API, but it is not required for ordinary client code.
+
 ### Migrating `executeTransactionBlock`
 
 ```diff
@@ -226,6 +278,27 @@ for parsing application data.
 + }
 ```
 
+### Migrating `waitForTransaction`
+
+```diff
+- const result = await jsonRpcClient.waitForTransaction({
+-   digest,
+-   options: { showEffects: true },
+-   timeout: 60_000,
+-   pollInterval: 2_000,
+- });
++ const result = await client.waitForTransaction({
++   digest,
++   include: { effects: true },
++   timeout: 60_000,
++   pollSchedule: [0, 2_000],
++ });
+```
+
+`waitForTransaction` is a top-level method on both `SuiGrpcClient` and `SuiGraphQLClient`. It can
+also accept the result of `executeTransaction` or `signAndExecuteTransaction` through its `result`
+option.
+
 ### Migrating `dryRunTransactionBlock`
 
 ```diff
@@ -259,6 +332,10 @@ for parsing application data.
 
 ## Transaction and event queries
 
+`listTransactions` and `listEvents` are first-class methods on `SuiGrpcClient`, `SuiGraphQLClient`,
+and the Core API. Application code should call the top-level method on its chosen client. Reusable
+SDK code should call the same method through `client.core`.
+
 ### Migrating `queryTransactionBlocks`
 
 ```diff
@@ -268,12 +345,13 @@ for parsing application data.
 -   limit: 10,
 - });
 - const digests = result.data.map((tx) => tx.digest);
-+ const result = await client.listTransactions({
++ const page = await client.listTransactions({
 +   filter: { sender: '0xabc...' },
 +   include: { effects: true },
 +   limit: 10,
++   order: 'descending',
 + });
-+ const digests = result.transactions.map(
++ const digests = page.transactions.map(
 +   (tx) => (tx.Transaction ?? tx.FailedTransaction).digest,
 + );
 ```
@@ -285,6 +363,27 @@ Common transaction filter mappings:
 | `FromAddress`                                                     | `sender`                                              |
 | `MoveFunction`                                                    | `function`                                            |
 | `ToAddress`, `FromOrToAddress`, `ChangedObject`, `AffectedObject` | Use raw gRPC ledger filters or a custom GraphQL query |
+
+The response contains normalized transaction results plus ledger-position cursors:
+
+```typescript
+for (const result of page.transactions) {
+	const transaction = result.Transaction ?? result.FailedTransaction;
+	console.log(transaction.digest, result.$kind);
+}
+
+const nextPage = page.hasNextPage
+	? await client.listTransactions({
+			filter: { sender: '0xabc...' },
+			before: page.endCursor,
+			limit: 10,
+		})
+	: null;
+```
+
+The legacy JSON-RPC transaction and event queries default to descending order, while
+`listTransactions` and `listEvents` default to ascending order. Pass `order: 'descending'` when
+preserving the legacy default.
 
 ### Migrating `queryEvents`
 
@@ -299,6 +398,9 @@ Common transaction filter mappings:
 +   limit: 10,
 +   order: 'descending',
 + });
++ for (const event of result.events) {
++   console.log(event.eventType, event.transactionDigest, event.json);
++ }
 ```
 
 Common event filter mappings:
@@ -313,6 +415,10 @@ The top-level query methods handle pagination and cursor normalization. For rich
 combined predicates, affected addresses, affected objects, or checkpoint ranges, use the raw
 [`ledgerService`](/sui/clients/grpc#ledger-service) on `SuiGrpcClient` or a custom GraphQL query.
 
+Use `after: result.endCursor` to continue an ascending query and `before: result.endCursor` to
+continue a descending query. `startCursor` identifies the first item in a page and can be used with
+`after` to poll for newer transactions or events.
+
 ## Native gRPC replacements
 
 Some JSON-RPC methods map to gRPC service clients rather than top-level methods:
@@ -326,7 +432,6 @@ Some JSON-RPC methods map to gRPC service clients rather than top-level methods:
 | `getCommitteeInfo`                  | `ledgerService.getEpoch` with `committee` in the read mask      |
 | `getLatestSuiSystemState`           | `client.core.getCurrentSystemState` or `ledgerService.getEpoch` |
 | `getProtocolConfig`                 | `client.core.getProtocolConfig` or `ledgerService.getEpoch`     |
-| `multiGetTransactionBlocks`         | `ledgerService.batchGetTransactions`                            |
 | `getTotalSupply`                    | `stateService.getCoinInfo` and read `treasury.totalSupply`      |
 | `getNormalizedMoveModule`           | `movePackageService.getPackage`                                 |
 | `getNormalizedMoveModulesByPackage` | `movePackageService.getPackage`                                 |
@@ -346,11 +451,6 @@ const latestCheckpoint = info.checkpointHeight;
 const { response: checkpoint } = await client.ledgerService.getCheckpoint({
 	checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: latestCheckpoint },
 	readMask: { paths: ['sequence_number', 'digest', 'timestamp'] },
-});
-
-const { response: transactions } = await client.ledgerService.batchGetTransactions({
-	digests: ['<TRANSACTION_DIGEST>'],
-	readMask: { paths: ['digest', 'effects', 'events'] },
 });
 ```
 
@@ -395,8 +495,10 @@ replay the gap with `client.listEvents()` using the same filter.
 
 ## When to use GraphQL
 
-Use `SuiGraphQLClient` when the replacement needs indexed data, historical reads, or a custom
-selection set:
+Use `SuiGraphQLClient` when the replacement needs a custom indexed query, a historical object
+version, staking data, or a custom selection set. Standard transaction and event history does not
+require a custom GraphQL query; call `graphqlClient.listTransactions()` or
+`graphqlClient.listEvents()` directly.
 
 | JSON-RPC Method      | GraphQL Alternative                                 |
 | -------------------- | --------------------------------------------------- |

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -101,29 +101,35 @@ export async function readObject(client: ClientWithCoreApi, objectId: string) {
 Replace legacy JSON-RPC method names with the gRPC top-level method when one exists. In SDK code,
 use the same replacement under `client.core`.
 
-| JSON-RPC Method              | App Code Replacement                                                           |
-| ---------------------------- | ------------------------------------------------------------------------------ |
-| `getObject`                  | `getObject`                                                                    |
-| `multiGetObjects`            | `getObjects`                                                                   |
-| `getOwnedObjects`            | `listOwnedObjects`                                                             |
-| `getCoins`                   | `listCoins`                                                                    |
-| `getAllBalances`             | `listBalances`                                                                 |
-| `getBalance`                 | `getBalance`                                                                   |
-| `getCoinMetadata`            | `getCoinMetadata`                                                              |
-| `getDynamicFields`           | `listDynamicFields`                                                            |
-| `getDynamicFieldObject`      | `getDynamicField` or `client.core.getDynamicObjectField`                       |
-| `getTransactionBlock`        | `getTransaction`                                                               |
-| `multiGetTransactionBlocks`  | Multiple `getTransaction` calls                                                |
-| `executeTransactionBlock`    | `executeTransaction`                                                           |
-| `waitForTransaction`         | `waitForTransaction`                                                           |
-| `dryRunTransactionBlock`     | `simulateTransaction`                                                          |
-| `devInspectTransactionBlock` | `simulateTransaction` with `checksEnabled: false`                              |
-| `queryTransactionBlocks`     | `listTransactions`                                                             |
-| `queryEvents`                | `listEvents`                                                                   |
-| `getNormalizedMoveFunction`  | `getMoveFunction`                                                              |
-| `getMoveFunctionArgTypes`    | `getMoveFunction`                                                              |
-| `resolveNameServiceAddress`  | `nameService.lookupName` or GraphQL query                                      |
-| `resolveNameServiceNames`    | `nameService.reverseLookupName`; `defaultNameServiceName` for the default name |
+| JSON-RPC Method              | App Code Replacement                                                  |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `getObject`                  | `getObject`                                                           |
+| `multiGetObjects`            | `getObjects`                                                          |
+| `getOwnedObjects`            | `listOwnedObjects` for an exact `StructType` filter                   |
+| `getCoins`                   | `listCoins`                                                           |
+| `getAllBalances`             | Paginate `listBalances` and map its normalized response               |
+| `getBalance`                 | `getBalance`                                                          |
+| `getCoinMetadata`            | `getCoinMetadata`                                                     |
+| `getDynamicFields`           | `listDynamicFields`                                                   |
+| `getDynamicFieldObject`      | `getDynamicField` or `client.core.getDynamicObjectField`              |
+| `getTransactionBlock`        | `getTransaction`                                                      |
+| `multiGetTransactionBlocks`  | Multiple `getTransaction` calls                                       |
+| `executeTransactionBlock`    | `executeTransaction`                                                  |
+| `waitForTransaction`         | `waitForTransaction`                                                  |
+| `dryRunTransactionBlock`     | `simulateTransaction`                                                 |
+| `devInspectTransactionBlock` | `simulateTransaction` with the sender set and `checksEnabled: false`  |
+| `queryTransactionBlocks`     | `listTransactions`                                                    |
+| `queryEvents`                | `listEvents`                                                          |
+| `getNormalizedMoveFunction`  | `getMoveFunction`                                                     |
+| `getMoveFunctionArgTypes`    | No direct equivalent; `getMoveFunction` returns normalized signatures |
+| `resolveNameServiceAddress`  | `nameService.lookupName` or GraphQL query                             |
+| `resolveNameServiceNames`    | No direct equivalent for listing every name assigned to an address    |
+
+`getMoveFunction` exposes normalized parameter signatures, but it does not reproduce the legacy
+`Pure`, `Object`, and object-access classifications from `getMoveFunctionArgTypes`. Likewise,
+`defaultNameServiceName` and raw gRPC `nameService.reverseLookupName` return only the configured
+default name; they do not replace the paginated list returned by `resolveNameServiceNames`. Keep a
+legacy endpoint or use an application indexer when those exact results are required.
 
 Some composed helpers are currently exposed through `client.core` rather than as top-level gRPC or
 GraphQL methods:
@@ -151,6 +157,12 @@ const { chainIdentifier } = await client.core.getChainIdentifier();
 + });
 ```
 
+Only the legacy `StructType` filter maps directly to `listOwnedObjects.type`. Legacy package,
+module, owner, object ID, version, and boolean-composition filters do not have top-level Core
+equivalents. A custom GraphQL `ObjectFilter` can cover package, module, and owner-kind cases. For
+the remaining filters, use an indexer or paginate and filter the normalized results in application
+code.
+
 ### Migrating `getCoins`
 
 ```diff
@@ -163,6 +175,13 @@ const { chainIdentifier } = await client.core.getChainIdentifier();
 +   coinType: '0x2::sui::SUI',
 + });
 ```
+
+### Migrating `getAllBalances`
+
+Unlike `getAllBalances`, `listBalances` is paginated. It also returns normalized `balance`,
+`coinBalance`, and `addressBalance` fields instead of the legacy `CoinBalance` shape with
+`coinObjectCount`, `totalBalance`, and `lockedBalance`. Follow `cursor` while `hasNextPage` is true
+and map the result explicitly if existing code depends on the legacy shape.
 
 ### Migrating object include options
 
@@ -189,6 +208,15 @@ Use `include.content` for BCS-encoded Move struct bytes. It is the most stable c
 for parsing application data.
 
 ## Transaction execution and simulation
+
+Legacy JSON-RPC methods accept serialized transaction blocks as base64 strings. `executeTransaction`
+accepts bytes, while `simulateTransaction` accepts bytes or a `Transaction`, so decode existing
+strings before passing them to the new client:
+
+```typescript
+import { Transaction } from '@mysten/sui/transactions';
+import { fromBase64 } from '@mysten/sui/utils';
+```
 
 ### Migrating `getTransactionBlock`
 
@@ -246,7 +274,7 @@ specifically needs the transport's batch wire API, but it is not required for or
 -   },
 - });
 + const result = await client.executeTransaction({
-+   transaction: bytes,
++   transaction: fromBase64(bytes),
 +   signatures: [signature],
 +   include: {
 +     effects: true,
@@ -306,7 +334,7 @@ option.
 -   transactionBlock: tx,
 - });
 + const result = await client.simulateTransaction({
-+   transaction: tx,
++   transaction: fromBase64(tx),
 +   include: {
 +     effects: true,
 +     balanceChanges: true,
@@ -322,8 +350,10 @@ option.
 -   transactionBlock: tx,
 - });
 - const returnValues = result.results?.[0]?.returnValues;
++ const transaction = Transaction.fromKind(tx);
++ transaction.setSender('0xabc...');
 + const result = await client.simulateTransaction({
-+   transaction: tx,
++   transaction,
 +   checksEnabled: false,
 +   include: { commandResults: true },
 + });
@@ -375,6 +405,7 @@ for (const result of page.transactions) {
 const nextPage = page.hasNextPage
 	? await client.listTransactions({
 			filter: { sender: '0xabc...' },
+			include: { effects: true },
 			before: page.endCursor,
 			limit: 10,
 		})
@@ -405,11 +436,12 @@ preserving the legacy default.
 
 Common event filter mappings:
 
-| JSON-RPC Filter                 | gRPC/GraphQL Top-Level Filter |
-| ------------------------------- | ----------------------------- |
-| `Sender`                        | `sender`                      |
-| `MoveModule`, `MoveEventModule` | `emitModule`                  |
-| `MoveEventType`                 | `eventType`                   |
+| JSON-RPC Filter   | gRPC/GraphQL Top-Level Filter         |
+| ----------------- | ------------------------------------- |
+| `Sender`          | `sender`                              |
+| `MoveModule`      | `emitModule: 'package::module'`       |
+| `MoveEventModule` | `eventType: 'package::module'`        |
+| `MoveEventType`   | `eventType: 'package::module::Event'` |
 
 The top-level query methods handle pagination and cursor normalization. For richer filters, such as
 combined predicates, affected addresses, affected objects, or checkpoint ranges, use the raw
@@ -448,10 +480,16 @@ const client = new SuiGrpcClient({
 const { response: info } = await client.ledgerService.getServiceInfo({});
 const latestCheckpoint = info.checkpointHeight;
 
-const { response: checkpoint } = await client.ledgerService.getCheckpoint({
+if (latestCheckpoint == null) {
+	throw new Error('The server did not return a checkpoint height');
+}
+
+const { response } = await client.ledgerService.getCheckpoint({
 	checkpointId: { oneofKind: 'sequenceNumber', sequenceNumber: latestCheckpoint },
-	readMask: { paths: ['sequence_number', 'digest', 'timestamp'] },
+	readMask: { paths: ['sequence_number', 'digest', 'summary.timestamp'] },
 });
+
+console.log(response.checkpoint?.sequenceNumber, response.checkpoint?.summary?.timestamp);
 ```
 
 ## Subscriptions
@@ -490,25 +528,28 @@ for await (const frame of stream.responses) {
 }
 ```
 
-Subscriptions begin at the current tip of the chain. To recover events missed between connections,
-replay the gap with `client.listEvents()` using the same filter.
+Subscriptions begin at the current tip of the chain and do not resume automatically. For gap
+recovery, retain the last `frame.watermark.cursor`, open the new subscription to establish its
+first-frame position, and replay with the paired raw `client.ledgerService.listEvents()` call using
+the same protobuf filter and `options.after` cursor. Repeat the raw list call as the index advances
+until it reaches the new subscription's start position. Do not pass the subscription filter or
+cursor to top-level `client.listEvents()`: its Core filter and base64 cursor are different types.
 
 ## When to use GraphQL
 
 Use `SuiGraphQLClient` when the replacement needs a custom indexed query, a historical object
-version, staking data, or a custom selection set. Standard transaction and event history does not
-require a custom GraphQL query; call `graphqlClient.listTransactions()` or
-`graphqlClient.listEvents()` directly.
+version, or a custom selection set. Standard transaction and event history does not require a custom
+GraphQL query; call `graphqlClient.listTransactions()` or `graphqlClient.listEvents()` directly.
 
-| JSON-RPC Method      | GraphQL Alternative                                 |
-| -------------------- | --------------------------------------------------- |
-| `getEpochs`          | `epochs` query                                      |
-| `tryGetPastObject`   | `object(address:, version:)` query                  |
-| `getStakes`          | `address.stakedSuis` query                          |
-| `getStakesByIds`     | `multiGetObjects` query                             |
-| `getNetworkMetrics`  | Use an indexer or analytics-specific GraphQL schema |
-| `getAddressMetrics`  | Use an indexer or analytics-specific GraphQL schema |
-| `getMoveCallMetrics` | Use an indexer or analytics-specific GraphQL schema |
+| JSON-RPC Method      | Alternative                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `getEpochs`          | GraphQL `epochs` query                                         |
+| `tryGetPastObject`   | GraphQL `object(address:, version:)` query                     |
+| `getStakes`          | No current gRPC/Core/GraphQL equivalent; use a staking indexer |
+| `getStakesByIds`     | No current gRPC/Core/GraphQL equivalent; use a staking indexer |
+| `getNetworkMetrics`  | Use an indexer or analytics-specific GraphQL schema            |
+| `getAddressMetrics`  | Use an indexer or analytics-specific GraphQL schema            |
+| `getMoveCallMetrics` | Use an indexer or analytics-specific GraphQL schema            |
 
 ```typescript
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
@@ -595,7 +636,7 @@ const client = new SuiGrpcClient({
 }).$extend(deepbook({ address: myAddress }), suins());
 
 await client.deepbook.checkManagerBalance(manager, asset);
-await client.suins.getName('0xabc...');
+await client.suins.getNameRecord('example.sui');
 ```
 
 ## See also

--- a/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
@@ -8,14 +8,14 @@ keywords:
 This package now exports a client extension that integrates with Sui clients.
 
 <Callout type="info">
-	The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
-	`SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
+	The Kiosk SDK accepts `SuiGrpcClient`, `SuiGraphQLClient`, and other clients that implement
+	`ClientWithCoreApi`. Use `SuiGrpcClient` for new Kiosk code.
 </Callout>
 
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
 - import { KioskClient, Network } from '@mysten/kiosk';
-+ import { SuiGraphQLClient } from '@mysten/sui/graphql';
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 + import { kiosk } from '@mysten/kiosk';
 
 - const suiClient = new SuiClient({ url: getFullnodeUrl('mainnet') });
@@ -23,8 +23,8 @@ This package now exports a client extension that integrates with Sui clients.
 -   client: suiClient,
 -   network: Network.MAINNET,
 - });
-+ const client = new SuiGraphQLClient({
-+   url: 'https://sui-mainnet.mystenlabs.com/graphql',
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.mainnet.sui.io:443',
 +   network: 'mainnet',
 + }).$extend(kiosk());
 
@@ -105,14 +105,14 @@ The low-level helper functions have been removed in favor of the `KioskTransacti
 ```diff
 - import { createKiosk, shareKiosk, placeAndList } from '@mysten/kiosk';
 + import { kiosk, KioskTransaction } from '@mysten/kiosk';
-+ import { SuiGraphQLClient } from '@mysten/sui/graphql';
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 - const [kiosk, cap] = createKiosk(tx);
 - shareKiosk(tx, kiosk);
 - placeAndList(tx, itemType, kiosk, cap, item, price);
 
-+ const client = new SuiGraphQLClient({
-+   url: 'https://sui-mainnet.mystenlabs.com/graphql',
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.mainnet.sui.io:443',
 +   network: 'mainnet',
 + }).$extend(kiosk());
 +

--- a/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
@@ -9,7 +9,8 @@ This package now exports a client extension that integrates with Sui clients.
 
 <Callout type="info">
 	The Kiosk SDK accepts `SuiGrpcClient`, `SuiGraphQLClient`, and other clients that implement
-	`ClientWithCoreApi`. Use `SuiGrpcClient` for new Kiosk code.
+	`ClientWithCoreApi`. Use `SuiGrpcClient` for new Kiosk code. The gRPC object API returns Display
+	v2 metadata; use GraphQL or JSON-RPC for object types that still rely on legacy Display metadata.
 </Callout>
 
 ```diff

--- a/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/kiosk.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/kiosk'
-description: Migrate @mysten/kiosk to 2.0 with client extension pattern and KioskTransaction.
+description: Migrate @mysten/kiosk to 2.0 with client extension pattern and KioskTransaction
 keywords:
   [migration, mysten/kiosk, Kiosk, 2.0, client extension, KioskTransaction, NFT, breaking changes]
 ---
@@ -8,14 +8,14 @@ keywords:
 This package now exports a client extension that integrates with Sui clients.
 
 <Callout type="info">
-	The Kiosk SDK requires `SuiJsonRpcClient` or `SuiGraphQLClient`. It does not work with
-	`SuiGrpcClient` because it uses event queries that are not available in gRPC.
+	The Kiosk SDK currently requires `SuiGraphQLClient` or the deprecated `SuiJsonRpcClient`. Use
+	`SuiGraphQLClient` for new Kiosk code until the Kiosk SDK supports gRPC.
 </Callout>
 
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
 - import { KioskClient, Network } from '@mysten/kiosk';
-+ import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc'; // or SuiGraphQLClient
++ import { SuiGraphQLClient } from '@mysten/sui/graphql';
 + import { kiosk } from '@mysten/kiosk';
 
 - const suiClient = new SuiClient({ url: getFullnodeUrl('mainnet') });
@@ -23,8 +23,8 @@ This package now exports a client extension that integrates with Sui clients.
 -   client: suiClient,
 -   network: Network.MAINNET,
 - });
-+ const client = new SuiJsonRpcClient({
-+   url: getJsonRpcFullnodeUrl('mainnet'),
++ const client = new SuiGraphQLClient({
++   url: 'https://sui-mainnet.mystenlabs.com/graphql',
 +   network: 'mainnet',
 + }).$extend(kiosk());
 
@@ -105,14 +105,14 @@ The low-level helper functions have been removed in favor of the `KioskTransacti
 ```diff
 - import { createKiosk, shareKiosk, placeAndList } from '@mysten/kiosk';
 + import { kiosk, KioskTransaction } from '@mysten/kiosk';
-+ import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
++ import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 - const [kiosk, cap] = createKiosk(tx);
 - shareKiosk(tx, kiosk);
 - placeAndList(tx, itemType, kiosk, cap, item, price);
 
-+ const client = new SuiJsonRpcClient({
-+   url: getJsonRpcFullnodeUrl('mainnet'),
++ const client = new SuiGraphQLClient({
++   url: 'https://sui-mainnet.mystenlabs.com/graphql',
 +   network: 'mainnet',
 + }).$extend(kiosk());
 +

--- a/packages/docs/content/sui/migrations/sui-2.0/sdk-maintainers.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/sdk-maintainers.mdx
@@ -1,6 +1,6 @@
 ---
 title: SDK Maintainers
-description: Migration guide for SDK maintainers and library authors upgrading to 2.0.
+description: Migration guide for SDK maintainers and library authors upgrading to 2.0
 keywords:
   [
     migration,
@@ -21,8 +21,8 @@ For comprehensive SDK development patterns, see the [Building SDKs guide](/sui/s
 
 ## Use `ClientWithCoreApi`
 
-Accept `ClientWithCoreApi` instead of `SuiClient` to support all 3 Sui clients (JSON-RPC, GraphQL,
-gRPC):
+Accept `ClientWithCoreApi` instead of `SuiClient` so applications can pass a `SuiGrpcClient`,
+`SuiGraphQLClient`, or a legacy `SuiJsonRpcClient` during migration:
 
 ```diff
 - import { SuiClient } from '@mysten/sui/client';
@@ -36,7 +36,9 @@ export class MySDKClient {
 
 ## Access data through `client.core` methods
 
-All data access methods are namespaced under `client.core`:
+SDKs should access shared client methods through `client.core`. Application code can use the same
+methods at the top level of its concrete client, but `client.core` is the stable contract for
+libraries that should work across transports:
 
 ```diff
 - const result = await this.client.getObject({ objectId });
@@ -46,13 +48,13 @@ All data access methods are namespaced under `client.core`:
 + const result = await this.client.core.listOwnedObjects({ owner });
 ```
 
-| v1.x Method                      | v2.0 Method                       |
-| -------------------------------- | --------------------------------- |
-| `client.getObject()`             | `client.core.getObject()`         |
-| `client.getOwnedObjects()`       | `client.core.listOwnedObjects()`  |
-| `client.getDynamicFieldObject()` | `client.core.getDynamicField()`   |
-| `client.getDynamicFields()`      | `client.core.listDynamicFields()` |
-| `client.multiGetObjects()`       | `client.core.getObjects()`        |
+| v1.x Method                      | v2.0 Method                           |
+| -------------------------------- | ------------------------------------- |
+| `client.getObject()`             | `client.core.getObject()`             |
+| `client.getOwnedObjects()`       | `client.core.listOwnedObjects()`      |
+| `client.getDynamicFieldObject()` | `client.core.getDynamicObjectField()` |
+| `client.getDynamicFields()`      | `client.core.listDynamicFields()`     |
+| `client.multiGetObjects()`       | `client.core.getObjects()`            |
 
 See the [Core API documentation](/sui/clients/core) for all available methods.
 

--- a/packages/docs/content/sui/migrations/sui-2.0/sdk-maintainers.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/sdk-maintainers.mdx
@@ -48,13 +48,17 @@ libraries that should work across transports:
 + const result = await this.client.core.listOwnedObjects({ owner });
 ```
 
-| v1.x Method                      | v2.0 Method                           |
-| -------------------------------- | ------------------------------------- |
-| `client.getObject()`             | `client.core.getObject()`             |
-| `client.getOwnedObjects()`       | `client.core.listOwnedObjects()`      |
-| `client.getDynamicFieldObject()` | `client.core.getDynamicObjectField()` |
-| `client.getDynamicFields()`      | `client.core.listDynamicFields()`     |
-| `client.multiGetObjects()`       | `client.core.getObjects()`            |
+| v1.x Method                      | v2.0 Method                                                              |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `client.getObject()`             | `client.core.getObject()`                                                |
+| `client.getOwnedObjects()`       | `client.core.listOwnedObjects()`                                         |
+| `client.getDynamicFieldObject()` | `client.core.getDynamicField()` or `client.core.getDynamicObjectField()` |
+| `client.getDynamicFields()`      | `client.core.listDynamicFields()`                                        |
+| `client.multiGetObjects()`       | `client.core.getObjects()`                                               |
+
+Use `getDynamicField()` for regular dynamic fields and when you need the field entry or BCS-encoded
+value. Use `getDynamicObjectField()` only for dynamic object fields when you want the referenced
+child object returned directly.
 
 See the [Core API documentation](/sui/clients/core) for all available methods.
 

--- a/packages/docs/content/sui/migrations/sui-2.0/sui.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/sui.mdx
@@ -32,7 +32,7 @@ JSON-RPC method names or response shapes during migration.
 - `isSuiClient` (use `isSuiGrpcClient`, `isSuiGraphQLClient`, or legacy `isSuiJsonRpcClient`)
 - `SuiTransport` (legacy JSON-RPC code can use `JsonRpcTransport`)
 - `SuiTransportRequestOptions` (use `JsonRpcTransportRequestOptions` instead)
-- `SuiTransportSubscribeOptions` (use `JsonRpcTransportSubscribeOptions` instead)
+- `SuiTransportSubscribeOptions` (removed; use the gRPC subscription service for streaming APIs)
 - `SuiHTTPTransportOptions` (use `JsonRpcHTTPTransportOptions` instead)
 - `SuiHTTPTransport` (use `JsonRpcHTTPTransport` instead)
 - `getFullnodeUrl` (pass the full node URL to `SuiGrpcClient.baseUrl`; legacy JSON-RPC code can use
@@ -288,7 +288,8 @@ requiring `SuiJsonRpcClient` specifically.
 **Breaking changes:**
 
 - Constructor `client` parameter type changed from `SuiJsonRpcClient` to `ClientWithCoreApi`
-- Return type of `executeTransaction()`: `data` property renamed to `result`
+- Return type of `executeTransaction()` changed from the legacy `{ digest, effects, data }` wrapper
+  to a Core API `TransactionResult` discriminated union returned directly
 - The second parameter changed from JSON-RPC options to core API include options
 
 **Migration:**
@@ -311,10 +312,10 @@ const executor = new SerialTransactionExecutor({
 
 const result = await executor.executeTransaction(tx);
 
-// Accessing the transaction result (changed)
+// Accessing the transaction result now returned directly
 - console.log(result.data.effects?.status.status);
-+ const tx = result.Transaction ?? result.FailedTransaction;
-+ console.log(tx.effects.status.success);
++ const transaction = result.Transaction ?? result.FailedTransaction;
++ console.log(transaction.effects.status.success);
 ```
 
 Include options have also changed:

--- a/packages/docs/content/sui/migrations/sui-2.0/sui.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/sui.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/sui'
-description: Migrate @mysten/sui from 1.x to 2.0 with new client APIs and BCS changes.
+description: Migrate @mysten/sui from 1.x to 2.0 with gRPC clients, Core API, and BCS changes
 keywords:
   [
     migration,
@@ -16,48 +16,60 @@ keywords:
 
 ## Removal of `SuiClient` exports
 
-The `@mysten/sui/client` export path has been removed. All JSON-RPC client functionality is now
-exported from `@mysten/sui/jsonRpc`.
+The old `SuiClient` export has been removed from `@mysten/sui/client`. For application code, migrate
+to [`SuiGrpcClient`](/sui/clients/grpc) and use top-level methods such as `client.getObject()`,
+`client.listCoins()`, and `client.signAndExecuteTransaction()`.
+
+Legacy JSON-RPC functionality moved to `@mysten/sui/jsonRpc`, but JSON-RPC APIs are deprecated in
+the Sui TypeScript SDK. Use the JSON-RPC exports only when maintaining code that still needs the old
+JSON-RPC method names or response shapes during migration.
 
 **Removed exports:**
 
-- `SuiClient` (use `SuiJsonRpcClient` instead)
-- `SuiClientOptions` (use `SuiJsonRpcClientOptions` instead)
-- `isSuiClient` (use `isSuiJsonRpcClient` instead)
-- `SuiTransport` (use `JsonRpcTransport` instead)
+- `SuiClient` (use `SuiGrpcClient`; legacy JSON-RPC code can use `SuiJsonRpcClient`)
+- `SuiClientOptions` (use `SuiGrpcClientOptions`; legacy JSON-RPC code can use
+  `SuiJsonRpcClientOptions`)
+- `isSuiClient` (use `isSuiGrpcClient`, `isSuiGraphQLClient`, or legacy `isSuiJsonRpcClient`)
+- `SuiTransport` (legacy JSON-RPC code can use `JsonRpcTransport`)
 - `SuiTransportRequestOptions` (use `JsonRpcTransportRequestOptions` instead)
 - `SuiTransportSubscribeOptions` (use `JsonRpcTransportSubscribeOptions` instead)
 - `SuiHTTPTransportOptions` (use `JsonRpcHTTPTransportOptions` instead)
 - `SuiHTTPTransport` (use `JsonRpcHTTPTransport` instead)
-- `getFullnodeUrl` (use `getJsonRpcFullnodeUrl` instead)
+- `getFullnodeUrl` (pass the full node URL to `SuiGrpcClient.baseUrl`; legacy JSON-RPC code can use
+  `getJsonRpcFullnodeUrl`)
 - All JSON-RPC types (now exported from `@mysten/sui/jsonRpc`)
 
 **Migration:**
 
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
-+ import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 - const client = new SuiClient({
 -   url: getFullnodeUrl('devnet'),
-+ const client = new SuiJsonRpcClient({
-+   url: getJsonRpcFullnodeUrl('devnet'),
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.devnet.sui.io:443',
     network: 'devnet',
   });
 ```
 
 ## Network parameter required
 
-When creating a new `SuiGraphQLClient` or `SuiJsonRpcClient`, you must now provide a `network`
-parameter:
+When creating a new `SuiGrpcClient`, `SuiGraphQLClient`, or legacy `SuiJsonRpcClient`, provide a
+`network` parameter:
 
 ```ts
-const client = new SuiGraphQLClient({
+const grpcClient = new SuiGrpcClient({
+	baseUrl: 'https://...',
+	network: 'mainnet', // Required
+});
+
+const graphqlClient = new SuiGraphQLClient({
 	url: 'https://...',
 	network: 'mainnet', // Required
 });
 
-const client = new SuiJsonRpcClient({
+const jsonRpcClient = new SuiJsonRpcClient({
 	url: 'https://...',
 	network: 'mainnet', // Required
 });
@@ -78,11 +90,12 @@ objects.
 + effects.status.Failure.error
 ```
 
-**Core API** (gRPC and GraphQL responses): Uses a simplified structure with a `success` boolean:
+**Core API and top-level client methods** (gRPC and GraphQL responses): Use a simplified structure
+with a `success` boolean:
 
 ```typescript
-// Core API returns this structure
-const result = await client.core.getTransaction({ digest, include: { effects: true } });
+// Top-level gRPC and GraphQL methods return this structure.
+const result = await client.getTransaction({ digest, include: { effects: true } });
 const tx = result.Transaction ?? result.FailedTransaction;
 
 if (tx.effects.status.success) {
@@ -235,7 +248,7 @@ resolution is now built directly into the core client.
 **How it works now:**
 
 MVR name resolution happens automatically during transaction building. The SDK detects `.move` names
-(like `@org/package::module::Type`) and resolves them using the client's MVR resolver.
+like `@org/package::module::Type` and resolves them using the client's MVR resolver.
 
 **Migration:**
 
@@ -250,11 +263,10 @@ MVR name resolution happens automatically during transaction building. The SDK d
 -   })
 - );
 
-+ import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-+ import type { NamedPackagesOverrides } from '@mysten/sui/client';
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 +
-+ const client = new SuiJsonRpcClient({
-+   url: 'https://fullnode.mainnet.sui.io:443',
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.mainnet.sui.io:443',
 +   network: 'mainnet',
 +   mvr: {
 +     overrides: myOverrides,
@@ -284,7 +296,12 @@ requiring `SuiJsonRpcClient` specifically.
 ```diff
 import { SerialTransactionExecutor } from '@mysten/sui/transactions';
 - import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-+ // Works with any client: SuiJsonRpcClient, SuiGrpcClient, or SuiGraphQLClient
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
+
++ const client = new SuiGrpcClient({
++   baseUrl: 'https://fullnode.devnet.sui.io:443',
++   network: 'devnet',
++ });
 
 const executor = new SerialTransactionExecutor({
 -   client: jsonRpcClient,

--- a/packages/docs/content/sui/migrations/sui-2.0/suins.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/suins.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/suins'
-description: Migrate @mysten/suins to 2.0 with client extension pattern.
+description: Migrate @mysten/suins to 2.0 with client extension pattern
 keywords: [migration, '@mysten/suins', SuiNS, 2.0, client extension, name service, breaking changes]
 ---
 
@@ -9,7 +9,7 @@ This package now exports a client extension that integrates with Sui clients.
 ```diff
 - import { SuiClient, getFullnodeUrl } from '@mysten/sui/client';
 - import { SuinsClient } from '@mysten/suins';
-+ import { SuiGrpcClient } from '@mysten/sui/grpc'; // or SuiJsonRpcClient, SuiGraphQLClient
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 + import { suins } from '@mysten/suins';
 
 - const suiClient = new SuiClient({ url: getFullnodeUrl('mainnet') });

--- a/packages/docs/content/sui/migrations/sui-2.0/walrus.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/walrus.mdx
@@ -1,6 +1,6 @@
 ---
 title: '@mysten/walrus'
-description: Migrate @mysten/walrus to 2.0 with required client parameter and updated API.
+description: Migrate @mysten/walrus to 2.0 with required client parameter and updated API
 keywords:
   [
     migration,
@@ -29,7 +29,7 @@ If you were creating `WalrusClient` directly:
 
 ```diff
 - import { WalrusClient } from '@mysten/walrus';
-+ import { SuiGrpcClient } from '@mysten/sui/grpc'; // or SuiJsonRpcClient, SuiGraphQLClient
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 + import { walrus } from '@mysten/walrus';
 
 - const walrusClient = new WalrusClient({

--- a/packages/docs/content/sui/migrations/sui-2.0/walrus.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/walrus.mdx
@@ -42,7 +42,7 @@ If you were creating `WalrusClient` directly:
 + }).$extend(walrus());
 
 - await walrusClient.getBlob(blobId);
-+ await client.walrus.getBlob(blobId);
++ await client.walrus.getBlob({ blobId });
 ```
 
 If you were passing `network` to `walrus()`, remove it:

--- a/packages/docs/content/sui/migrations/sui-2.0/zksend.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/zksend.mdx
@@ -1,12 +1,12 @@
 ---
 title: '@mysten/zksend'
-description: Migrate @mysten/zksend to 2.0 with client extension pattern and simplified API.
+description: Migrate @mysten/zksend to 2.0 with client extension pattern and simplified API
 keywords:
   [migration, '@mysten/zksend', zkSend, 2.0, client extension, contract links, breaking changes]
 ---
 
-This package now exports a client extension that integrates with Sui clients, enabling compatibility
-with gRPC, GraphQL, and JSON RPC transports.
+This package now exports a client extension that integrates with Sui clients through the Core API.
+Use `SuiGrpcClient` for most applications.
 
 ## Breaking changes
 
@@ -26,7 +26,7 @@ Update your code to use the client extension:
 ```diff
 - import { ZkSendLinkBuilder, ZkSendLink } from '@mysten/zksend';
 + import { zksend } from '@mysten/zksend';
-+ import { SuiGrpcClient } from '@mysten/sui/grpc'; // or SuiJsonRpcClient, SuiGraphQLClient
++ import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 + const client = new SuiGrpcClient({
 +   baseUrl: 'https://fullnode.testnet.sui.io:443',
@@ -75,7 +75,7 @@ Update your code to use the client extension:
 
 ```ts
 import { zksend } from '@mysten/zksend';
-import { SuiGrpcClient } from '@mysten/sui/grpc'; // or SuiJsonRpcClient, SuiGraphQLClient
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 
 // Create client with zkSend extension
 const client = new SuiGrpcClient({

--- a/packages/docs/content/sui/migrations/sui-2.0/zksend.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/zksend.mdx
@@ -89,12 +89,13 @@ const linkBuilder = client.zksend.linkBuilder({
 });
 
 // Add assets to the link
-linkBuilder.addSui(1_000_000_000n); // 1 SUI
+linkBuilder.addClaimableMist(1_000_000_000n); // 1 SUI
 
-// Create the transaction
-const { tx, link } = await linkBuilder.build();
+// Create the transaction and get the claim URL
+const tx = await linkBuilder.createSendTransaction();
+const linkUrl = linkBuilder.getLink();
 
 // Later, load an existing link
 const existingLink = await client.zksend.loadLinkFromUrl(linkUrl);
-const assets = await existingLink.getAssets();
+const assets = existingLink.assets;
 ```

--- a/packages/docs/content/sui/sdk-building.mdx
+++ b/packages/docs/content/sui/sdk-building.mdx
@@ -1,6 +1,6 @@
 ---
 title: Building SDKs
-description: Build custom SDKs on top of the Sui TypeScript SDK.
+description: Build custom SDKs on top of the Sui TypeScript SDK
 keywords:
   [
     SDK development,
@@ -14,12 +14,14 @@ keywords:
 ---
 
 This guide covers recommended patterns for building TypeScript SDKs that integrate with the Sui SDK.
-Following these patterns ensures your SDK integrates seamlessly with the ecosystem, works across
-different transports (JSON-RPC, GraphQL, gRPC), and composes well with other SDKs.
+Following these patterns ensures your SDK integrates seamlessly with the ecosystem, works with
+`SuiGrpcClient` and `SuiGraphQLClient` through the shared Core API, and composes well with other
+SDKs. Legacy JSON-RPC clients can also be supported during migration because they implement the same
+Core API contract.
 
 All SDKs should depend on [`ClientWithCoreApi`](./clients/core), which is the transport-agnostic
-interface implemented by all Sui clients. This ensures your SDK works with any client the user
-chooses.
+interface implemented by Sui clients. This lets application code choose one concrete client and use
+top-level methods, while SDK internals use `client.core` for portable reads, writes, and queries.
 
 ## Package setup
 

--- a/packages/kiosk/package.json
+++ b/packages/kiosk/package.json
@@ -35,7 +35,7 @@
 		"build": "rm -rf dist && tsc --noEmit && tsdown",
 		"build:docs": "node ../docs/scripts/build-docs.ts",
 		"codegen": "sui-ts-codegen generate && pnpm lint:fix",
-		"test": "echo 'No unit tests for kiosk SDK'",
+		"test": "vitest run --typecheck --config vitest.unit.config.mts",
 		"pre-commit": "pnpm prettier:fix && pnpm lint && pnpm build",
 		"prettier:check": "prettier -c --ignore-unknown .",
 		"prettier:fix": "prettier -w --ignore-unknown .",
@@ -46,8 +46,7 @@
 		"test:e2e": "vitest run e2e"
 	},
 	"dependencies": {
-		"@mysten/bcs": "workspace:^",
-		"@mysten/utils": "workspace:^"
+		"@mysten/bcs": "workspace:^"
 	},
 	"devDependencies": {
 		"@mysten/codegen": "workspace:^",

--- a/packages/kiosk/src/client/kiosk-client.ts
+++ b/packages/kiosk/src/client/kiosk-client.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PaginationArguments } from '@mysten/sui/jsonRpc';
 import type { SuiClientTypes } from '@mysten/sui/client';
 
 import {
@@ -24,6 +23,7 @@ import type {
 	KioskClientOptions,
 	KioskCompatibleClient,
 	KioskData,
+	KioskPaginationArguments,
 	OwnedKiosks,
 } from '../types/index.js';
 
@@ -37,11 +37,11 @@ export type KioskExtensionOptions<Name extends string = 'kiosk'> = {
  *
  * @example
  * ```ts
- * import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+ * import { SuiGrpcClient } from '@mysten/sui/grpc';
  * import { kiosk } from '@mysten/kiosk';
  *
- * const client = new SuiJsonRpcClient({
- *   url: getJsonRpcFullnodeUrl('mainnet'),
+ * const client = new SuiGrpcClient({
+ *   baseUrl: 'https://fullnode.mainnet.sui.io:443',
  *   network: 'mainnet',
  * }).$extend(kiosk());
  *
@@ -100,7 +100,7 @@ export class KioskClient {
 		pagination,
 	}: {
 		address: string;
-		pagination?: PaginationArguments<string>;
+		pagination?: KioskPaginationArguments;
 	}): Promise<OwnedKiosks> {
 		const personalPackageId =
 			this.packageIds?.personalKioskRulePackageId || PERSONAL_KIOSK_RULE_ADDRESS[this.network];

--- a/packages/kiosk/src/query/client-utils.ts
+++ b/packages/kiosk/src/query/client-utils.ts
@@ -8,6 +8,7 @@ import type { ObjectWithDisplay } from '../types/kiosk.js';
 import type { KioskCompatibleClient } from '../types/index.js';
 
 const DEFAULT_QUERY_LIMIT = 50;
+const MAX_EVENT_QUERY_PAGES = 10;
 
 export async function getAllObjects(
 	client: KioskCompatibleClient,
@@ -55,16 +56,19 @@ export async function queryEvents(
 	const events: SuiClientTypes.EventEntry[] = [];
 	let cursor: string | null = null;
 
-	while (true) {
+	// gRPC can return empty scan-limited pages. Continue through a bounded number of those pages
+	// while preserving the 50-event window returned by the previous transport-specific queries.
+	for (let pageCount = 0; pageCount < MAX_EVENT_QUERY_PAGES; pageCount++) {
+		const remaining = DEFAULT_QUERY_LIMIT - events.length;
 		const page = await client.core.listEvents({
 			filter: { eventType },
-			limit: DEFAULT_QUERY_LIMIT,
+			limit: remaining,
 			order,
 			...(cursor ? (order === 'descending' ? { before: cursor } : { after: cursor }) : {}),
 		});
 
-		events.push(...page.events);
-		if (!page.hasNextPage) break;
+		events.push(...page.events.slice(0, remaining));
+		if (!page.hasNextPage || events.length === DEFAULT_QUERY_LIMIT) break;
 
 		if (!page.endCursor || page.endCursor === cursor) {
 			throw new Error('Event query did not return a cursor for the next page');

--- a/packages/kiosk/src/query/client-utils.ts
+++ b/packages/kiosk/src/query/client-utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SuiClientTypes } from '@mysten/sui/client';
+import { isSuiGraphQLClient } from '@mysten/sui/graphql';
 
 import type { ObjectWithDisplay } from '../types/kiosk.js';
 import type { KioskCompatibleClient } from '../types/index.js';
@@ -49,11 +50,27 @@ export async function queryEvents(
 	client: KioskCompatibleClient,
 	eventType: string,
 ): Promise<{ json: unknown }[]> {
-	const { events } = await client.core.listEvents({
-		filter: { eventType },
-		limit: DEFAULT_QUERY_LIMIT,
-		order: 'descending',
-	});
+	// Preserve the windows returned by the previously transport-specific implementations.
+	const order = isSuiGraphQLClient(client) ? 'ascending' : 'descending';
+	const events: SuiClientTypes.EventEntry[] = [];
+	let cursor: string | null = null;
+
+	while (events.length < DEFAULT_QUERY_LIMIT) {
+		const page = await client.core.listEvents({
+			filter: { eventType },
+			limit: DEFAULT_QUERY_LIMIT - events.length,
+			order,
+			...(cursor ? (order === 'descending' ? { before: cursor } : { after: cursor }) : {}),
+		});
+
+		events.push(...page.events);
+		if (!page.hasNextPage || events.length >= DEFAULT_QUERY_LIMIT) break;
+
+		if (!page.endCursor || page.endCursor === cursor) {
+			throw new Error('Event query did not return a cursor for the next page');
+		}
+		cursor = page.endCursor;
+	}
 
 	return events.map((event) => ({ json: event.json }));
 }

--- a/packages/kiosk/src/query/client-utils.ts
+++ b/packages/kiosk/src/query/client-utils.ts
@@ -55,16 +55,16 @@ export async function queryEvents(
 	const events: SuiClientTypes.EventEntry[] = [];
 	let cursor: string | null = null;
 
-	while (events.length < DEFAULT_QUERY_LIMIT) {
+	while (true) {
 		const page = await client.core.listEvents({
 			filter: { eventType },
-			limit: DEFAULT_QUERY_LIMIT - events.length,
+			limit: DEFAULT_QUERY_LIMIT,
 			order,
 			...(cursor ? (order === 'descending' ? { before: cursor } : { after: cursor }) : {}),
 		});
 
 		events.push(...page.events);
-		if (!page.hasNextPage || events.length >= DEFAULT_QUERY_LIMIT) break;
+		if (!page.hasNextPage) break;
 
 		if (!page.endCursor || page.endCursor === cursor) {
 			throw new Error('Event query did not return a cursor for the next page');

--- a/packages/kiosk/src/query/client-utils.ts
+++ b/packages/kiosk/src/query/client-utils.ts
@@ -2,66 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { SuiClientTypes } from '@mysten/sui/client';
-import { graphql } from '@mysten/sui/graphql/schema';
-import { isSuiGraphQLClient } from '@mysten/sui/graphql';
-import { isSuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-import { normalizeStructTag } from '@mysten/sui/utils';
-import { chunk, fromBase64 } from '@mysten/utils';
 
-import type { KioskDisplay, ObjectWithDisplay } from '../types/kiosk.js';
+import type { ObjectWithDisplay } from '../types/kiosk.js';
 import type { KioskCompatibleClient } from '../types/index.js';
 
 const DEFAULT_QUERY_LIMIT = 50;
-
-const FetchObjectsWithDisplayQuery = graphql(`
-	query FetchObjectsWithDisplay($objectKeys: [ObjectKey!]!) {
-		multiGetObjects(keys: $objectKeys) {
-			address
-			digest
-			version
-			asMoveObject {
-				contents {
-					bcs
-					type {
-						repr
-					}
-					display {
-						output
-						errors
-					}
-				}
-			}
-			asMovePackage {
-				__typename
-			}
-			owner {
-				__typename
-				... on AddressOwner {
-					address {
-						address
-					}
-				}
-				... on ObjectOwner {
-					address {
-						address
-					}
-				}
-				... on Shared {
-					initialSharedVersion
-				}
-				... on ConsensusAddressOwner {
-					startVersion
-					address {
-						address
-					}
-				}
-			}
-			previousTransaction {
-				digest
-			}
-		}
-	}
-`);
 
 export async function getAllObjects(
 	client: KioskCompatibleClient,
@@ -69,234 +14,46 @@ export async function getAllObjects(
 ): Promise<ObjectWithDisplay[]> {
 	if (ids.length === 0) return [];
 
-	const chunks = chunk(ids, DEFAULT_QUERY_LIMIT);
-	const results: ObjectWithDisplay[] = [];
+	const { objects } = await client.core.getObjects({
+		objectIds: ids,
+		include: {
+			content: true,
+			previousTransaction: true,
+			display: true,
+		},
+	});
 
-	if (isSuiGraphQLClient(client)) {
-		for (const batch of chunks) {
-			const { data } = await client.query({
-				query: FetchObjectsWithDisplayQuery,
-				variables: {
-					objectKeys: batch.map((address) => ({ address })),
-				},
-			});
-
-			if (data?.multiGetObjects) {
-				for (const obj of data.multiGetObjects) {
-					if (!obj) continue;
-
-					let type: string;
-					if (obj.asMovePackage) {
-						type = 'package';
-					} else if (obj.asMoveObject?.contents?.type?.repr) {
-						type = obj.asMoveObject.contents.type.repr;
-					} else {
-						type = '';
+	return objects
+		.filter(
+			(
+				object,
+			): object is SuiClientTypes.Object<{
+				content: true;
+				previousTransaction: true;
+				display: true;
+			}> => !(object instanceof Error),
+		)
+		.map((object) => ({
+			...object,
+			previousTransaction: object.previousTransaction ?? null,
+			display: object.display
+				? {
+						data: object.display.output,
+						error: object.display.errors ? JSON.stringify(object.display.errors) : null,
 					}
-
-					const bcsContent = obj.asMoveObject?.contents?.bcs
-						? fromBase64(obj.asMoveObject.contents.bcs)
-						: undefined;
-
-					const displayData = obj.asMoveObject?.contents?.display;
-					const display: KioskDisplay | undefined = displayData
-						? {
-								data: (displayData.output as Record<string, unknown> | null) ?? null,
-								error: displayData.errors ? JSON.stringify(displayData.errors) : null,
-							}
-						: undefined;
-
-					results.push({
-						objectId: obj.address,
-						version: obj.version?.toString()!,
-						digest: obj.digest!,
-						type,
-						content: bcsContent!,
-						owner: mapGraphQLOwner(obj.owner!),
-						previousTransaction: (obj.previousTransaction?.digest ?? null)!,
-						objectBcs: undefined,
-						json: undefined,
-						display,
-					});
-				}
-			}
-		}
-
-		return results;
-	}
-
-	if (isSuiJsonRpcClient(client)) {
-		for (const batch of chunks) {
-			const responses = await client.multiGetObjects({
-				ids: batch,
-				options: {
-					showDisplay: true,
-					showBcs: true,
-					showType: true,
-					showOwner: true,
-					showPreviousTransaction: true,
-				},
-			});
-
-			for (const resp of responses) {
-				if (!resp.data) continue;
-				const obj = resp.data;
-
-				const bcsContent =
-					obj.bcs?.dataType === 'moveObject' ? fromBase64(obj.bcs.bcsBytes) : undefined;
-
-				const type =
-					obj.type && obj.type.includes('::') ? normalizeStructTag(obj.type) : (obj.type ?? '');
-
-				const display: KioskDisplay | undefined = obj.display
-					? {
-							data: obj.display.data ?? null,
-							error: obj.display.error ? JSON.stringify(obj.display.error) : null,
-						}
-					: undefined;
-
-				results.push({
-					objectId: obj.objectId,
-					version: obj.version,
-					digest: obj.digest,
-					type,
-					content: bcsContent!,
-					owner: parseJsonRpcOwner(obj.owner!),
-					previousTransaction: (obj.previousTransaction ?? null)!,
-					objectBcs: undefined,
-					json: undefined,
-					display,
-				});
-			}
-		}
-
-		return results;
-	}
-
-	throw new Error(
-		'Object fetching requires a JSON-RPC or GraphQL client. ' +
-			'gRPC clients are not supported by the kiosk SDK.',
-	);
-}
-
-function parseJsonRpcOwner(owner: NonNullable<unknown>): SuiClientTypes.ObjectOwner {
-	if (owner === 'Immutable') {
-		return { $kind: 'Immutable', Immutable: true } as SuiClientTypes.ObjectOwner;
-	}
-
-	const ownerObj = owner as Record<string, any>;
-
-	if ('ConsensusAddressOwner' in ownerObj) {
-		return {
-			$kind: 'ConsensusAddressOwner',
-			ConsensusAddressOwner: {
-				owner: ownerObj.ConsensusAddressOwner.owner,
-				startVersion: ownerObj.ConsensusAddressOwner.start_version,
-			},
-		} as SuiClientTypes.ObjectOwner;
-	}
-
-	if ('AddressOwner' in ownerObj) {
-		return {
-			$kind: 'AddressOwner',
-			AddressOwner: ownerObj.AddressOwner,
-		} as SuiClientTypes.ObjectOwner;
-	}
-
-	if ('ObjectOwner' in ownerObj) {
-		return {
-			$kind: 'ObjectOwner',
-			ObjectOwner: ownerObj.ObjectOwner,
-		} as SuiClientTypes.ObjectOwner;
-	}
-
-	if ('Shared' in ownerObj) {
-		return {
-			$kind: 'Shared',
-			Shared: {
-				initialSharedVersion: ownerObj.Shared.initial_shared_version,
-			},
-		} as SuiClientTypes.ObjectOwner;
-	}
-
-	throw new Error(`Unknown owner type: ${JSON.stringify(owner)}`);
-}
-
-function mapGraphQLOwner(
-	owner: NonNullable<unknown> & { __typename?: string },
-): SuiClientTypes.ObjectOwner {
-	const o = owner as Record<string, any>;
-	switch (o.__typename) {
-		case 'AddressOwner':
-			return {
-				$kind: 'AddressOwner',
-				AddressOwner: o.address?.address!,
-			} as SuiClientTypes.ObjectOwner;
-		case 'ObjectOwner':
-			return {
-				$kind: 'ObjectOwner',
-				ObjectOwner: o.address?.address!,
-			} as SuiClientTypes.ObjectOwner;
-		case 'Immutable':
-			return { $kind: 'Immutable', Immutable: true } as SuiClientTypes.ObjectOwner;
-		case 'Shared':
-			return {
-				$kind: 'Shared',
-				Shared: { initialSharedVersion: String(o.initialSharedVersion) },
-			} as SuiClientTypes.ObjectOwner;
-		case 'ConsensusAddressOwner':
-			return {
-				$kind: 'ConsensusAddressOwner',
-				ConsensusAddressOwner: {
-					owner: o.address?.address!,
-					startVersion: String(o.startVersion),
-				},
-			} as SuiClientTypes.ObjectOwner;
-		default:
-			throw new Error(`Unknown GraphQL owner type: ${o.__typename}`);
-	}
+				: undefined,
+		}));
 }
 
 export async function queryEvents(
 	client: KioskCompatibleClient,
 	eventType: string,
 ): Promise<{ json: unknown }[]> {
-	if (isSuiGraphQLClient(client)) {
-		const query = graphql(`
-			query QueryEvents($eventType: String!) {
-				events(filter: { eventType: $eventType }, first: 50) {
-					nodes {
-						contents {
-							json
-						}
-					}
-				}
-			}
-		`);
+	const { events } = await client.core.listEvents({
+		filter: { eventType },
+		limit: DEFAULT_QUERY_LIMIT,
+		order: 'descending',
+	});
 
-		const result = await client.query({
-			query,
-			variables: { eventType },
-		});
-
-		return (
-			result.data?.events?.nodes.map((event) => ({
-				json: event.contents?.json,
-			})) ?? []
-		);
-	}
-
-	if (isSuiJsonRpcClient(client)) {
-		const events = await client.queryEvents({
-			query: { MoveEventType: eventType },
-		});
-
-		return events.data?.map((d) => ({ json: d.parsedJson })) ?? [];
-	}
-
-	throw new Error(
-		'Event querying is not supported by this client type. ' +
-			'JSON-RPC and GraphQL clients support event querying, but gRPC does not. ' +
-			'Please use a JSON-RPC or GraphQL client, or provide the required IDs directly.',
-	);
+	return events.map((event) => ({ json: event.json }));
 }

--- a/packages/kiosk/src/query/kiosk.ts
+++ b/packages/kiosk/src/query/kiosk.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { PaginationArguments } from '@mysten/sui/jsonRpc';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import { isValidSuiAddress } from '@mysten/sui/utils';
 
@@ -11,6 +10,7 @@ import type {
 	KioskCompatibleClient,
 	KioskExtension,
 	KioskListing,
+	KioskPaginationArguments,
 	OwnedKiosks,
 	PagedKioskData,
 } from '../types/index.js';
@@ -29,7 +29,7 @@ import { PersonalKioskCap } from '../contracts/kiosk/personal_kiosk.js';
 export async function fetchKiosk(
 	client: KioskCompatibleClient,
 	kioskId: string,
-	pagination: PaginationArguments<string>,
+	pagination: KioskPaginationArguments,
 	options: FetchKioskOptions,
 ): Promise<PagedKioskData> {
 	// TODO: Replace the `getAllDynamicFields` with a paginated
@@ -83,7 +83,7 @@ export async function getOwnedKiosks(
 	client: ClientWithCoreApi,
 	address: string,
 	options?: {
-		pagination?: PaginationArguments<string>;
+		pagination?: KioskPaginationArguments;
 		personalKioskType: string;
 	},
 ): Promise<OwnedKiosks> {

--- a/packages/kiosk/src/query/transfer-policy.ts
+++ b/packages/kiosk/src/query/transfer-policy.ts
@@ -21,12 +21,8 @@ import { queryEvents } from './client-utils.js';
  * and the caller needs to filter the results accordingly (ie single owner can not
  * be accessed by anyone but the owner).
  *
- * This method requires event querying support (JSON-RPC or GraphQL clients).
- * gRPC clients do not support event querying and will throw an error.
- *
- * @param client - The Sui client (must support event querying)
+ * @param client - A Sui client with the Core API
  * @param type - The type of the asset (e.g., "0x123::nft::NFT")
- * @throws Error if the client doesn't support event querying
  */
 export async function queryTransferPolicy(
 	client: KioskCompatibleClient,

--- a/packages/kiosk/src/types/index.ts
+++ b/packages/kiosk/src/types/index.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiClientTypes } from '@mysten/sui/client';
+import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import type { TransactionObjectArgument } from '@mysten/sui/transactions';
 
 import type { BaseRulePackageIds } from '../constants.js';
-import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
-import { SuiGraphQLClient } from '@mysten/sui/graphql';
 
 export * from './kiosk.js';
 export * from './transfer-policy.js';
@@ -25,4 +23,9 @@ export type KioskClientOptions = {
 	packageIds?: BaseRulePackageIds;
 };
 
-export type KioskCompatibleClient = SuiJsonRpcClient | SuiGraphQLClient;
+export type KioskCompatibleClient = ClientWithCoreApi;
+
+export type KioskPaginationArguments = {
+	cursor?: string | null;
+	limit?: number | null;
+};

--- a/packages/kiosk/src/types/transfer-policy.ts
+++ b/packages/kiosk/src/types/transfer-policy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ObjectOwner } from '@mysten/sui/jsonRpc';
+import type { SuiClientTypes } from '@mysten/sui/client';
 import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
 
 import type { KioskClient } from '../client/kiosk-client.js';
@@ -42,7 +42,7 @@ export type TransferPolicy = {
 	type: string;
 	balance: string;
 	rules: string[];
-	owner: ObjectOwner;
+	owner: SuiClientTypes.ObjectOwner;
 };
 
 /** Event emitted when a TransferPolicy is created. */

--- a/packages/kiosk/src/types/transfer-policy.ts
+++ b/packages/kiosk/src/types/transfer-policy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SuiClientTypes } from '@mysten/sui/client';
+import type { ObjectOwner } from '@mysten/sui/jsonRpc';
 import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
 
 import type { KioskClient } from '../client/kiosk-client.js';
@@ -42,7 +42,7 @@ export type TransferPolicy = {
 	type: string;
 	balance: string;
 	rules: string[];
-	owner: SuiClientTypes.ObjectOwner;
+	owner: ObjectOwner;
 };
 
 /** Event emitted when a TransferPolicy is created. */

--- a/packages/kiosk/src/utils.ts
+++ b/packages/kiosk/src/utils.ts
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { bcs } from '@mysten/sui/bcs';
-import { PaginationArguments } from '@mysten/sui/jsonRpc';
 import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
 import { normalizeStructTag, normalizeSuiAddress, parseStructTag } from '@mysten/sui/utils';
 
 import { Item, Listing, Lock, Kiosk as KioskStruct } from './contracts/0x2/kiosk.js';
-import type { Kiosk, KioskData, KioskListing, ObjectWithDisplay } from './types/index.js';
+import type {
+	Kiosk,
+	KioskData,
+	KioskListing,
+	KioskPaginationArguments,
+	ObjectWithDisplay,
+} from './types/index.js';
 
 export type DynamicFieldInfo = SuiClientTypes.ListDynamicFieldsResponse['dynamicFields'][number];
 
@@ -176,7 +181,7 @@ export function attachLockedItems(kioskData: KioskData, lockedItemIds: string[])
 export async function getAllDynamicFields(
 	client: ClientWithCoreApi,
 	parentId: string,
-	pagination: PaginationArguments<string>,
+	pagination: KioskPaginationArguments,
 ): Promise<DynamicFieldInfo[]> {
 	let hasNextPage = true;
 	let cursor: string | null = null;

--- a/packages/kiosk/test/unit/client-utils.test.ts
+++ b/packages/kiosk/test/unit/client-utils.test.ts
@@ -119,34 +119,49 @@ describe('Kiosk Core API queries', () => {
 		});
 	});
 
-	it('queries every event page when more than 50 policies exist', async () => {
+	it('stops after the existing 50-event window', async () => {
 		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
-		const firstPage = Array.from({ length: 50 }, (_, index) => ({ json: { id: `0x${index}` } }));
+		const firstPage = Array.from({ length: 40 }, (_, index) => ({ json: { id: `0x${index}` } }));
 		const listEvents = vi
 			.fn()
 			.mockResolvedValueOnce({
 				events: firstPage,
 				hasNextPage: true,
 				startCursor: 'first',
-				endCursor: 'fiftieth',
+				endCursor: 'fortieth',
 			})
 			.mockResolvedValueOnce({
-				events: [{ json: { id: '0x50' } }],
-				hasNextPage: false,
-				startCursor: 'fifty-first',
-				endCursor: 'fifty-first',
+				events: Array.from({ length: 10 }, (_, index) => ({ json: { id: `0x${index + 40}` } })),
+				hasNextPage: true,
+				startCursor: 'forty-first',
+				endCursor: 'fiftieth',
 			});
 		const client = { core: { listEvents } } as unknown as ClientWithCoreApi;
 
 		const events = await queryEvents(client, eventType);
-		expect(events).toHaveLength(51);
-		expect(events.at(-1)).toEqual({ json: { id: '0x50' } });
+		expect(events).toHaveLength(50);
+		expect(events.at(-1)).toEqual({ json: { id: '0x49' } });
+		expect(listEvents).toHaveBeenCalledTimes(2);
 		expect(listEvents).toHaveBeenNthCalledWith(2, {
 			filter: { eventType },
-			limit: 50,
+			limit: 10,
 			order: 'descending',
-			before: 'fiftieth',
+			before: 'fortieth',
 		});
+	});
+
+	it('stops after a bounded number of scan-limited pages', async () => {
+		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
+		const listEvents = vi.fn().mockImplementation(async () => ({
+			events: [],
+			hasNextPage: true,
+			startCursor: null,
+			endCursor: `scan-frontier-${listEvents.mock.calls.length}`,
+		}));
+		const client = { core: { listEvents } } as unknown as ClientWithCoreApi;
+
+		await expect(queryEvents(client, eventType)).resolves.toEqual([]);
+		expect(listEvents).toHaveBeenCalledTimes(10);
 	});
 
 	it('preserves the existing ascending GraphQL event window', async () => {

--- a/packages/kiosk/test/unit/client-utils.test.ts
+++ b/packages/kiosk/test/unit/client-utils.test.ts
@@ -91,4 +91,52 @@ describe('Kiosk Core API queries', () => {
 			order: 'descending',
 		});
 	});
+
+	it('continues scan-limited event pages until it finds matching events', async () => {
+		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
+		const listEvents = vi
+			.fn()
+			.mockResolvedValueOnce({
+				events: [],
+				hasNextPage: true,
+				startCursor: null,
+				endCursor: 'scan-frontier',
+			})
+			.mockResolvedValueOnce({
+				events: [{ json: { id: '0x5' } }],
+				hasNextPage: false,
+				startCursor: 'event',
+				endCursor: 'event',
+			});
+		const client = { core: { listEvents } } as unknown as ClientWithCoreApi;
+
+		await expect(queryEvents(client, eventType)).resolves.toEqual([{ json: { id: '0x5' } }]);
+		expect(listEvents).toHaveBeenNthCalledWith(2, {
+			filter: { eventType },
+			limit: 50,
+			order: 'descending',
+			before: 'scan-frontier',
+		});
+	});
+
+	it('preserves the existing ascending GraphQL event window', async () => {
+		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
+		const listEvents = vi.fn().mockResolvedValue({
+			events: [],
+			hasNextPage: false,
+			startCursor: null,
+			endCursor: null,
+		});
+		const client = {
+			core: { listEvents },
+			[Symbol.for('@mysten/SuiGraphQLClient')]: true,
+		} as unknown as ClientWithCoreApi;
+
+		await queryEvents(client, eventType);
+		expect(listEvents).toHaveBeenCalledWith({
+			filter: { eventType },
+			limit: 50,
+			order: 'ascending',
+		});
+	});
 });

--- a/packages/kiosk/test/unit/client-utils.test.ts
+++ b/packages/kiosk/test/unit/client-utils.test.ts
@@ -119,6 +119,36 @@ describe('Kiosk Core API queries', () => {
 		});
 	});
 
+	it('queries every event page when more than 50 policies exist', async () => {
+		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
+		const firstPage = Array.from({ length: 50 }, (_, index) => ({ json: { id: `0x${index}` } }));
+		const listEvents = vi
+			.fn()
+			.mockResolvedValueOnce({
+				events: firstPage,
+				hasNextPage: true,
+				startCursor: 'first',
+				endCursor: 'fiftieth',
+			})
+			.mockResolvedValueOnce({
+				events: [{ json: { id: '0x50' } }],
+				hasNextPage: false,
+				startCursor: 'fifty-first',
+				endCursor: 'fifty-first',
+			});
+		const client = { core: { listEvents } } as unknown as ClientWithCoreApi;
+
+		const events = await queryEvents(client, eventType);
+		expect(events).toHaveLength(51);
+		expect(events.at(-1)).toEqual({ json: { id: '0x50' } });
+		expect(listEvents).toHaveBeenNthCalledWith(2, {
+			filter: { eventType },
+			limit: 50,
+			order: 'descending',
+			before: 'fiftieth',
+		});
+	});
+
 	it('preserves the existing ascending GraphQL event window', async () => {
 		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
 		const listEvents = vi.fn().mockResolvedValue({

--- a/packages/kiosk/test/unit/client-utils.test.ts
+++ b/packages/kiosk/test/unit/client-utils.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { describe, expect, it, vi } from 'vitest';
+
+import { kiosk } from '../../src/client/kiosk-client.js';
+import { getAllObjects, queryEvents } from '../../src/query/client-utils.js';
+
+describe('Kiosk Core API queries', () => {
+	it('registers the kiosk extension on a gRPC client', () => {
+		const client = new SuiGrpcClient({
+			network: 'localnet',
+			baseUrl: 'http://127.0.0.1:9000',
+		});
+
+		const extendedClient = client.$extend(kiosk());
+
+		expect(extendedClient.kiosk.client).toBe(client);
+	});
+
+	it('fetches objects and maps Core display data to the Kiosk response shape', async () => {
+		const object: SuiClientTypes.Object<{
+			content: true;
+			previousTransaction: true;
+			display: true;
+		}> = {
+			objectId: '0x1',
+			version: '1',
+			digest: 'digest',
+			owner: { $kind: 'AddressOwner', AddressOwner: '0x2' },
+			type: '0x2::example::Item',
+			content: new Uint8Array([1, 2, 3]),
+			previousTransaction: 'transaction',
+			objectBcs: undefined,
+			json: undefined,
+			display: {
+				output: { name: 'Example' },
+				errors: { description: 'rendering failed' },
+			},
+		};
+		const getObjects = vi.fn().mockResolvedValue({ objects: [object, new Error('not found')] });
+		const client = { core: { getObjects } } as unknown as ClientWithCoreApi;
+
+		await expect(getAllObjects(client, ['0x1', '0x2'])).resolves.toEqual([
+			{
+				...object,
+				display: {
+					data: { name: 'Example' },
+					error: JSON.stringify({ description: 'rendering failed' }),
+				},
+			},
+		]);
+		expect(getObjects).toHaveBeenCalledWith({
+			objectIds: ['0x1', '0x2'],
+			include: {
+				content: true,
+				previousTransaction: true,
+				display: true,
+			},
+		});
+	});
+
+	it('queries transfer policy events through the Core API', async () => {
+		const listEvents = vi.fn().mockResolvedValue({
+			events: [
+				{
+					packageId: '0x2',
+					module: 'transfer_policy',
+					sender: '0x3',
+					eventType: '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>',
+					bcs: new Uint8Array(),
+					json: { id: '0x5' },
+					checkpoint: '1',
+					transactionDigest: 'transaction',
+					eventIndex: 0,
+				},
+			],
+			hasNextPage: false,
+			startCursor: 'start',
+			endCursor: 'end',
+		});
+		const client = { core: { listEvents } } as unknown as ClientWithCoreApi;
+		const eventType = '0x2::transfer_policy::TransferPolicyCreated<0x4::example::Item>';
+
+		await expect(queryEvents(client, eventType)).resolves.toEqual([{ json: { id: '0x5' } }]);
+		expect(listEvents).toHaveBeenCalledWith({
+			filter: { eventType },
+			limit: 50,
+			order: 'descending',
+		});
+	});
+});

--- a/packages/kiosk/vitest.unit.config.mts
+++ b/packages/kiosk/vitest.unit.config.mts
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['test/unit/**/*.test.ts'],
+	},
+	resolve: {
+		alias: {
+			'@mysten/bcs': new URL('../bcs/src', import.meta.url).pathname,
+			'@mysten/sui': new URL('../sui/src', import.meta.url).pathname,
+		},
+	},
+});

--- a/packages/sui/README.md
+++ b/packages/sui/README.md
@@ -89,8 +89,8 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.devnet.sui.io:443',
 });
 
-// get coins owned by an address using the Core API
-await client.getCoins({
+// get coins owned by an address
+await client.listCoins({
 	owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 });
 ```
@@ -108,8 +108,8 @@ const client = new SuiGrpcClient({
 	baseUrl: 'http://127.0.0.1:9000',
 });
 
-// get coins owned by an address using the Core API
-await client.getCoins({
+// get coins owned by an address
+await client.listCoins({
 	owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 });
 ```
@@ -125,8 +125,8 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://your-fullnode.example.com:443',
 });
 
-// get coins owned by an address using the Core API
-await client.getCoins({
+// get coins owned by an address
+await client.listCoins({
 	owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 });
 ```
@@ -421,13 +421,13 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
 
-const coins = await client.getCoins({
+const coins = await client.listCoins({
 	owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 	coinType: '0x65b0553a591d7b13376e03a408e112c706dc0909a79080c810b93b06f922c458::usdc::USDC',
 });
 ```
 
-Fetch all coin objects owned by an address:
+Fetch SUI coin objects owned by an address:
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';
@@ -437,7 +437,7 @@ const client = new SuiGrpcClient({
 	baseUrl: 'https://fullnode.testnet.sui.io:443',
 });
 
-const allCoins = await client.getAllCoins({
+const suiCoins = await client.listCoins({
 	owner: '0xcc2bd176a478baea9a0de7a24cd927661cc6e860d5bacecb9a138ef20dbab231',
 });
 ```

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -945,7 +945,7 @@ function parseObject<Include extends SuiClientTypes.ObjectInclude = {}>(
 				: undefined;
 
 	const displayData = include?.display
-		? object.display
+		? object.display && (object.display.data != null || object.display.error != null)
 			? {
 					output: (object.display.data as Record<string, unknown> | null) ?? null,
 					errors: object.display.error

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -945,15 +945,8 @@ function parseObject<Include extends SuiClientTypes.ObjectInclude = {}>(
 				: undefined;
 
 	const displayData = include?.display
-		? object.display && (object.display.data != null || object.display.error != null)
-			? {
-					output: (object.display.data as Record<string, unknown> | null) ?? null,
-					errors: object.display.error
-						? Object.fromEntries(
-								Object.entries(object.display.error).map(([key, value]) => [key, String(value)]),
-							)
-						: null,
-				}
+		? object.display?.data != null
+			? { output: object.display.data as Record<string, unknown>, errors: null }
 			: null
 		: undefined;
 

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -945,8 +945,15 @@ function parseObject<Include extends SuiClientTypes.ObjectInclude = {}>(
 				: undefined;
 
 	const displayData = include?.display
-		? object.display?.data != null
-			? { output: object.display.data as Record<string, unknown>, errors: null }
+		? object.display
+			? {
+					output: (object.display.data as Record<string, unknown> | null) ?? null,
+					errors: object.display.error
+						? Object.fromEntries(
+								Object.entries(object.display.error).map(([key, value]) => [key, String(value)]),
+							)
+						: null,
+				}
 			: null
 		: undefined;
 

--- a/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
+++ b/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
@@ -70,6 +70,15 @@ describe('Test Object Display Standard', () => {
 		expect([errorMessage1, errorMessage2, errorMessage3]).toContain(
 			(display.error as { error: string })?.error,
 		);
+
+		const { object } = await toolbox.jsonRpcClient.core.getObject({
+			objectId: boarId,
+			include: { display: true },
+		});
+		expect(object.display).toEqual({
+			output: display.data,
+			errors: display.error,
+		});
 	});
 
 	it('Test getting Display fields for object that has no display object', async () => {

--- a/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
+++ b/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
@@ -70,15 +70,6 @@ describe('Test Object Display Standard', () => {
 		expect([errorMessage1, errorMessage2, errorMessage3]).toContain(
 			(display.error as { error: string })?.error,
 		);
-
-		const { object } = await toolbox.jsonRpcClient.core.getObject({
-			objectId: boarId,
-			include: { display: true },
-		});
-		expect(object.display).toEqual({
-			output: display.data,
-			errors: display.error,
-		});
 	});
 
 	it('Test getting Display fields for object that has no display object', async () => {
@@ -91,11 +82,5 @@ describe('Test Object Display Standard', () => {
 			})
 		).data?.display;
 		expect(display?.data).toEqual(null);
-
-		const { object } = await toolbox.jsonRpcClient.core.getObject({
-			objectId: coinId,
-			include: { display: true },
-		});
-		expect(object.display).toBeNull();
 	});
 });

--- a/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
+++ b/packages/sui/test/e2e/clients/jsonRpc/object-display-standard.test.ts
@@ -91,5 +91,11 @@ describe('Test Object Display Standard', () => {
 			})
 		).data?.display;
 		expect(display?.data).toEqual(null);
+
+		const { object } = await toolbox.jsonRpcClient.core.getObject({
+			objectId: coinId,
+			include: { display: true },
+		});
+		expect(object.display).toBeNull();
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,9 +950,6 @@ importers:
       '@mysten/sui':
         specifier: workspace:^
         version: link:../sui
-      '@mysten/utils':
-        specifier: workspace:^
-        version: link:../utils
     devDependencies:
       '@mysten/codegen':
         specifier: workspace:^


### PR DESCRIPTION
## Description

- recommend `SuiGrpcClient` and its top-level methods as the default application client API, while SDKs accept `ClientWithCoreApi` and call `client.core`
- update Kiosk to accept any `ClientWithCoreApi`, including `SuiGrpcClient`, and route object/display and transfer-policy event queries through the shared Core API
- preserve existing GraphQL and JSON-RPC transfer-policy event windows while continuing scan-limited gRPC pages, and preserve Kiosk's published `TransferPolicy.owner` type
- preserve JSON-RPC Display rendering errors in the Core object adapter; document that gRPC object reads expose Display v2 metadata
- refresh the JSON-RPC migration guide for direct `getTransaction`, `waitForTransaction`, `listTransactions`, and `listEvents` usage on gRPC and GraphQL, including cursor, ordering, filter, and subscription differences
- correct reviewed client, Core, executor, dApp Kit, Kiosk, zkSend, Walrus, and SDK-maintainer migration examples
- remove Kiosk's unused `@mysten/utils` dependency and add changesets for `@mysten/kiosk` and `@mysten/sui`

## Test plan

- `./node_modules/.bin/tsc --noEmit -p packages/sui/tsconfig.json`
- `./node_modules/.bin/tsc --noEmit -p packages/kiosk/tsconfig.json`
- `./node_modules/.bin/vitest run --typecheck --config vitest.unit.config.mts` from `packages/kiosk` (5 tests)
- `./node_modules/.bin/vitest run --config vitest.config.mts test/e2e/e2e.test.ts` from `packages/kiosk` (12 tests)
- `./node_modules/.bin/vitest run --config test/e2e/vitest.config.mts test/e2e/clients/jsonRpc/object-display-standard.test.ts` from `packages/sui` (2 tests)
- `./node_modules/.bin/oxlint <changed TypeScript files>`
- `../../node_modules/.bin/tsdown` from `packages/sui` and `packages/kiosk`
- `node scripts/validate-llm-docs.ts` from `packages/docs`
- `node scripts/build-docs.ts --all` from `packages/docs`
- Prettier and `git diff --check`
- `changeset status --since origin/main`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.