### PR TITLE
fix(deepbook-predict): declare @mysten/sui as peer-only

### DIFF
--- a/packages/deepbook-predict/package.json
+++ b/packages/deepbook-predict/package.json
@@ -44,7 +44,6 @@
 	},
 	"devDependencies": {
 		"@mysten/codegen": "workspace:^",
-		"@mysten/sui": "workspace:^",
 		"@types/node": "^25.9.3",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,13 +580,14 @@ importers:
         version: 4.1.8(@types/node@25.9.3)(happy-dom@20.10.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/deepbook-predict:
+    dependencies:
+      '@mysten/sui':
+        specifier: workspace:^
+        version: link:../sui
     devDependencies:
       '@mysten/codegen':
         specifier: workspace:^
         version: link:../codegen
-      '@mysten/sui':
-        specifier: workspace:^
-        version: link:../sui
       '@types/node':
         specifier: ^25.9.3
         version: 25.9.3


### PR DESCRIPTION
## Description

`@mysten/deepbook-predict@0.0.1` failed to publish — the release build (`tsc --noEmit`) errored with `Cannot find module '@mysten/sui/transactions'` (and cascading `MoveStruct`/`unknown` errors) across the package.

**Root cause is a dependency misconfiguration**, not the code: `@mysten/sui` was declared in **both** `peerDependencies` and `devDependencies`. The release workflow (`_release-package.yml`) installs with `pnpm install --filter "@mysten/deepbook-predict..." --prod`, which excludes `devDependencies`. With `@mysten/sui` sitting in `devDependencies`, pnpm did not auto-install it as a peer either, so the package ended up with **no `node_modules`** (`WARN Local package.json exists, but node_modules missing`) and the build could not resolve `@mysten/sui/*`.

**Fix:** declare `@mysten/sui` as a peer dependency only — drop the redundant `devDependencies` entry — matching `@mysten/pas` and the other SDKs. Scoped to `deepbook-predict`; no other packages or the shared release template are touched.

Once merged, `release.yml` re-dispatches the release for `0.0.1` (not yet on npm) and the build now succeeds. Note: the `0.0.0` currently on npm was a manual `npm publish` that never rewrote `workspace:` refs (its `peerDependencies` reads `"@mysten/sui": "workspace:^"`), so it is uninstallable and should be deprecated separately.

## Test plan

Reproduced and verified locally against `origin/main`:

- **Repro:** `CI=true pnpm install --filter "@mysten/deepbook-predict..." --prod` removes `packages/deepbook-predict/node_modules` and `@mysten/sui` is absent — matching the failed CI build. `@mysten/pas` (peer-only, same otherwise) keeps its `node_modules` + `@mysten/sui` under the identical command.
- **Fix:** after moving `@mysten/sui` to peer-only, the same `--prod` install keeps `@mysten/sui` linked.
- **Build:** `pnpm turbo build --filter @mysten/deepbook-predict` builds clean. The build-graph edge to `@mysten/sui` is intact even with the peer-only declaration — verified by deleting `packages/sui/dist` and confirming turbo rebuilds it before predict.
- No source changes; offline unit suite and live-testnet smoke are unaffected.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
