### PR TITLE
feat(seal): add a fetch option for key server requests

### DIFF
--- a/.changeset/seal-custom-fetch.md
+++ b/.changeset/seal-custom-fetch.md
@@ -2,4 +2,4 @@
 '@mysten/seal': minor
 ---
 
-Add an optional `fetch` option to `SealClient`, used for all key server requests. This lets callers customize how requests are sent — e.g. send cookies with `credentials: 'include'` or attach your own headers — mirroring the `fetch` option of `SuiHTTPTransport`.
+Add an optional `fetch` option to `SealClient`, used for all key server requests. This lets callers customize how requests are sent — for example send cookies with `credentials: 'include'` or attach your own headers — mirroring the `fetch` option of `SuiHTTPTransport`.

--- a/.changeset/seal-custom-fetch.md
+++ b/.changeset/seal-custom-fetch.md
@@ -2,4 +2,4 @@
 '@mysten/seal': minor
 ---
 
-Add an optional `fetch` option to `SealClient`, used for all key server requests. This lets callers customize how requests are sent — e.g. send cookies with `credentials: 'include'` or attach per-request headers — mirroring the `fetch` option of `SuiHTTPTransport`.
+Add an optional `fetch` option to `SealClient`, used for all key server requests. This lets callers customize how requests are sent — e.g. send cookies with `credentials: 'include'` or attach your own headers — mirroring the `fetch` option of `SuiHTTPTransport`.

--- a/.changeset/seal-custom-fetch.md
+++ b/.changeset/seal-custom-fetch.md
@@ -1,0 +1,5 @@
+---
+'@mysten/seal': minor
+---
+
+Add an optional `fetch` option to `SealClient`, used for all key server requests. This lets callers customize how requests are sent — e.g. send cookies with `credentials: 'include'` or attach per-request headers — mirroring the `fetch` option of `SuiHTTPTransport`.

--- a/packages/docs/content/seal/index.mdx
+++ b/packages/docs/content/seal/index.mdx
@@ -63,7 +63,8 @@ The `seal()` function accepts the following options:
 - **`verifyKeyServers`** (optional) - Whether to verify key server authenticity (default: `true`)
 - **`timeout`** (optional) - Timeout in milliseconds for network requests (default: `10000`)
 - **`fetch`** (optional) - Custom fetch implementation used for all key server requests (default:
-  the global `fetch`), e.g. to send cookies with `credentials: 'include'` or attach your own headers
+  the global `fetch`), for example to send cookies with `credentials: 'include'` or attach your own
+  headers
 
 ## Choosing key servers
 

--- a/packages/docs/content/seal/index.mdx
+++ b/packages/docs/content/seal/index.mdx
@@ -62,6 +62,9 @@ The `seal()` function accepts the following options:
     authentication
 - **`verifyKeyServers`** (optional) - Whether to verify key server authenticity (default: `true`)
 - **`timeout`** (optional) - Timeout in milliseconds for network requests (default: `10000`)
+- **`fetch`** (optional) - Custom fetch implementation used for all key server requests, e.g. to
+  send cookies (`credentials: 'include'`) or attach per-request headers (default: the global
+  `fetch`)
 
 ## Choosing key servers
 

--- a/packages/docs/content/seal/index.mdx
+++ b/packages/docs/content/seal/index.mdx
@@ -62,9 +62,8 @@ The `seal()` function accepts the following options:
     authentication
 - **`verifyKeyServers`** (optional) - Whether to verify key server authenticity (default: `true`)
 - **`timeout`** (optional) - Timeout in milliseconds for network requests (default: `10000`)
-- **`fetch`** (optional) - Custom fetch implementation used for all key server requests, e.g. to
-  send cookies (`credentials: 'include'`) or attach per-request headers (default: the global
-  `fetch`)
+- **`fetch`** (optional) - Custom fetch implementation used for all key server requests (default:
+  the global `fetch`), e.g. to send cookies with `credentials: 'include'` or attach your own headers
 
 ## Choosing key servers
 

--- a/packages/seal/src/client.ts
+++ b/packages/seal/src/client.ts
@@ -59,6 +59,7 @@ export class SealClient {
 	#cachedPublicKeys = new Map<string, G2Element>();
 	#timeout: number;
 	#totalWeight: number;
+	#fetch?: typeof fetch;
 
 	constructor(options: SealClientOptions) {
 		this.#suiClient = options.suiClient;
@@ -84,6 +85,7 @@ export class SealClient {
 
 		this.#verifyKeyServers = options.verifyKeyServers ?? false;
 		this.#timeout = options.timeout ?? 10_000;
+		this.#fetch = options.fetch;
 	}
 
 	/**
@@ -299,7 +301,15 @@ export class SealClient {
 						return;
 					}
 					const config = this.#configs.get(server.objectId);
-					if (!(await verifyKeyServer(server, this.#timeout, config?.apiKeyName, config?.apiKey))) {
+					if (
+						!(await verifyKeyServer(
+							server,
+							this.#timeout,
+							config?.apiKeyName,
+							config?.apiKey,
+							this.#fetch,
+						))
+					) {
 						throw new InvalidKeyServerError(`Key server ${server.objectId} is not valid`);
 					}
 				}),
@@ -370,6 +380,7 @@ export class SealClient {
 					apiKeyName: config?.apiKeyName,
 					apiKey: config?.apiKey,
 					signal: controller.signal,
+					fetch: this.#fetch,
 				});
 				// Check validity of the keys and add them to the cache.
 				for (const { fullId, key } of allKeys) {

--- a/packages/seal/src/key-server.ts
+++ b/packages/seal/src/key-server.ts
@@ -179,9 +179,10 @@ export async function verifyKeyServer(
 	timeout: number,
 	apiKeyName?: string,
 	apiKey?: string,
+	fetchFn: typeof fetch = globalThis.fetch,
 ): Promise<boolean> {
 	const requestId = crypto.randomUUID();
-	const response = await fetch(server.url! + '/v1/service?service_id=' + server.objectId, {
+	const response = await fetchFn(server.url! + '/v1/service?service_id=' + server.objectId, {
 		method: 'GET',
 		headers: {
 			'Content-Type': 'application/json',
@@ -271,6 +272,8 @@ export interface FetchKeysOptions {
 	apiKey?: string;
 	/** Optional abort signal for cancellation. */
 	signal?: AbortSignal;
+	/** Optional custom fetch implementation. Defaults to the global `fetch`. */
+	fetch?: typeof fetch;
 }
 
 /**
@@ -297,6 +300,7 @@ export async function fetchKeysForAllIds({
 	apiKeyName,
 	apiKey,
 	signal,
+	fetch: fetchFn = globalThis.fetch,
 }: FetchKeysOptions): Promise<{ fullId: string; key: Uint8Array<ArrayBuffer> }[]> {
 	const body = {
 		ptb: toBase64(transactionBytes.slice(1)), // removes the byte of the transaction type version
@@ -310,7 +314,7 @@ export async function fetchKeysForAllIds({
 	const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
 	const requestId = crypto.randomUUID();
-	const response = await fetch(url + '/v1/fetch_key', {
+	const response = await fetchFn(url + '/v1/fetch_key', {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',

--- a/packages/seal/src/types.ts
+++ b/packages/seal/src/types.ts
@@ -23,7 +23,7 @@ export interface SealOptions<Name = 'seal'> {
 	timeout?: number;
 	/**
 	 * Custom fetch implementation used for all key server requests, e.g. to send
-	 * cookies (`credentials: 'include'`) or attach per-request headers.
+	 * cookies (`credentials: 'include'`) or attach your own headers.
 	 * Defaults to the global `fetch`.
 	 */
 	fetch?: typeof fetch;
@@ -56,7 +56,7 @@ export interface SealClientOptions {
 	timeout?: number;
 	/**
 	 * Custom fetch implementation used for all key server requests, e.g. to send
-	 * cookies (`credentials: 'include'`) or attach per-request headers.
+	 * cookies (`credentials: 'include'`) or attach your own headers.
 	 * Defaults to the global `fetch`.
 	 */
 	fetch?: typeof fetch;

--- a/packages/seal/src/types.ts
+++ b/packages/seal/src/types.ts
@@ -22,7 +22,7 @@ export interface SealOptions<Name = 'seal'> {
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;
 	/**
-	 * Custom fetch implementation used for all key server requests, e.g. to send
+	 * Custom fetch implementation used for all key server requests, for example to send
 	 * cookies (`credentials: 'include'`) or attach your own headers.
 	 * Defaults to the global `fetch`.
 	 */
@@ -55,7 +55,7 @@ export interface SealClientOptions {
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;
 	/**
-	 * Custom fetch implementation used for all key server requests, e.g. to send
+	 * Custom fetch implementation used for all key server requests, for example to send
 	 * cookies (`credentials: 'include'`) or attach your own headers.
 	 * Defaults to the global `fetch`.
 	 */

--- a/packages/seal/src/types.ts
+++ b/packages/seal/src/types.ts
@@ -21,6 +21,12 @@ export interface SealOptions<Name = 'seal'> {
 	verifyKeyServers?: boolean;
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;
+	/**
+	 * Custom fetch implementation used for all key server requests, e.g. to send
+	 * cookies (`credentials: 'include'`) or attach per-request headers.
+	 * Defaults to the global `fetch`.
+	 */
+	fetch?: typeof fetch;
 	// Name of the seal extension, defaults to 'seal'
 	name?: Name;
 }
@@ -48,6 +54,12 @@ export interface SealClientOptions {
 	verifyKeyServers?: boolean;
 	/** Timeout in milliseconds for network requests. */
 	timeout?: number;
+	/**
+	 * Custom fetch implementation used for all key server requests, e.g. to send
+	 * cookies (`credentials: 'include'`) or attach per-request headers.
+	 * Defaults to the global `fetch`.
+	 */
+	fetch?: typeof fetch;
 }
 
 export interface EncryptOptions {

--- a/packages/seal/test/unit/key-server.test.ts
+++ b/packages/seal/test/unit/key-server.test.ts
@@ -299,7 +299,7 @@ describe('key-server tests', () => {
 			return Promise.resolve({
 				ok: false,
 				status: 503,
-				text: () => Promise.resolve('Internal server error, please try again later'),
+				text: () => Promise.resolve('Mock 503 response from customFetch'),
 			});
 		});
 		const client = new SealClient({
@@ -325,7 +325,7 @@ describe('key-server tests', () => {
 			return Promise.resolve({
 				ok: false,
 				status: 503,
-				text: () => Promise.resolve('Internal server error, please try again later'),
+				text: () => Promise.resolve('Mock 503 response from customFetch'),
 			});
 		});
 		const client = new SealClient({

--- a/packages/seal/test/unit/key-server.test.ts
+++ b/packages/seal/test/unit/key-server.test.ts
@@ -7,6 +7,7 @@ import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { bcs } from '@mysten/sui/bcs';
 
+import { SealClient } from '../../src/client.js';
 import { GeneralError, InvalidClientOptionsError } from '../../src/error.js';
 import {
 	retrieveKeyServers,
@@ -14,6 +15,8 @@ import {
 	ServerType,
 	verifyKeyServer,
 } from '../../src/key-server.js';
+import type { SessionKey } from '../../src/session-key.js';
+import type { SealCompatibleClient } from '../../src/types.js';
 import { Version } from '../../src/utils.js';
 
 // Data for mock response from SuiGrpcClient
@@ -111,6 +114,7 @@ function createMockV2Client(
 describe('key-server tests', () => {
 	afterEach(() => {
 		vi.clearAllMocks();
+		vi.unstubAllGlobals();
 	});
 
 	it('test retrieveKeyServers with invalid version', async () => {
@@ -286,5 +290,91 @@ describe('key-server tests', () => {
 				},
 			}),
 		);
+	});
+
+	it('test SealClient passes the custom fetch to verifyKeyServer', async () => {
+		const globalFetch = vi.fn();
+		vi.stubGlobal('fetch', globalFetch);
+		const customFetch = vi.fn().mockImplementation(() => {
+			return Promise.resolve({
+				ok: false,
+				status: 503,
+				text: () => Promise.resolve('Internal server error, please try again later'),
+			});
+		});
+		const client = new SealClient({
+			suiClient: createMockV2Client(
+				id,
+				2,
+				2,
+				'Independent',
+				url,
+			) as unknown as SealCompatibleClient,
+			serverConfigs: [{ objectId: id, weight: 1 }],
+			verifyKeyServers: true,
+			fetch: customFetch,
+		});
+
+		await expect(client.getKeyServers()).rejects.toThrow(GeneralError);
+		expect(customFetch).toHaveBeenCalledOnce();
+		expect(customFetch).toHaveBeenCalledWith(
+			url + '/v1/service?service_id=' + id,
+			expect.anything(),
+		);
+		expect(globalFetch).not.toHaveBeenCalled();
+	});
+
+	it('test SealClient passes the custom fetch to fetchKeysForAllIds', async () => {
+		const globalFetch = vi.fn();
+		vi.stubGlobal('fetch', globalFetch);
+		const customFetch = vi.fn().mockImplementation(() => {
+			return Promise.resolve({
+				ok: false,
+				status: 503,
+				text: () => Promise.resolve('Internal server error, please try again later'),
+			});
+		});
+		const client = new SealClient({
+			suiClient: createMockV2Client(
+				id,
+				2,
+				2,
+				'Independent',
+				url,
+			) as unknown as SealCompatibleClient,
+			serverConfigs: [{ objectId: id, weight: 1 }],
+			verifyKeyServers: false,
+			fetch: customFetch,
+		});
+		const sessionKey = {
+			getPackageId: () => '0x0000000000000000000000000000000000000000000000000000000000000001',
+			getCertificate: () =>
+				Promise.resolve({
+					user: '0x1',
+					session_vk: 'vk',
+					creation_time: 0,
+					ttl_min: 10,
+					signature: 'sig',
+				}),
+			createRequestParams: () =>
+				Promise.resolve({
+					requestSignature: 'sig',
+					encKey: new Uint8Array(32),
+					encKeyPk: new Uint8Array(32),
+					encVerificationKey: new Uint8Array(32),
+				}),
+		} as unknown as SessionKey;
+
+		await expect(
+			client.fetchKeys({
+				ids: ['0x01'],
+				txBytes: new Uint8Array([0, 1, 2]),
+				sessionKey,
+				threshold: 1,
+			}),
+		).rejects.toThrow(GeneralError);
+		expect(customFetch).toHaveBeenCalledOnce();
+		expect(customFetch).toHaveBeenCalledWith(url + '/v1/fetch_key', expect.anything());
+		expect(globalFetch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/seal/test/unit/key-server.test.ts
+++ b/packages/seal/test/unit/key-server.test.ts
@@ -108,7 +108,7 @@ function createMockV2Client(
 			getObject: mockGetObject,
 			getDynamicField: mockGetDynamicField,
 		},
-	} as unknown as SuiGrpcClient;
+	} as unknown as SealCompatibleClient;
 }
 
 describe('key-server tests', () => {
@@ -303,13 +303,7 @@ describe('key-server tests', () => {
 			});
 		});
 		const client = new SealClient({
-			suiClient: createMockV2Client(
-				id,
-				2,
-				2,
-				'Independent',
-				url,
-			) as unknown as SealCompatibleClient,
+			suiClient: createMockV2Client(id, 2, 2, 'Independent', url),
 			serverConfigs: [{ objectId: id, weight: 1 }],
 			verifyKeyServers: true,
 			fetch: customFetch,
@@ -335,13 +329,7 @@ describe('key-server tests', () => {
 			});
 		});
 		const client = new SealClient({
-			suiClient: createMockV2Client(
-				id,
-				2,
-				2,
-				'Independent',
-				url,
-			) as unknown as SealCompatibleClient,
+			suiClient: createMockV2Client(id, 2, 2, 'Independent', url),
 			serverConfigs: [{ objectId: id, weight: 1 }],
 			verifyKeyServers: false,
 			fetch: customFetch,


### PR DESCRIPTION
## Description

Adds an optional `fetch` to `SealClientOptions`, used for all key server requests (`/v1/fetch_key` and `/v1/service` verification). Mirrors the `fetch` option of `SuiHTTPTransport`. Defaults to the global `fetch`; no behavior change otherwise.

**Use case:** the seal-mpc aggregator authenticates apps with an API key, which is a secret — it can't be shipped to the browser — so apps route `fetch_key` through their own backend, which attaches the key server-side (MystenLabs/console#428). `SealClient` still has to run in the browser: it's what guarantees that only the user can decrypt their data. If the backend ran it instead, the backend would see the decryption keys and could read user data.

That leaves authenticating the browser→backend leg, which is typically the app's session cookie. On a same-origin backend that just works — but when the API lives on a different origin than the app (the usual setup), cookies are only sent if the request opts in with `credentials: 'include'`, and the SDK's `fetch` doesn't and can't. The cookie also can't be copied into the `apiKeyName`/`apiKey` header slot because it's HttpOnly. `apiKey` is also fixed at construction, so rotating credentials force rebuilding the whole client. MystenLabs/console#379 shows the workaround this forces today: a dedicated short-lived token endpoint, a custom header, and client rebuilds on every rotation.

With this option, such apps pass `fetch: (url, init) => fetch(url, { ...init, credentials: 'include' })` and their existing session just rides along. This is likely a common shape for any cookie-authenticated app fronting a keyed seal-mpc aggregator.

## Test plan

Client-level unit tests: `SealClient` built with a custom fetch must route both `verifyKeyServer` (`/v1/service`) and `fetchKeysForAllIds` (`/v1/fetch_key`) through it, never through the (stubbed) global fetch. `pnpm --filter @mysten/seal vitest run test/unit/key-server.test.ts` — 10/10 passing.

Also red/green-tested this in Walrus Console (MystenLabs/console#459) by patching globalThis.fetch around each decrypt equivalent to this option, since the SDK reads the global at request time.

- Green: patched fetch adds credentials: 'include' → session cookie reaches our fetch_key proxy → decrypt works.
- Red: patch removed → default same-origin credentials drop the cookie cross-origin → 401.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
