### PR TITLE
feat(deepbook-predict): range markets, market pinning, and single-PTB account funding

### DIFF
--- a/.changeset/tall-doors-predict.md
+++ b/.changeset/tall-doors-predict.md
@@ -1,0 +1,13 @@
+---
+'@mysten/deepbook-predict': minor
+---
+
+Add facade capabilities and minimal composition exports. `MarketDescriptor` becomes a
+discriminated union that also accepts two-strike range positions (`side: 'range'` with
+`lower`/`upper` bounds) and an optional `marketId` pin that mints against an exact
+`ExpiryMarket` object instead of resolving by underlying+expiry.
+`tx.deposit` gains a `create: true`
+option that composes first-time funding into one PTB (create the account wrapper,
+deposit through the fresh handle, share last). The root entry now exports `generateAuth`,
+`deriveAccountWrapperId`, `ACCUMULATOR_ROOT_ID`, and `POSITION_LOT_SIZE` for PTBs that
+compose predict accounts with foreign packages.

--- a/packages/deepbook-predict/src/client.ts
+++ b/packages/deepbook-predict/src/client.ts
@@ -1,5 +1,6 @@
 import type { ClientWithCoreApi, SuiClientRegistration } from '@mysten/sui/client';
 import { Transaction, coinWithBalance } from '@mysten/sui/transactions';
+import { isValidSuiObjectId } from '@mysten/sui/utils';
 import { getConfig, type PredictConfig } from './config/index.js';
 import {
 	decodeAccountsCreated,
@@ -37,7 +38,12 @@ import { poolStats } from './reads/pool.js';
 import { readPricerSnapshot, type PricerSnapshot } from './reads/pricing.js';
 import { boardPricer, type BoardPricer } from './pricing.js';
 import { POS_INF_TICK, binaryRangeTicks, type Side } from './ticks.js';
-import { createAccount, depositFunds, withdrawFunds } from './tx/account.js';
+import {
+	createAccount,
+	createAccountAndDeposit,
+	depositFunds,
+	withdrawFunds,
+} from './tx/account.js';
 import { setBuilderCode, unsetBuilderCode } from './tx/builderCode.js';
 import { deriveAccountWrapperId } from './tx/common.js';
 import {
@@ -60,20 +66,39 @@ import {
 
 // `position_lot_size` — a position quantity must be a whole multiple of this many
 // raw payout units ($0.01 lots). See packages/predict/sources/constants.move.
-const POSITION_LOT_SIZE = 10_000n;
+export const POSITION_LOT_SIZE = 10_000n;
 
-/** A live/settled binary market addressed by its human coordinates. */
-export interface MarketDescriptor {
+/** A live/settled market addressed by its human coordinates: a binary position
+ * (single strike + side) or a two-strike range position. */
+export type MarketDescriptor = {
 	underlying: string;
 	expiryMs: number | bigint;
 	/**
-	 * Strike in USD, or "reference" to trade at the market's on-chain reference
-	 * price (the Polymarket-style anchor: derived from the exact previous-window
-	 * oracle observation, so consecutive windows chain settlement → next strike).
+	 * Pin resolution to this exact `ExpiryMarket` object, skipping the
+	 * underlying+expiry lookup — a caller that reviewed a specific market object
+	 * mints against exactly that object, not whatever resolves at submit time.
 	 */
-	strike: number | 'reference';
-	side: Side;
-}
+	marketId?: string;
+} & (
+	| {
+			side: Side;
+			/**
+			 * Strike in USD, or "reference" to trade at the market's on-chain reference
+			 * price (the Polymarket-style anchor: derived from the exact previous-window
+			 * oracle observation, so consecutive windows chain settlement → next strike).
+			 */
+			strike: number | 'reference';
+	  }
+	| {
+			/** A range position: pays out when settlement lands inside `(lower, upper]`
+			 * (left-open, right-closed — same convention as the on-chain range key). */
+			side: 'range';
+			/** Lower strike bound in USD — finite, on the tick grid. */
+			lower: number;
+			/** Upper strike bound in USD — finite, on the tick grid, above `lower`. */
+			upper: number;
+	  }
+);
 
 /** Options for the friendly `mint` (exact payout quantity). */
 export interface MintOptions {
@@ -171,6 +196,12 @@ interface ResolvedMarket {
 	state: MarketState;
 }
 
+// The strike-bearing (binary) arm of MarketDescriptor, for read.price and its
+// seam — anonymous board pricing has no range semantics.
+type BinaryMarketCoordinates = Pick<MarketDescriptor, 'underlying' | 'expiryMs' | 'marketId'> & {
+	strike: number | 'reference';
+};
+
 /** The Sui client surface PredictClient reads through: any `ClientWithCoreApi`
  * (gRPC or JSON-RPC) provides both the `simulateTransaction` the reads/quotes
  * sit on and the `core` object methods position enumeration needs. */
@@ -240,10 +271,31 @@ export class PredictClient {
 		};
 	}
 
-	// Resolve (and cache) a market's id + state from its human coordinates.
+	// Resolve (and cache) a market's id + state from its human coordinates. An
+	// explicit `marketId` pin skips the underlying+expiry lookup but still reads
+	// that market's state — tx building depends on tickSizeRaw.
 	async #resolveMarket(
-		m: Pick<MarketDescriptor, 'underlying' | 'expiryMs'>,
+		m: Pick<MarketDescriptor, 'underlying' | 'expiryMs' | 'marketId'>,
 	): Promise<ResolvedMarket> {
+		if (m.marketId != null) {
+			if (!isValidSuiObjectId(m.marketId)) {
+				throw new PredictInputError(`invalid marketId: ${JSON.stringify(m.marketId)}`);
+			}
+			const resolved: ResolvedMarket = this.#marketCache.get(m.marketId) ?? {
+				id: m.marketId,
+				state: await marketState(this.#client, this.cfg, m.marketId),
+			};
+			// The pin must agree with the descriptor's coordinates: catching a stale or
+			// wrong-market id here beats minting against mismatched oracle feeds. (The
+			// underlying cannot be cross-checked — market state does not carry it.)
+			if (resolved.state.expiryMs !== BigInt(m.expiryMs)) {
+				throw new PredictInputError(
+					`pinned market ${m.marketId} expires at ${resolved.state.expiryMs}, descriptor says ${BigInt(m.expiryMs)}`,
+				);
+			}
+			this.#marketCache.set(m.marketId, resolved);
+			return resolved;
+		}
 		const expiryMs = BigInt(m.expiryMs);
 		const key = `${m.underlying}:${expiryMs}`;
 		const hit = this.#marketCache.get(key);
@@ -263,15 +315,44 @@ export class PredictClient {
 			: fromRaw(state.referenceTickRaw * state.tickSizeRaw, 9);
 	}
 
-	// Resolve a descriptor's strike to the (lower, higher) tick pair. A numeric
-	// strike converts and validates against the tick grid; "reference" reads the
-	// market's reference tick FRESH (never cached — it is unset early in a
-	// window) and uses it directly: it is on the tick grid by construction.
+	// A finite tick from a USD strike, validated exactly like binaryRangeTicks:
+	// whole-tick multiple, inside the finite domain (1..POS_INF_TICK-1).
+	#gridTick(strike: number, tickSizeRaw: bigint): bigint {
+		const raw = priceToRaw(strike);
+		const tick = raw / tickSizeRaw;
+		if (tick * tickSizeRaw !== raw) {
+			throw new PredictInputError(
+				`strike ${strike} is not on the ${fromRaw(tickSizeRaw, 9)} tick grid`,
+			);
+		}
+		if (tick <= 0n || tick >= POS_INF_TICK) {
+			throw new PredictInputError(
+				`strike tick ${tick} outside the finite tick domain (1..POS_INF_TICK-1)`,
+			);
+		}
+		return tick;
+	}
+
+	// Resolve a descriptor's strike(s) to the (lower, higher) tick pair. A binary
+	// numeric strike converts and validates against the tick grid; "reference"
+	// reads the market's reference tick FRESH (never cached — it is unset early in
+	// a window) and uses it directly: it is on the tick grid by construction. A
+	// range descriptor converts both bounds to finite grid ticks ("reference" is
+	// binary-only: a range has no single reference strike).
 	async #strikeTicks(
 		m: MarketDescriptor,
 		marketId: string,
 		state: MarketState,
 	): Promise<{ lowerTick: bigint; higherTick: bigint }> {
+		if (m.side === 'range') {
+			if (!(m.lower < m.upper)) {
+				throw new PredictInputError(`range lower ${m.lower} must be below upper ${m.upper}`);
+			}
+			return {
+				lowerTick: this.#gridTick(m.lower, state.tickSizeRaw),
+				higherTick: this.#gridTick(m.upper, state.tickSizeRaw),
+			};
+		}
 		if (m.strike !== 'reference') {
 			return binaryRangeTicks(priceToRaw(m.strike), m.side, state.tickSizeRaw);
 		}
@@ -344,18 +425,14 @@ export class PredictClient {
 	// Raw strike for anonymous pricing: numeric strikes validate against the tick
 	// grid; "reference" reads the market's reference tick fresh (unset → typed error).
 	async #strikeRawFor(
-		m: Pick<MarketDescriptor, 'underlying' | 'expiryMs' | 'strike'>,
+		m: BinaryMarketCoordinates,
 		marketId: string,
 		state: MarketState,
 	): Promise<bigint> {
 		if (m.strike !== 'reference') {
-			const raw = priceToRaw(m.strike);
-			if (raw % state.tickSizeRaw !== 0n) {
-				throw new PredictInputError(
-					`strike ${m.strike} is not on the ${fromRaw(state.tickSizeRaw, 9)} tick grid`,
-				);
-			}
-			return raw;
+			// Same validation as the mint path: on the grid AND inside the finite tick
+			// domain (0 / POS_INF are the ±inf sentinels, not quotable strikes).
+			return this.#gridTick(m.strike, state.tickSizeRaw) * state.tickSizeRaw;
 		}
 		const tick = await referenceTick(this.#client, this.cfg, marketId);
 		if (tick == null) {
@@ -375,7 +452,20 @@ export class PredictClient {
 			return tx;
 		},
 
-		deposit: (owner: string, amountUsdc: number | string): Transaction => {
+		// `create: true` composes first-time funding into ONE PTB: create the account
+		// wrapper, deposit into it through the fresh handle, and `share` it LAST (once
+		// shared, by-value use of the handle is over). The wrapper is derived from the
+		// transaction SENDER (`account_registry::new` takes no owner), so `owner` MUST
+		// be the address that signs this transaction — a sponsored/backend signer would
+		// silently fund its own fresh account instead. The caller also asserts the
+		// account does not exist yet: `new` ABORTS at the deterministic address if it
+		// already exists — no chain read is done here. Gate on your own existence check
+		// (`wrapperIdFor(owner)` + a getObject), or retry without the flag on that abort.
+		deposit: (
+			owner: string,
+			amountUsdc: number | string,
+			opts?: { create?: boolean },
+		): Transaction => {
 			const tx = new Transaction();
 			const coin = tx.add(
 				coinWithBalance({
@@ -384,7 +474,11 @@ export class PredictClient {
 					useGasCoin: false,
 				}),
 			);
-			tx.add(depositFunds(this.cfg, { wrapperId: this.wrapperIdFor(owner), coin }));
+			if (opts?.create) {
+				tx.add(createAccountAndDeposit(this.cfg, { coin }));
+			} else {
+				tx.add(depositFunds(this.cfg, { wrapperId: this.wrapperIdFor(owner), coin }));
+			}
 			return tx;
 		},
 
@@ -460,7 +554,7 @@ export class PredictClient {
 
 		claimSettled: async (
 			owner: string,
-			m: Pick<MarketDescriptor, 'underlying' | 'expiryMs'>,
+			m: Pick<MarketDescriptor, 'underlying' | 'expiryMs' | 'marketId'>,
 			opts: CloseOptions,
 		): Promise<Transaction> => {
 			const { id } = await this.#resolveMarket(m);
@@ -564,9 +658,7 @@ export class PredictClient {
 		// Anonymous board pricing: the chain's probability for both sides of a
 		// strike, from one fresh pricer (no account needed). This is the ↑/↓
 		// button price before a user has onboarded.
-		price: async (
-			m: Pick<MarketDescriptor, 'underlying' | 'expiryMs' | 'strike'>,
-		): Promise<{ up: number; down: number }> => {
+		price: async (m: BinaryMarketCoordinates): Promise<{ up: number; down: number }> => {
 			const feeds = this.#feeds(m.underlying);
 			const { id, state } = await this.#resolveMarket(m);
 			const strikeRaw = await this.#strikeRawFor(m, id, state);

--- a/packages/deepbook-predict/src/index.ts
+++ b/packages/deepbook-predict/src/index.ts
@@ -1,11 +1,10 @@
 // Public API for `@mysten/deepbook-predict`. The curated surface is the `PredictClient`
 // facade plus the value types, unit conversions, tick helpers, typed errors, and typed
-// execution-result decoders. Low-level move-call builders and raw reads are internal to
-// the facade; power users who need to compose PTBs directly can use the generated
-// bindings under `contracts/` or the facade's exported primitives on request.
+// execution-result decoders — and the few primitives below that compose predict
+// accounts into PTBs on FOREIGN packages, which no facade shape can cover.
 
 // === Facade === (register as a client extension: `client.$extend(predict({ network }))`)
-export { PredictClient, predict } from './client.js';
+export { POSITION_LOT_SIZE, PredictClient, predict } from './client.js';
 export type { PredictCompatibleClient } from './client.js';
 export type {
 	ActiveMarket,
@@ -19,8 +18,15 @@ export type {
 	RedeemQuote,
 } from './client.js';
 
+// === Composition with foreign packages === auth + deterministic account addressing
+// for PTBs that compose predict accounts with packages this SDK doesn't know (e.g.
+// `deepbook_core_account` spot trading). `deriveAccountWrapperId` is the pure
+// `(cfg, owner)` form of `wrapperIdFor` for contexts with no client instance;
+// ACCUMULATOR_ROOT_ID is the shared accumulator root those same calls take.
+export { deriveAccountWrapperId, generateAuth } from './tx/common.js';
+
 // === Config ===
-export { TESTNET_CONFIG, getConfig } from './config/index.js';
+export { ACCUMULATOR_ROOT_ID, TESTNET_CONFIG, getConfig } from './config/index.js';
 export type { PredictConfig, PredictPackages, UnderlyingConfig } from './config/index.js';
 
 // === Units (raw ⇄ human conversions) === domain-specific only; the generic `toRaw`/

--- a/packages/deepbook-predict/src/tx/account.ts
+++ b/packages/deepbook-predict/src/tx/account.ts
@@ -29,6 +29,41 @@ export function createAccount(cfg: PredictConfig): (tx: Transaction) => void {
 	};
 }
 
+// First-time funding in ONE PTB: create the sender's canonical wrapper, deposit the
+// caller-provided `coin` into it through the fresh handle, and `share` it LAST (once
+// shared, by-value use of the handle is over). This cannot be split across
+// `createAccount` + `depositFunds`: an object input can only address an object that
+// pre-exists the PTB, so a wrapper created inside it is reachable only through `new`'s
+// result handle. `new` derives the wrapper at its deterministic address and aborts if
+// it already exists.
+export function createAccountAndDeposit(
+	cfg: PredictConfig,
+	args: { coin: TransactionObjectArgument; coinType?: string },
+): (tx: Transaction) => void {
+	return (tx) => {
+		const wrapper = tx.add(
+			accountRegistry._new({
+				package: cfg.packages.account,
+				arguments: { registry: cfg.objects.accountRegistry },
+			}),
+		);
+		const auth = tx.add(generateAuth(cfg));
+		tx.add(
+			account.depositFunds({
+				package: cfg.packages.account,
+				arguments: { wrapper, auth, coin: args.coin, root: ACCUMULATOR_ROOT_ID },
+				typeArguments: [args.coinType ?? cfg.quoteCoinType],
+			}),
+		);
+		tx.add(
+			account.share({
+				package: cfg.packages.account,
+				arguments: { self: wrapper },
+			}),
+		);
+	};
+}
+
 // Deposit a caller-provided `coin` into the account's stored balance via the
 // PTB-callable `deposit_funds` (folds settle → authorize → load → deposit; clock
 // auto-injected). The caller owns coin sourcing. See

--- a/packages/deepbook-predict/tests/client.test.ts
+++ b/packages/deepbook-predict/tests/client.test.ts
@@ -1,12 +1,14 @@
 import { bcs } from '@mysten/sui/bcs';
-import type { Transaction } from '@mysten/sui/transactions';
+import { Transaction, coinWithBalance } from '@mysten/sui/transactions';
 import { describe, expect, test } from 'vitest';
 import { PredictClient } from '../src/client.js';
 import { TESTNET_CONFIG as cfg } from '../src/config/index.js';
+import * as accountEvents from '../src/contracts/account/account_events.js';
 import * as orderEvents from '../src/contracts/deepbook_predict/order_events.js';
 import { PredictInputError } from '../src/errors.js';
 import type { ReadClient } from '../src/reads/inspect.js';
 import { POS_INF_TICK } from '../src/ticks.js';
+import { depositFunds } from '../src/tx/account.js';
 
 const OWNER = '0x' + 'ab'.repeat(32);
 const MARKET_ID = '0x' + 'cd'.repeat(32);
@@ -222,6 +224,70 @@ describe('tx.deposit / tx.withdraw', () => {
 		expect(hasTransfer).toBe(false);
 	});
 
+	test('deposit({ create: true }) composes coin → new → auth → deposit_funds → share', () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const tx = pc.tx.deposit(OWNER, 100, { create: true });
+		const cmds = tx.getData().commands;
+		expect(cmds).toHaveLength(5);
+		// exact order; the coin intent resolves in place at build time
+		expect('$Intent' in cmds[0] && cmds[0].$Intent?.name).toBe('CoinWithBalance');
+		expect('MoveCall' in cmds[1] && cmds[1].MoveCall!.function).toBe('new');
+		expect('MoveCall' in cmds[2] && cmds[2].MoveCall!.function).toBe('generate_auth');
+		expect('MoveCall' in cmds[3] && cmds[3].MoveCall!.function).toBe('deposit_funds');
+		expect('MoveCall' in cmds[4] && cmds[4].MoveCall!.function).toBe('share');
+		// deposit_funds addresses the wrapper through the `new` RESULT HANDLE — not a
+		// pure/object input (an input could only reference a pre-existing object) —
+		// and share consumes the same handle, last.
+		const wrapperArg = call(tx, 3).arguments[0] as { $kind: string; Result?: number };
+		expect(wrapperArg).toMatchObject({ $kind: 'Result', Result: 1 });
+		const shareArg = call(tx, 4).arguments[0] as { $kind: string; Result?: number };
+		expect(shareArg).toMatchObject({ $kind: 'Result', Result: 1 });
+	});
+
+	test('deposit without create is unchanged (regression pin)', () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const tx = pc.tx.deposit(OWNER, 100);
+		// Pin against the pre-`create` construction, byte for byte.
+		const expected = new Transaction();
+		const coin = expected.add(
+			coinWithBalance({ type: cfg.quoteCoinType, balance: 100_000_000n, useGasCoin: false }),
+		);
+		expected.add(depositFunds(cfg, { wrapperId: pc.wrapperIdFor(OWNER), coin }));
+		const json = (v: unknown) =>
+			JSON.stringify(v, (_k, x) => (typeof x === 'bigint' ? `${x}n` : x));
+		expect(json(tx.getData())).toBe(json(expected.getData()));
+	});
+
+	test('decode.createManager and decode.deposit both resolve from one combined result', () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const wrapperId = pc.wrapperIdFor(OWNER);
+		const result = {
+			events: [
+				{
+					eventType: `${cfg.packages.account}::account_events::AccountCreated`,
+					bcs: accountEvents.AccountCreated.serialize({
+						account_id: MARKET_ID,
+						wrapper_id: wrapperId,
+						owner: OWNER,
+						self_owned: false,
+						referrer_account_id: null,
+					}).toBytes(),
+				},
+				{
+					eventType: `${cfg.packages.account}::account_events::Deposited`,
+					bcs: accountEvents.Deposited.serialize({
+						account_id: MARKET_ID,
+						coin_type: cfg.quoteCoinType,
+						amount: 100_000_000n,
+						new_balance: 100_000_000n,
+					}).toBytes(),
+				},
+			],
+		};
+		expect(pc.decode.createManager(result).wrapperId).toBe(wrapperId);
+		expect(pc.decode.deposit(result).amount).toBe(100);
+	});
+
 	test('withdraw({ toCoinObject: true }) returns a discrete Coin via TransferObjects', () => {
 		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
 		const tx = pc.tx.withdraw(OWNER, '5', { toCoinObject: true });
@@ -404,6 +470,13 @@ describe('tx.mint (market resolution + unit conversion)', () => {
 		).rejects.toThrow(/tick grid/);
 	});
 
+	test('read.price rejects sentinel strikes (same domain rule as mint)', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		await expect(pc.read.price({ underlying: 'BTC', expiryMs: EXPIRY, strike: 0 })).rejects.toThrow(
+			/finite tick domain/,
+		);
+	});
+
 	test('read.quoteMint dry-runs the mint and computes the all-in cost', async () => {
 		const { client, counts } = mockClient();
 		const pc = new PredictClient({ network: 'testnet', client });
@@ -443,6 +516,95 @@ describe('tx.mint (market resolution + unit conversion)', () => {
 		await pc.tx.mint(OWNER, m, { quantity: 50 });
 		await pc.tx.mint(OWNER, m, { quantity: 50 });
 		expect(counts.expiry_market_id).toBe(1);
+	});
+});
+
+describe('range markets', () => {
+	const RANGE = {
+		underlying: 'BTC',
+		expiryMs: EXPIRY,
+		side: 'range',
+		lower: 104_000,
+		upper: 106_000,
+	} as const;
+
+	test('mint converts both bounds to finite grid ticks', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const tx = await pc.tx.mint(OWNER, RANGE, { quantity: 50 });
+		expect(targets(tx)).toContain(`${cfg.packages.predict}::expiry_market::mint_exact_quantity`);
+		// mint args: [market, wrapper, auth, config, pricer, lower, higher, ...]
+		expect(argPureBytes(tx, 2, 5)).toBe(b64(10_400_000n)); // 104,000 / $0.01
+		expect(argPureBytes(tx, 2, 6)).toBe(b64(10_600_000n)); // 106,000 / $0.01 — finite, not +inf
+	});
+
+	test('off-grid bound → PredictInputError /tick grid/', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const bad = { ...RANGE, upper: 106_000.005 };
+		await expect(pc.tx.mint(OWNER, bad, { quantity: 50 })).rejects.toBeInstanceOf(
+			PredictInputError,
+		);
+		await expect(pc.tx.mint(OWNER, bad, { quantity: 50 })).rejects.toThrow(/tick grid/);
+	});
+
+	test('inverted or empty range → PredictInputError', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		const inverted = { ...RANGE, lower: 106_000, upper: 104_000 };
+		await expect(pc.tx.mint(OWNER, inverted, { quantity: 50 })).rejects.toBeInstanceOf(
+			PredictInputError,
+		);
+		await expect(pc.tx.mint(OWNER, inverted, { quantity: 50 })).rejects.toThrow(/below upper/);
+		const empty = { ...RANGE, lower: 104_000, upper: 104_000 };
+		await expect(pc.tx.mint(OWNER, empty, { quantity: 50 })).rejects.toThrow(/below upper/);
+	});
+
+	test('bounds outside the finite tick domain → PredictInputError', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		await expect(pc.tx.mint(OWNER, { ...RANGE, lower: 0 }, { quantity: 50 })).rejects.toThrow(
+			/finite tick domain/,
+		);
+	});
+});
+
+describe('marketId pin', () => {
+	test('skips the underlying+expiry ladder and reads the pinned market state', async () => {
+		const { client, counts } = mockClient();
+		const pc = new PredictClient({ network: 'testnet', client });
+		const tx = await pc.tx.mint(
+			OWNER,
+			{ underlying: 'BTC', expiryMs: EXPIRY, marketId: MARKET_ID, strike: 105_000, side: 'up' },
+			{ quantity: 50 },
+		);
+		expect(counts.expiry_market_id).toBeUndefined(); // no ladder resolution
+		expect(counts.expiry).toBe(1); // the pinned market's state IS read (tickSizeRaw)
+		expect(targets(tx)).toContain(`${cfg.packages.predict}::expiry_market::mint_exact_quantity`);
+	});
+
+	test('pin disagreeing with the descriptor expiry → PredictInputError', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{
+					underlying: 'BTC',
+					expiryMs: EXPIRY + 1,
+					marketId: MARKET_ID,
+					strike: 105_000,
+					side: 'up',
+				},
+				{ quantity: 50 },
+			),
+		).rejects.toThrow(/expires at/);
+	});
+
+	test('malformed marketId → PredictInputError, not a silent ladder fallback', async () => {
+		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
+		await expect(
+			pc.tx.mint(
+				OWNER,
+				{ underlying: 'BTC', expiryMs: EXPIRY, marketId: '', strike: 105_000, side: 'up' },
+				{ quantity: 50 },
+			),
+		).rejects.toThrow(/invalid marketId/);
 	});
 });
 


### PR DESCRIPTION
## Description

Extends the `PredictClient` facade with capabilities consumers were previously reaching
around it for, plus a minimal set of composition exports. No new on-chain reads, no
renames, no signature changes to existing internals.

### Facade

- **Range markets** — `MarketDescriptor` is now a discriminated union: the existing
  binary arm (`side: 'up' | 'down'`, `strike`) is untouched, and a new
  `{ side: 'range', lower, upper }` arm mints two-strike range positions (payout on
  `(lower, upper]`). Implemented entirely in the `#strikeTicks` seam — both bounds are
  converted with `priceToRaw` and validated like `binaryRangeTicks` (whole-tick
  multiple, finite domain, `lower < upper`, `PredictInputError` on violation) — so
  `tx.mint`, `tx.mintAmount`, `tx.redeem`, and both quotes inherit range support.
  `'reference'` stays binary-only. `read.price` keeps a binary-arm param.
- **Explicit market pin** — optional `marketId` on `MarketDescriptor`. When present,
  `#resolveMarket` never runs the underlying+expiry ladder lookup: it validates the id
  shape, reads that market's state directly (one devInspect cold, zero warm), and
  cross-checks the object's on-chain expiry against the descriptor's `expiryMs`
  (typed error on mismatch). A UI that reviewed a specific `ExpiryMarket` object mints
  against exactly that object — a window roll surfaces as a loud error, never a silent
  re-route to the next market.
- **Single-PTB create-and-deposit** — `tx.deposit(owner, amount, { create: true })`
  composes first-time funding in one signature: `account_registry::new` →
  coin → auth → `deposit_funds` via the fresh result handle → `account::share` last.
  This cannot be built by chaining `createManager()` + `deposit()` (an object input can
  only address a pre-existing object). Composition lives in `tx/account.ts` as
  `createAccountAndDeposit`, next to `createAccount`. The wrapper derives from the
  transaction sender; docs state `owner` must be the signer and that `new` aborts if
  the account already exists (callers gate on their own existence check).

### Exports

- Root entry adds `generateAuth`, `deriveAccountWrapperId`, `ACCUMULATOR_ROOT_ID`, and
  `POSITION_LOT_SIZE` — the primitives needed to compose predict accounts into PTBs on
  foreign packages (e.g. `deepbook_core_account` spot trading), which no facade shape
  can cover.

### Review hardening

- `read.price` now rejects sentinel strikes (0 / `POS_INF`) with the same finite-domain
  rule as the mint path (previously it quoted the −inf tick as a real price).
- Corrected the range payout interval in docs to `(lower, upper]`, matching the chain.

## Test plan

- New unit tests (vitest, mocked `ReadClient`): range mints produce finite
  grid-validated ticks; off-grid / inverted / out-of-domain ranges throw
  `PredictInputError`; pinned mints skip the ladder (asserted via simulate counts) but
  still read the pinned market's state; mismatched pin expiry and malformed `marketId`
  throw typed errors; `deposit({ create: true })` emits exactly
  coin → new → auth → deposit_funds → share with the wrapper wired through the `new`
  result handle; default `deposit` output is byte-identical to the previous
  construction (regression pin); a combined create+deposit result decodes through both
  `decode.createManager` and `decode.deposit`; root exports resolve.
- `pnpm --filter @mysten/deepbook-predict build` (tsc + tsdown), full test suite
  (145 passing), and `pnpm lint` are green.
- Verified in a standalone consumer under `nodenext` resolution that all new root
  exports typecheck and load at runtime.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
