### PR TITLE
Add Core API SuiNS address resolution

### DIFF
--- a/.changeset/tidy-names-resolve.md
+++ b/.changeset/tidy-names-resolve.md
@@ -2,5 +2,5 @@
 '@mysten/sui': minor
 ---
 
-Add `lookupName` to the Core, gRPC, and GraphQL client APIs for transport-agnostic SuiNS
-name-to-address resolution.
+Add `resolveNameServiceAddress` to the Core, gRPC, and GraphQL client APIs for transport-agnostic
+SuiNS name-to-address resolution.

--- a/.changeset/tidy-names-resolve.md
+++ b/.changeset/tidy-names-resolve.md
@@ -1,0 +1,6 @@
+---
+'@mysten/sui': minor
+---
+
+Add `lookupName` to the Core, gRPC, and GraphQL client APIs for transport-agnostic SuiNS
+name-to-address resolution.

--- a/packages/docs/content/sui/clients/core.mdx
+++ b/packages/docs/content/sui/clients/core.mdx
@@ -627,13 +627,13 @@ console.log(fn.typeParameters);
 
 ## Name service methods
 
-### `lookupName`
+### `resolveNameServiceAddress`
 
 Resolve a SuiNS name to its target address. The address is `null` when the name does not exist, has
 expired, or does not have a target address.
 
 ```typescript
-const { address } = await client.core.lookupName({
+const { address } = await client.core.resolveNameServiceAddress({
 	name: 'example.sui',
 });
 

--- a/packages/docs/content/sui/clients/core.mdx
+++ b/packages/docs/content/sui/clients/core.mdx
@@ -627,12 +627,27 @@ console.log(fn.typeParameters);
 
 ## Name service methods
 
+### `lookupName`
+
+Resolve a SuiNS name to its target address. The address is `null` when the name does not exist, has
+expired, or does not have a target address.
+
+```typescript
+const { address } = await client.core.lookupName({
+	name: 'example.sui',
+});
+
+console.log(address); // e.g., "0x..." or null
+```
+
 ### `defaultNameServiceName`
 
 Resolve an address to its default SuiNS name.
 
 ```typescript
-const { name } = await client.core.defaultNameServiceName({
+const {
+	data: { name },
+} = await client.core.defaultNameServiceName({
 	address: '0xabc...',
 });
 

--- a/packages/docs/content/sui/clients/graphql.mdx
+++ b/packages/docs/content/sui/clients/graphql.mdx
@@ -52,15 +52,15 @@ The same methods are available through `client.core` when SDK code needs the tra
 
 Common top-level methods:
 
-| Category       | Methods                                                                                            |
-| -------------- | -------------------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
-| Simulation     | `simulateTransaction`                                                                              |
-| Queries        | `listTransactions`, `listEvents`                                                                   |
-| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
-| Verification   | `verifyZkLoginSignature`                                                                           |
+| Category       | Methods                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`                             |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                                      |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`                         |
+| Simulation     | `simulateTransaction`                                                                                             |
+| Queries        | `listTransactions`, `listEvents`                                                                                  |
+| Move and names | `getMoveFunction`, `resolveNameServiceAddress`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                                          |
 
 GraphQL-specific top-level options include `doGasSelection` on `simulateTransaction` and
 `include: { value: true }` on `listDynamicFields`.

--- a/packages/docs/content/sui/clients/graphql.mdx
+++ b/packages/docs/content/sui/clients/graphql.mdx
@@ -52,15 +52,15 @@ The same methods are available through `client.core` when SDK code needs the tra
 
 Common top-level methods:
 
-| Category       | Methods                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
-| Simulation     | `simulateTransaction`                                                                     |
-| Queries        | `listTransactions`, `listEvents`                                                          |
-| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
-| Verification   | `verifyZkLoginSignature`                                                                  |
+| Category       | Methods                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
+| Simulation     | `simulateTransaction`                                                                              |
+| Queries        | `listTransactions`, `listEvents`                                                                   |
+| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                           |
 
 GraphQL-specific top-level options include `doGasSelection` on `simulateTransaction` and
 `include: { value: true }` on `listDynamicFields`.
@@ -110,7 +110,9 @@ passed to your query are properly typed.
 const getSuinsName = graphql(`
 	query getSuiName($address: SuiAddress!) {
 		address(address: $address) {
-			defaultSuinsName
+			defaultNameRecord {
+				domain
+			}
 		}
 	}
 `);
@@ -123,7 +125,7 @@ async function getDefaultSuinsName(address: string) {
 		},
 	});
 
-	return result.data?.address?.defaultSuinsName;
+	return result.data?.address?.defaultNameRecord?.domain;
 }
 ```
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -74,15 +74,15 @@ const coins = await grpcClient.listCoins({
 
 Common top-level methods:
 
-| Category       | Methods                                                                                            |
-| -------------- | -------------------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
-| Simulation     | `simulateTransaction`                                                                              |
-| Queries        | `listTransactions`, `listEvents`                                                                   |
-| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
-| Verification   | `verifyZkLoginSignature`                                                                           |
+| Category       | Methods                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`                             |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                                      |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`                         |
+| Simulation     | `simulateTransaction`                                                                                             |
+| Queries        | `listTransactions`, `listEvents`                                                                                  |
+| Move and names | `getMoveFunction`, `resolveNameServiceAddress`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                                          |
 
 ### gRPC-specific top-level data
 
@@ -345,7 +345,7 @@ const { response } = await grpcClient.movePackageService.getFunction({
 ### Name service
 
 ```typescript
-const { address } = await grpcClient.lookupName({
+const { address } = await grpcClient.resolveNameServiceAddress({
 	name: 'example.sui',
 });
 ```

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -74,15 +74,15 @@ const coins = await grpcClient.listCoins({
 
 Common top-level methods:
 
-| Category       | Methods                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
-| Simulation     | `simulateTransaction`                                                                     |
-| Queries        | `listTransactions`, `listEvents`                                                          |
-| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
-| Verification   | `verifyZkLoginSignature`                                                                  |
+| Category       | Methods                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
+| Simulation     | `simulateTransaction`                                                                              |
+| Queries        | `listTransactions`, `listEvents`                                                                   |
+| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                           |
 
 ### gRPC-specific top-level data
 
@@ -345,8 +345,20 @@ const { response } = await grpcClient.movePackageService.getFunction({
 ### Name service
 
 ```typescript
-// Reverse lookup address to get name
-const { response } = await grpcClient.nameService.reverseLookupName({
+const { address } = await grpcClient.lookupName({
+	name: 'example.sui',
+});
+```
+
+Use the raw name service when you need the complete gRPC `NameRecord` instead of only its target
+address:
+
+```typescript
+const { response } = await grpcClient.nameService.lookupName({
+	name: 'example.sui',
+});
+
+const { response: reverseResponse } = await grpcClient.nameService.reverseLookupName({
 	address: '0xabc...',
 });
 ```

--- a/packages/docs/content/sui/clients/index.mdx
+++ b/packages/docs/content/sui/clients/index.mdx
@@ -73,15 +73,15 @@ const result = await client.signAndExecuteTransaction({
 
 Common top-level methods include:
 
-| Category       | Methods                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`     |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                              |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction` |
-| Simulation     | `simulateTransaction`                                                                     |
-| Queries        | `listTransactions`, `listEvents`                                                          |
-| Move and names | `getMoveFunction`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType`      |
-| Verification   | `verifyZkLoginSignature`                                                                  |
+| Category       | Methods                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
+| Simulation     | `simulateTransaction`                                                                              |
+| Queries        | `listTransactions`, `listEvents`                                                                   |
+| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                           |
 
 ### Core API
 

--- a/packages/docs/content/sui/clients/index.mdx
+++ b/packages/docs/content/sui/clients/index.mdx
@@ -73,15 +73,15 @@ const result = await client.signAndExecuteTransaction({
 
 Common top-level methods include:
 
-| Category       | Methods                                                                                            |
-| -------------- | -------------------------------------------------------------------------------------------------- |
-| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`              |
-| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                       |
-| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`          |
-| Simulation     | `simulateTransaction`                                                                              |
-| Queries        | `listTransactions`, `listEvents`                                                                   |
-| Move and names | `getMoveFunction`, `lookupName`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
-| Verification   | `verifyZkLoginSignature`                                                                           |
+| Category       | Methods                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Objects        | `getObject`, `getObjects`, `listOwnedObjects`, `listDynamicFields`, `getDynamicField`                             |
+| Coins          | `listCoins`, `getBalance`, `listBalances`, `getCoinMetadata`                                                      |
+| Transactions   | `getTransaction`, `executeTransaction`, `signAndExecuteTransaction`, `waitForTransaction`                         |
+| Simulation     | `simulateTransaction`                                                                                             |
+| Queries        | `listTransactions`, `listEvents`                                                                                  |
+| Move and names | `getMoveFunction`, `resolveNameServiceAddress`, `defaultNameServiceName`, `mvr.resolvePackage`, `mvr.resolveType` |
+| Verification   | `verifyZkLoginSignature`                                                                                          |
 
 ### Core API
 

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -122,7 +122,7 @@ use the same replacement under `client.core`.
 | `queryEvents`                | `listEvents`                                                          |
 | `getNormalizedMoveFunction`  | `getMoveFunction`                                                     |
 | `getMoveFunctionArgTypes`    | No direct equivalent; `getMoveFunction` returns normalized signatures |
-| `resolveNameServiceAddress`  | `nameService.lookupName` or GraphQL query                             |
+| `resolveNameServiceAddress`  | `lookupName`                                                          |
 | `resolveNameServiceNames`    | No direct equivalent for listing every name assigned to an address    |
 
 `getMoveFunction` exposes normalized parameter signatures, but it does not reproduce the legacy
@@ -130,6 +130,12 @@ use the same replacement under `client.core`.
 `defaultNameServiceName` and raw gRPC `nameService.reverseLookupName` return only the configured
 default name; they do not replace the paginated list returned by `resolveNameServiceNames`. Keep a
 legacy endpoint or use an application indexer when those exact results are required.
+
+```typescript
+const { address } = await client.lookupName({
+	name: 'example.sui',
+});
+```
 
 Some composed helpers are currently exposed through `client.core` rather than as top-level gRPC or
 GraphQL methods:

--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -122,7 +122,7 @@ use the same replacement under `client.core`.
 | `queryEvents`                | `listEvents`                                                          |
 | `getNormalizedMoveFunction`  | `getMoveFunction`                                                     |
 | `getMoveFunctionArgTypes`    | No direct equivalent; `getMoveFunction` returns normalized signatures |
-| `resolveNameServiceAddress`  | `lookupName`                                                          |
+| `resolveNameServiceAddress`  | `resolveNameServiceAddress` (returns `{ address }`)                   |
 | `resolveNameServiceNames`    | No direct equivalent for listing every name assigned to an address    |
 
 `getMoveFunction` exposes normalized parameter signatures, but it does not reproduce the legacy
@@ -132,7 +132,7 @@ default name; they do not replace the paginated list returned by `resolveNameSer
 legacy endpoint or use an application indexer when those exact results are required.
 
 ```typescript
-const { address } = await client.lookupName({
+const { address } = await client.resolveNameServiceAddress({
 	name: 'example.sui',
 });
 ```

--- a/packages/sui/src/client/core.ts
+++ b/packages/sui/src/client/core.ts
@@ -134,9 +134,9 @@ export abstract class CoreClient extends BaseClient implements SuiClientTypes.Tr
 		options: SuiClientTypes.DefaultNameServiceNameOptions,
 	): Promise<SuiClientTypes.DefaultNameServiceNameResponse>;
 
-	abstract lookupName(
-		options: SuiClientTypes.LookupNameOptions,
-	): Promise<SuiClientTypes.LookupNameResponse>;
+	abstract resolveNameServiceAddress(
+		options: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse>;
 
 	async getDynamicField(
 		options: SuiClientTypes.GetDynamicFieldOptions,

--- a/packages/sui/src/client/core.ts
+++ b/packages/sui/src/client/core.ts
@@ -134,6 +134,10 @@ export abstract class CoreClient extends BaseClient implements SuiClientTypes.Tr
 		options: SuiClientTypes.DefaultNameServiceNameOptions,
 	): Promise<SuiClientTypes.DefaultNameServiceNameResponse>;
 
+	abstract lookupName(
+		options: SuiClientTypes.LookupNameOptions,
+	): Promise<SuiClientTypes.LookupNameResponse>;
+
 	async getDynamicField(
 		options: SuiClientTypes.GetDynamicFieldOptions,
 	): Promise<SuiClientTypes.GetDynamicFieldResponse> {

--- a/packages/sui/src/client/types.ts
+++ b/packages/sui/src/client/types.ts
@@ -757,6 +757,14 @@ export namespace SuiClientTypes {
 	}
 
 	/** Name service methods */
+	export interface LookupNameOptions extends CoreClientMethodOptions {
+		name: string;
+	}
+
+	export interface LookupNameResponse {
+		address: string | null;
+	}
+
 	export interface DefaultNameServiceNameOptions extends CoreClientMethodOptions {
 		address: string;
 	}
@@ -768,6 +776,7 @@ export namespace SuiClientTypes {
 	}
 
 	export interface TransportMethods {
+		lookupName: (options: LookupNameOptions) => Promise<LookupNameResponse>;
 		defaultNameServiceName: (
 			options: DefaultNameServiceNameOptions,
 		) => Promise<DefaultNameServiceNameResponse>;

--- a/packages/sui/src/client/types.ts
+++ b/packages/sui/src/client/types.ts
@@ -757,11 +757,11 @@ export namespace SuiClientTypes {
 	}
 
 	/** Name service methods */
-	export interface LookupNameOptions extends CoreClientMethodOptions {
+	export interface ResolveNameServiceAddressOptions extends CoreClientMethodOptions {
 		name: string;
 	}
 
-	export interface LookupNameResponse {
+	export interface ResolveNameServiceAddressResponse {
 		address: string | null;
 	}
 
@@ -776,7 +776,9 @@ export namespace SuiClientTypes {
 	}
 
 	export interface TransportMethods {
-		lookupName: (options: LookupNameOptions) => Promise<LookupNameResponse>;
+		resolveNameServiceAddress: (
+			options: ResolveNameServiceAddressOptions,
+		) => Promise<ResolveNameServiceAddressResponse>;
 		defaultNameServiceName: (
 			options: DefaultNameServiceNameOptions,
 		) => Promise<DefaultNameServiceNameResponse>;

--- a/packages/sui/src/graphql/client.ts
+++ b/packages/sui/src/graphql/client.ts
@@ -370,7 +370,9 @@ export class SuiGraphQLClient<Queries extends Record<string, GraphQLDocument> = 
 		return this.core.defaultNameServiceName(input);
 	}
 
-	lookupName(input: SuiClientTypes.LookupNameOptions): Promise<SuiClientTypes.LookupNameResponse> {
-		return this.core.lookupName(input);
+	resolveNameServiceAddress(
+		input: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
+		return this.core.resolveNameServiceAddress(input);
 	}
 }

--- a/packages/sui/src/graphql/client.ts
+++ b/packages/sui/src/graphql/client.ts
@@ -369,4 +369,8 @@ export class SuiGraphQLClient<Queries extends Record<string, GraphQLDocument> = 
 	): Promise<SuiClientTypes.DefaultNameServiceNameResponse> {
 		return this.core.defaultNameServiceName(input);
 	}
+
+	lookupName(input: SuiClientTypes.LookupNameOptions): Promise<SuiClientTypes.LookupNameResponse> {
+		return this.core.lookupName(input);
+	}
 }

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -30,8 +30,8 @@ import {
 	GetTransactionBlockDocument,
 	ListEventsDocument,
 	ListTransactionsDocument,
-	LookupNameDocument,
 	MultiGetObjectsDocument,
+	ResolveNameServiceAddressDocument,
 	ResolveTransactionDocument,
 	SimulateTransactionDocument,
 	VerifyZkLoginSignatureDocument,
@@ -777,11 +777,11 @@ export class GraphQLCoreClient extends CoreClient {
 		};
 	}
 
-	async lookupName(
-		options: SuiClientTypes.LookupNameOptions,
-	): Promise<SuiClientTypes.LookupNameResponse> {
+	async resolveNameServiceAddress(
+		options: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
 		const { data, errors } = await this.#graphqlClient.query({
-			query: LookupNameDocument,
+			query: ResolveNameServiceAddressDocument,
 			signal: options.signal,
 			variables: { name: options.name },
 		});

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -30,6 +30,7 @@ import {
 	GetTransactionBlockDocument,
 	ListEventsDocument,
 	ListTransactionsDocument,
+	LookupNameDocument,
 	MultiGetObjectsDocument,
 	ResolveTransactionDocument,
 	SimulateTransactionDocument,
@@ -774,6 +775,20 @@ export class GraphQLCoreClient extends CoreClient {
 		return {
 			data: { name: name },
 		};
+	}
+
+	async lookupName(
+		options: SuiClientTypes.LookupNameOptions,
+	): Promise<SuiClientTypes.LookupNameResponse> {
+		const { data, errors } = await this.#graphqlClient.query({
+			query: LookupNameDocument,
+			signal: options.signal,
+			variables: { name: options.name },
+		});
+
+		handleGraphQLErrors(errors);
+
+		return { address: data?.address?.address ?? null };
 	}
 
 	async getMoveFunction(

--- a/packages/sui/src/graphql/generated/queries.ts
+++ b/packages/sui/src/graphql/generated/queries.ts
@@ -286,12 +286,12 @@ export type DefaultSuinsNameQueryVariables = Exact<{
 
 export type DefaultSuinsNameQuery = { address: { defaultNameRecord: { domain: string } | null } | null };
 
-export type LookupNameQueryVariables = Exact<{
+export type ResolveNameServiceAddressQueryVariables = Exact<{
   name: string;
 }>;
 
 
-export type LookupNameQuery = { address: { address: string } | null };
+export type ResolveNameServiceAddressQuery = { address: { address: string } | null };
 
 export type GetOwnedObjectsQueryVariables = Exact<{
   owner: string;
@@ -911,13 +911,13 @@ export const DefaultSuinsNameDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<DefaultSuinsNameQuery, DefaultSuinsNameQueryVariables>;
-export const LookupNameDocument = new TypedDocumentString(`
-    query lookupName($name: String!) {
+export const ResolveNameServiceAddressDocument = new TypedDocumentString(`
+    query resolveNameServiceAddress($name: String!) {
   address(name: $name) {
     address
   }
 }
-    `) as unknown as TypedDocumentString<LookupNameQuery, LookupNameQueryVariables>;
+    `) as unknown as TypedDocumentString<ResolveNameServiceAddressQuery, ResolveNameServiceAddressQueryVariables>;
 export const GetOwnedObjectsDocument = new TypedDocumentString(`
     query getOwnedObjects($owner: SuiAddress!, $limit: Int, $cursor: String, $filter: ObjectFilter, $includeContent: Boolean = false, $includePreviousTransaction: Boolean = false, $includeObjectBcs: Boolean = false, $includeJson: Boolean = false, $includeDisplay: Boolean = false) {
   address(address: $owner) {

--- a/packages/sui/src/graphql/generated/queries.ts
+++ b/packages/sui/src/graphql/generated/queries.ts
@@ -286,6 +286,13 @@ export type DefaultSuinsNameQueryVariables = Exact<{
 
 export type DefaultSuinsNameQuery = { address: { defaultNameRecord: { domain: string } | null } | null };
 
+export type LookupNameQueryVariables = Exact<{
+  name: string;
+}>;
+
+
+export type LookupNameQuery = { address: { address: string } | null };
+
 export type GetOwnedObjectsQueryVariables = Exact<{
   owner: string;
   limit?: number | null | undefined;
@@ -904,6 +911,13 @@ export const DefaultSuinsNameDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<DefaultSuinsNameQuery, DefaultSuinsNameQueryVariables>;
+export const LookupNameDocument = new TypedDocumentString(`
+    query lookupName($name: String!) {
+  address(name: $name) {
+    address
+  }
+}
+    `) as unknown as TypedDocumentString<LookupNameQuery, LookupNameQueryVariables>;
 export const GetOwnedObjectsDocument = new TypedDocumentString(`
     query getOwnedObjects($owner: SuiAddress!, $limit: Int, $cursor: String, $filter: ObjectFilter, $includeContent: Boolean = false, $includePreviousTransaction: Boolean = false, $includeObjectBcs: Boolean = false, $includeJson: Boolean = false, $includeDisplay: Boolean = false) {
   address(address: $owner) {

--- a/packages/sui/src/graphql/queries/nameService.graphql
+++ b/packages/sui/src/graphql/queries/nameService.graphql
@@ -9,7 +9,7 @@ query defaultSuinsName($address: SuiAddress!) {
 	}
 }
 
-query lookupName($name: String!) {
+query resolveNameServiceAddress($name: String!) {
 	address(name: $name) {
 		address
 	}

--- a/packages/sui/src/graphql/queries/nameService.graphql
+++ b/packages/sui/src/graphql/queries/nameService.graphql
@@ -8,3 +8,9 @@ query defaultSuinsName($address: SuiAddress!) {
 		}
 	}
 }
+
+query lookupName($name: String!) {
+	address(name: $name) {
+		address
+	}
+}

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -336,4 +336,8 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 	): Promise<SuiClientTypes.DefaultNameServiceNameResponse> {
 		return this.core.defaultNameServiceName(input);
 	}
+
+	lookupName(input: SuiClientTypes.LookupNameOptions): Promise<SuiClientTypes.LookupNameResponse> {
+		return this.core.lookupName(input);
+	}
 }

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -337,7 +337,9 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 		return this.core.defaultNameServiceName(input);
 	}
 
-	lookupName(input: SuiClientTypes.LookupNameOptions): Promise<SuiClientTypes.LookupNameResponse> {
-		return this.core.lookupName(input);
+	resolveNameServiceAddress(
+		input: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
+		return this.core.resolveNameServiceAddress(input);
 	}
 }

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -54,6 +54,7 @@ import {
 import type { QueryEnd, QueryOptions } from './proto/sui/rpc/v2/query_options.js';
 import { Ordering, QueryEndReason } from './proto/sui/rpc/v2/query_options.js';
 import type { ResolvedPagination } from '../client/query-filters.js';
+import { RpcError } from '@protobuf-ts/runtime-rpc';
 import {
 	resolveEventFilter,
 	resolvePagination,
@@ -795,6 +796,29 @@ export class GrpcCoreClient extends CoreClient {
 				name,
 			},
 		};
+	}
+
+	async lookupName(
+		options: SuiClientTypes.LookupNameOptions,
+	): Promise<SuiClientTypes.LookupNameResponse> {
+		try {
+			const { response } = await this.#client.nameService.lookupName(
+				{ name: options.name },
+				{ abort: options.signal },
+			);
+
+			return { address: response.record?.targetAddress ?? null };
+		} catch (error) {
+			if (
+				error instanceof RpcError &&
+				(error.code === 'NOT_FOUND' ||
+					(error.code === 'RESOURCE_EXHAUSTED' && error.message === 'name has expired'))
+			) {
+				return { address: null };
+			}
+
+			throw error;
+		}
 	}
 
 	async getMoveFunction(

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -67,6 +67,21 @@ export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
 }
 
+function isNameServiceResolutionMiss(error: unknown): boolean {
+	if (!(error instanceof RpcError)) return false;
+	if (error.code === 'NOT_FOUND') return true;
+	if (error.code !== 'RESOURCE_EXHAUSTED') return false;
+
+	try {
+		// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a
+		// structured reason. grpc-web URI-encodes status messages, so decode before matching while
+		// preserving unrelated RESOURCE_EXHAUSTED failures such as capacity limits.
+		return decodeURIComponent(error.message) === 'name has expired';
+	} catch {
+		return false;
+	}
+}
+
 export class GrpcCoreClient extends CoreClient {
 	#client: SuiGrpcClient;
 	constructor({ client, ...options }: GrpcCoreClientOptions) {
@@ -798,9 +813,9 @@ export class GrpcCoreClient extends CoreClient {
 		};
 	}
 
-	async lookupName(
-		options: SuiClientTypes.LookupNameOptions,
-	): Promise<SuiClientTypes.LookupNameResponse> {
+	async resolveNameServiceAddress(
+		options: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
 		try {
 			const { response } = await this.#client.nameService.lookupName(
 				{ name: options.name },
@@ -809,11 +824,7 @@ export class GrpcCoreClient extends CoreClient {
 
 			return { address: response.record?.targetAddress ?? null };
 		} catch (error) {
-			if (
-				error instanceof RpcError &&
-				(error.code === 'NOT_FOUND' ||
-					(error.code === 'RESOURCE_EXHAUSTED' && error.message === 'name has expired'))
-			) {
+			if (isNameServiceResolutionMiss(error)) {
 				return { address: null };
 			}
 

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -806,9 +806,9 @@ export class JSONRpcCoreClient extends CoreClient {
 	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
 	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
-	async lookupName(
-		options: SuiClientTypes.LookupNameOptions,
-	): Promise<SuiClientTypes.LookupNameResponse> {
+	async resolveNameServiceAddress(
+		options: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
 		return {
 			address: await this.#jsonRpcClient.resolveNameServiceAddress(options),
 		};

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -806,6 +806,18 @@ export class JSONRpcCoreClient extends CoreClient {
 	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
 	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
 	 */
+	async lookupName(
+		options: SuiClientTypes.LookupNameOptions,
+	): Promise<SuiClientTypes.LookupNameResponse> {
+		return {
+			address: await this.#jsonRpcClient.resolveNameServiceAddress(options),
+		};
+	}
+
+	/**
+	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`
+	 * from `@mysten/sui/grpc` or `SuiGraphQLClient` from `@mysten/sui/graphql` instead.
+	 */
 	resolveTransactionPlugin() {
 		return coreClientResolveTransactionPlugin;
 	}

--- a/packages/sui/test/e2e/clients/core/name-service.test.ts
+++ b/packages/sui/test/e2e/clients/core/name-service.test.ts
@@ -16,9 +16,9 @@ describe('Core API - Name Service', () => {
 		testAddress = toolbox.address();
 	});
 
-	describe('lookupName', () => {
+	describe('resolveNameServiceAddress', () => {
 		testWithAllClients('should throw for an invalid name', async (client) => {
-			await expect(client.core.lookupName({ name: '' })).rejects.toThrow();
+			await expect(client.core.resolveNameServiceAddress({ name: '' })).rejects.toThrow();
 		});
 	});
 

--- a/packages/sui/test/e2e/clients/core/name-service.test.ts
+++ b/packages/sui/test/e2e/clients/core/name-service.test.ts
@@ -16,6 +16,12 @@ describe('Core API - Name Service', () => {
 		testAddress = toolbox.address();
 	});
 
+	describe('lookupName', () => {
+		testWithAllClients('should throw for an invalid name', async (client) => {
+			await expect(client.core.lookupName({ name: '' })).rejects.toThrow();
+		});
+	});
+
 	describe('defaultNameServiceName', () => {
 		// Note: SuiNS is not configured on localnet, so we expect specific behavior
 		// gRPC throws "SuiNS not configured for this network"

--- a/packages/sui/test/unit/client/name-service.test.ts
+++ b/packages/sui/test/unit/client/name-service.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RpcError } from '@protobuf-ts/runtime-rpc';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SuiGraphQLClient } from '../../../src/graphql/index.js';
+import { SuiGrpcClient } from '../../../src/grpc/index.js';
+import type {
+	JsonRpcTransport,
+	JsonRpcTransportRequestOptions,
+} from '../../../src/jsonRpc/index.js';
+import { SuiJsonRpcClient } from '../../../src/jsonRpc/index.js';
+
+const name = '@mysten';
+const address = '0x123';
+
+describe('lookupName', () => {
+	it('maps the gRPC name record target address', async () => {
+		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
+		const signal = AbortSignal.timeout(1_000);
+		const lookupName = vi.fn(() =>
+			Promise.resolve({ response: { record: { targetAddress: address } } }),
+		);
+		client.nameService.lookupName = lookupName as never;
+
+		await expect(client.lookupName({ name, signal })).resolves.toEqual({ address });
+		expect(lookupName).toHaveBeenCalledWith({ name }, { abort: signal });
+	});
+
+	it.each([
+		new RpcError('not found', 'NOT_FOUND'),
+		new RpcError('name has expired', 'RESOURCE_EXHAUSTED'),
+	])('maps absent gRPC names to null ($code)', async (error) => {
+		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
+		client.nameService.lookupName = (() => Promise.reject(error)) as never;
+
+		await expect(client.core.lookupName({ name })).resolves.toEqual({ address: null });
+	});
+
+	it.each([
+		new RpcError('invalid domain', 'INVALID_ARGUMENT'),
+		new RpcError('quota exceeded', 'RESOURCE_EXHAUSTED'),
+	])('preserves other gRPC errors ($code)', async (error) => {
+		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
+		client.nameService.lookupName = (() => Promise.reject(error)) as never;
+
+		await expect(client.core.lookupName({ name })).rejects.toBe(error);
+	});
+
+	it.each([address, null])('maps GraphQL address results (%s)', async (resolvedAddress) => {
+		let requestInit: RequestInit | undefined;
+		const fetch: typeof globalThis.fetch = async (_input, init) => {
+			requestInit = init;
+			return Response.json({
+				data: {
+					address: resolvedAddress ? { address: resolvedAddress } : null,
+				},
+			});
+		};
+		const client = new SuiGraphQLClient({
+			url: 'http://localhost/graphql',
+			network: 'mainnet',
+			fetch,
+		});
+
+		await expect(client.lookupName({ name })).resolves.toEqual({ address: resolvedAddress });
+		expect(JSON.parse(String(requestInit?.body))).toMatchObject({
+			variables: { name },
+		});
+	});
+
+	it.each([address, null])('maps JSON-RPC address results (%s)', async (resolvedAddress) => {
+		let requestInput: JsonRpcTransportRequestOptions | undefined;
+		const transport: JsonRpcTransport = {
+			async request<T>(input: JsonRpcTransportRequestOptions) {
+				requestInput = input;
+				return resolvedAddress as T;
+			},
+		};
+		const client = new SuiJsonRpcClient({ network: 'mainnet', transport });
+
+		await expect(client.core.lookupName({ name })).resolves.toEqual({ address: resolvedAddress });
+		expect(requestInput).toEqual({
+			method: 'suix_resolveNameServiceAddress',
+			params: [name],
+			signal: undefined,
+		});
+	});
+});

--- a/packages/sui/test/unit/client/name-service.test.ts
+++ b/packages/sui/test/unit/client/name-service.test.ts
@@ -15,7 +15,7 @@ import { SuiJsonRpcClient } from '../../../src/jsonRpc/index.js';
 const name = '@mysten';
 const address = '0x123';
 
-describe('lookupName', () => {
+describe('resolveNameServiceAddress', () => {
 	it('maps the gRPC name record target address', async () => {
 		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
 		const signal = AbortSignal.timeout(1_000);
@@ -24,28 +24,32 @@ describe('lookupName', () => {
 		);
 		client.nameService.lookupName = lookupName as never;
 
-		await expect(client.lookupName({ name, signal })).resolves.toEqual({ address });
+		await expect(client.resolveNameServiceAddress({ name, signal })).resolves.toEqual({ address });
 		expect(lookupName).toHaveBeenCalledWith({ name }, { abort: signal });
 	});
 
 	it.each([
 		new RpcError('not found', 'NOT_FOUND'),
 		new RpcError('name has expired', 'RESOURCE_EXHAUSTED'),
+		new RpcError('name%20has%20expired', 'RESOURCE_EXHAUSTED'),
 	])('maps absent gRPC names to null ($code)', async (error) => {
 		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
 		client.nameService.lookupName = (() => Promise.reject(error)) as never;
 
-		await expect(client.core.lookupName({ name })).resolves.toEqual({ address: null });
+		await expect(client.core.resolveNameServiceAddress({ name })).resolves.toEqual({
+			address: null,
+		});
 	});
 
 	it.each([
 		new RpcError('invalid domain', 'INVALID_ARGUMENT'),
 		new RpcError('quota exceeded', 'RESOURCE_EXHAUSTED'),
+		new RpcError('%invalid-encoding', 'RESOURCE_EXHAUSTED'),
 	])('preserves other gRPC errors ($code)', async (error) => {
 		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
 		client.nameService.lookupName = (() => Promise.reject(error)) as never;
 
-		await expect(client.core.lookupName({ name })).rejects.toBe(error);
+		await expect(client.core.resolveNameServiceAddress({ name })).rejects.toBe(error);
 	});
 
 	it.each([address, null])('maps GraphQL address results (%s)', async (resolvedAddress) => {
@@ -64,7 +68,9 @@ describe('lookupName', () => {
 			fetch,
 		});
 
-		await expect(client.lookupName({ name })).resolves.toEqual({ address: resolvedAddress });
+		await expect(client.resolveNameServiceAddress({ name })).resolves.toEqual({
+			address: resolvedAddress,
+		});
 		expect(JSON.parse(String(requestInit?.body))).toMatchObject({
 			variables: { name },
 		});
@@ -80,7 +86,9 @@ describe('lookupName', () => {
 		};
 		const client = new SuiJsonRpcClient({ network: 'mainnet', transport });
 
-		await expect(client.core.lookupName({ name })).resolves.toEqual({ address: resolvedAddress });
+		await expect(client.core.resolveNameServiceAddress({ name })).resolves.toEqual({
+			address: resolvedAddress,
+		});
 		expect(requestInput).toEqual({
 			method: 'suix_resolveNameServiceAddress',
 			params: [name],

--- a/packages/suins/README.md
+++ b/packages/suins/README.md
@@ -1,8 +1,8 @@
 # SuiNS SDK
 
 > Name resolution is available directly from `SuiGrpcClient` and `SuiGraphQLClient`. Use
-> `lookupName` for name-to-address resolution and `defaultNameServiceName` for address-to-name
-> resolution.
+> `resolveNameServiceAddress` for name-to-address resolution and `defaultNameServiceName` for
+> address-to-name resolution.
 
 SuiNS SDK is a convenient wrapper for querying detailed name records and building transactions for
 the Name Service.

--- a/packages/suins/README.md
+++ b/packages/suins/README.md
@@ -1,9 +1,10 @@
 # SuiNS SDK
 
-> Note 1: You do not need to use the SDK for name resolution (name -> address, address -> name).
-> That is already covered by JSONRPC & GraphQL.
+> Name resolution is available directly from `SuiGrpcClient` and `SuiGraphQLClient`. Use
+> `lookupName` for name-to-address resolution and `defaultNameServiceName` for address-to-name
+> resolution.
 
-SuiNS SDK is a convenient wrapper for querying more detailed information and building transactions
-towards the Name Service.
+SuiNS SDK is a convenient wrapper for querying detailed name records and building transactions for
+the Name Service.
 
 You can find our docs [by clicking here](https://docs.suins.io).

--- a/packages/wallet-sdk/test/mocks/MockSuiClient.ts
+++ b/packages/wallet-sdk/test/mocks/MockSuiClient.ts
@@ -341,6 +341,12 @@ export class MockSuiClient extends CoreClient {
 		throw new Error('defaultNameServiceName not implemented in MockSuiClient');
 	}
 
+	async resolveNameServiceAddress(
+		_options: SuiClientTypes.ResolveNameServiceAddressOptions,
+	): Promise<SuiClientTypes.ResolveNameServiceAddressResponse> {
+		throw new Error('resolveNameServiceAddress not implemented in MockSuiClient');
+	}
+
 	async listTransactions<Include extends SuiClientTypes.TransactionInclude = object>(
 		_options: SuiClientTypes.ListTransactionsOptions<Include>,
 	): Promise<SuiClientTypes.ListTransactionsResponse<Include>> {


### PR DESCRIPTION
## Description

Add `resolveNameServiceAddress({ name })` to the transport-agnostic Core API and expose the same SDK-shaped method on `SuiGrpcClient` and `SuiGraphQLClient`.

The response is `{ address: string | null }`. It intentionally projects gRPC `NameRecord.targetAddress` rather than exposing the complete transport-specific record. Missing, expired, and targetless names resolve to `null` across transports. Other errors still reject.

The gRPC service currently reports a missing record as `NOT_FOUND`, but reports an expired name as `RESOURCE_EXHAUSTED` with the message `name has expired`. The Core mapper normalizes only that exact decoded expired-name status; unrelated capacity failures remain visible.

The implementation maps:

- gRPC `NameService.LookupName`
- GraphQL `address(name:)`
- legacy JSON-RPC `suix_resolveNameServiceAddress` through `client.core`

Update the Core/client/migration documentation and replace the stale SuiNS README note with the concrete modern client methods. Also refresh the outdated GraphQL reverse-lookup example while touching that page.

Closes #1187.

## Test plan

- `pnpm turbo build --filter=@mysten/sui`
- `pnpm --filter @mysten/sui test`
- `pnpm --filter @mysten/sui vitest run --config test/e2e/vitest.config.mts test/e2e/clients/core/name-service.test.ts`
- `pnpm --filter @mysten/docs validate-docs`
- `pnpm --filter @mysten/docs build:docs`
- `pnpm --filter @mysten/sui oxlint:check`
- Prettier check for all changed files
- Live Mainnet smoke test against gRPC and GraphQL, including missing, expired, and invalid names

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
