### PR TITLE
fix(hashi): cap the withdrawalFees fee bound at a realistic ceiling

### DIFF
--- a/.changeset/fix-hashi-withdrawal-fee-estimate-cap.md
+++ b/.changeset/fix-hashi-withdrawal-fee-estimate-cap.md
@@ -1,0 +1,13 @@
+---
+'@mysten/hashi': patch
+---
+
+Fix `view.withdrawalFees()` reporting an absurd `worstCaseNetworkFeeSats` when governance raises
+`bitcoin_withdrawal_minimum` as a policy throttle. The value mirrors the on-chain per-user fee
+budget (`bitcoin_withdrawal_minimum - 546`), so a temporary 10 BTC minimum turned the "worst-case
+network fee" into ~10 BTC — UIs subtracting it from a 10.84 BTC withdrawal displayed "~0.84 BTC"
+as the estimated payout. The fee-estimation API now caps the reported bound at 100,000 sats, a
+ceiling derived from validator consensus limits (5x the fleet's 30 sat/vB feerate clamp on a
+generous per-request weight share), so it stays safe to subtract for net-of-fee display. The raw
+protocol budget is still available unchanged via `view.all().worstCaseNetworkFee`, now documented
+as a budget rather than a fee expectation.

--- a/packages/hashi/src/client.ts
+++ b/packages/hashi/src/client.ts
@@ -30,6 +30,7 @@ import {
 	GUARDIAN_BTC_PUBLIC_KEY_LEN,
 	GUARDIAN_PUBLIC_KEY_LEN,
 	NETWORK_CONFIG,
+	WORST_CASE_NETWORK_FEE_CEILING_SATS,
 } from './constants.js';
 import type { AmountViolation } from './errors.js';
 import {
@@ -1056,7 +1057,15 @@ export class HashiClient {
 			}
 
 			return {
-				worstCaseNetworkFeeSats: snap.worstCaseNetworkFee,
+				// The raw on-chain budget tracks `bitcoin_withdrawal_minimum`, so it
+				// explodes when governance raises the minimum as a policy throttle
+				// (a 10 BTC minimum implies a ~10 BTC "fee"). Cap it at the ceiling
+				// derived from validator consensus limits so this stays a usable
+				// display bound — see WORST_CASE_NETWORK_FEE_CEILING_SATS.
+				worstCaseNetworkFeeSats:
+					snap.worstCaseNetworkFee < WORST_CASE_NETWORK_FEE_CEILING_SATS
+						? snap.worstCaseNetworkFee
+						: WORST_CASE_NETWORK_FEE_CEILING_SATS,
 				withdrawalMinimumSats: snap.bitcoinWithdrawalMinimum,
 				gasEstimateMist,
 			};

--- a/packages/hashi/src/constants.ts
+++ b/packages/hashi/src/constants.ts
@@ -31,6 +31,28 @@ export const NUMS_KEY = new Uint8Array([
 export const DUST_RELAY_MIN_VALUE = 546n;
 
 /**
+ * Ceiling on the per-withdrawal network fee reported by
+ * `view.withdrawalFees()`, in satoshis.
+ *
+ * The protocol's own per-user fee budget (`worst_case_network_fee` in
+ * `hashi::btc_config`) is defined as `bitcoin_withdrawal_minimum - 546`, so it
+ * tracks the withdrawal minimum. That makes it a sound on-chain bound but a
+ * meaningless fee *estimate* whenever governance raises the minimum as a
+ * policy throttle (e.g. a 10 BTC minimum implies a "worst-case fee" of
+ * ~10 BTC, and UIs subtracting it display nonsense).
+ *
+ * What the committee can actually deduct is governed by validator consensus
+ * rules: the leader clamps the feerate to 30 sat/vB
+ * (`DEFAULT_HIGH_FEE_RATE_THRESHOLD` in the validator's `utxo_pool`), and
+ * validators reject any transaction whose total fee exceeds 5x the estimate
+ * at that clamped rate. 100,000 sats is 5x the clamp applied to a ~666 vB
+ * per-request weight share — several times anything the fleet's coin
+ * selection produces in practice, while five orders of magnitude tighter
+ * than the degenerate on-chain budget.
+ */
+export const WORST_CASE_NETWORK_FEE_CEILING_SATS = 100_000n;
+
+/**
  * Length of the Guardian's Ed25519 attestation public key, in bytes. Matches
  * `GUARDIAN_PUBLIC_KEY_LEN` in `hashi::config`.
  */

--- a/packages/hashi/src/types.ts
+++ b/packages/hashi/src/types.ts
@@ -34,8 +34,13 @@ export interface HashiClientOptions<Name = string> {
  * by `HashiClient.view.all()`. Fields are `readonly` because the snapshot is
  * a point-in-time read from chain — mutating it locally cannot change on-chain
  * state. `depositMinimum` is a Move-side alias of `bitcoinDepositMinimum`;
- * `worstCaseNetworkFee` is derived as `bitcoinWithdrawalMinimum - 546` (the
- * dust relay floor) and is always ≥ 1.
+ * `worstCaseNetworkFee` mirrors the on-chain `worst_case_network_fee()`
+ * function: `bitcoinWithdrawalMinimum - 546` (the dust relay floor), always
+ * ≥ 1. It is the protocol's per-user miner-fee *budget* (the bound the batch
+ * verifier enforces), NOT a realistic fee expectation — because it tracks the
+ * withdrawal minimum, it balloons whenever governance raises the minimum as a
+ * policy throttle. For display, prefer `view.withdrawalFees()`, which caps
+ * this at a ceiling derived from validator consensus limits.
  *
  * The three `guardian*` fields are `null` on deployments where the guardian
  * config hasn't been written yet (pre-feature chains or in-flight rollouts).
@@ -254,7 +259,14 @@ export interface DepositFees {
 }
 
 export interface WithdrawalFees {
-	/** Worst-case BTC network fee in satoshis. */
+	/**
+	 * Worst-case BTC network fee in satoshis: the protocol's per-user fee
+	 * budget (`worst_case_network_fee` on-chain), capped at
+	 * `WORST_CASE_NETWORK_FEE_CEILING_SATS` so it remains a usable display
+	 * bound when governance raises the withdrawal minimum as a policy
+	 * throttle. Safe to subtract from a withdrawal amount for a net-of-fee
+	 * estimate.
+	 */
 	readonly worstCaseNetworkFeeSats: bigint;
 	/** Minimum withdrawal amount in satoshis. */
 	readonly withdrawalMinimumSats: bigint;

--- a/packages/hashi/test/unit/client.test.ts
+++ b/packages/hashi/test/unit/client.test.ts
@@ -1907,6 +1907,27 @@ describe('HashiClient', () => {
 			// (2000 + 1000 - 500) * 120 / 100 = 3000
 			expect(result.gasEstimateMist).toBe(3000n);
 		});
+
+		it('caps the fee bound when the withdrawal minimum is raised as a policy throttle', async () => {
+			// A 10 BTC minimum makes the on-chain fee budget (min - 546)
+			// ~10 BTC — subtracting THAT from a 10.84 BTC withdrawal displayed
+			// "~0.84 BTC" in production. The estimation API must cap it.
+			const throttledConfig = [
+				...WELL_FORMED_CONFIG.filter((e) => e.key !== 'bitcoin_withdrawal_minimum'),
+				{ key: 'bitcoin_withdrawal_minimum', value: { $kind: 'U64', U64: '1000000000' } },
+			];
+			mockHashiWithConfig(throttledConfig);
+
+			const result = await client.hashi.view.withdrawalFees();
+			expect(result.withdrawalMinimumSats).toBe(1_000_000_000n);
+			expect(result.worstCaseNetworkFeeSats).toBe(100_000n);
+
+			// The uncapped protocol budget stays visible on the raw snapshot
+			// (each view call fetches once, so re-arm the single-shot mock).
+			mockHashiWithConfig(throttledConfig);
+			const snap = await client.hashi.view.all();
+			expect(snap.worstCaseNetworkFee).toBe(1_000_000_000n - 546n);
+		});
 	});
 
 	describe('waitForDeposit', () => {


### PR DESCRIPTION
## Description

`view.withdrawalFees()` returns `worstCaseNetworkFeeSats`, which was the raw on-chain per-user fee budget: `bitcoin_withdrawal_minimum − 546` (mirroring `worst_case_network_fee()` in `hashi::btc_config`). Because that budget tracks the withdrawal minimum, raising the minimum as a governance policy throttle balloons the "worst-case fee" with it. On testnet the temporary 10 BTC minimum produced a **999,999,454-sat** bound, and the frontend's net-of-fee display rendered a user's 10.84 BTC withdrawal as **"~0.84 BTC"** ([reported](https://testnet.hashi.sui.io/withdraw/AkX9PCx8dWXxGWuUPrwm3ztgBrzRv5DJvqjhPq1DraT5) — the on-chain `btc_amount` is 1,084,292,855 sats; the displayed value is exactly `amount − (minimum − 546)`).

This PR caps the bound reported by the fee-estimation API at a new internal constant `WORST_CASE_NETWORK_FEE_CEILING_SATS = 100,000`, derived from validator consensus limits: leaders clamp feerates to 30 sat/vB (`DEFAULT_HIGH_FEE_RATE_THRESHOLD` in the validator `utxo_pool`), and validators reject total fees above 5× the estimate at the clamped rate. Measured real deductions on testnet are ~7,000 sats, so the ceiling only binds in the degenerate regime (minimum > 100,546 sats).

Deliberately unchanged: `view.all().worstCaseNetworkFee` still mirrors the on-chain function exactly — the Move batch verifier enforces `per_user_miner_fee <= worst_case_network_fee` (`withdrawal_queue.move`), and the integration payout test correctly uses that uncapped bound. Docs on both fields now distinguish "protocol fee budget" from "fee expectation".

## Test plan

- New unit test: a policy-throttled config (`bitcoin_withdrawal_minimum = 1e9`) → `withdrawalFees()` returns the 100,000-sat ceiling while `view.all()` still exposes the uncapped budget.
- Existing tests unchanged and passing: the default 30k-min config stays below the ceiling, so `30_000n − 546n` assertions are unaffected; integration `view`/`withdrawal-payout` tests assert on the snapshot field, which is untouched.
- `pnpm turbo build --filter @mysten/hashi` + `pnpm --filter @mysten/hashi test` (typecheck + 186 unit tests) + `lint` all green.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.