### PR TITLE
fix(codegen): resolve MVR packages for on-chain summaries

### DIFF
--- a/.changeset/tidy-lions-resolve.md
+++ b/.changeset/tidy-lions-resolve.md
@@ -1,0 +1,6 @@
+---
+'@mysten/codegen': patch
+---
+
+Resolve MVR package names and use the configured network when generating summaries for on-chain
+packages.

--- a/.changeset/tidy-lions-resolve.md
+++ b/.changeset/tidy-lions-resolve.md
@@ -2,5 +2,5 @@
 '@mysten/codegen': minor
 ---
 
-Resolve MVR package names and add configurable fullnode URLs for generating summaries from on-chain
-packages.
+Resolve MVR package names, preserve named package and type identifiers in generated code, support
+separate source package IDs, and add configurable fullnode URLs for on-chain package summaries.

--- a/.changeset/tidy-lions-resolve.md
+++ b/.changeset/tidy-lions-resolve.md
@@ -1,6 +1,6 @@
 ---
-'@mysten/codegen': patch
+'@mysten/codegen': minor
 ---
 
-Resolve MVR package names and use the configured network when generating summaries for on-chain
+Resolve MVR package names and add configurable fullnode URLs for generating summaries from on-chain
 packages.

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -50,8 +50,19 @@ const config: SuiCodegenConfig = {
 ```
 
 `fullnodeUrls` can override the default mainnet or testnet fullnode used to fetch summaries for
-on-chain packages. It does not change the configured `package` value used in generated code. Local
-or unpublished MVR names can still be resolved at runtime through client overrides.
+on-chain packages. It does not change the configured `package` value used in generated code.
+
+To generate a portable unpublished name from an on-chain package, configure the generated identity
+and summary source separately:
+
+```ts
+{
+	package: '@local-pkg/your-package',
+	sourcePackageId: YOUR_TESTNET_PACKAGE_ID,
+	packageName: 'your-package',
+	network: 'testnet',
+}
+```
 
 The `package` field should be the MVR name for your move package. If you have not registered your
 package on MVR yet, you can use the `@local-pkg` scope, and set up an override in your
@@ -105,10 +116,18 @@ const client = new SuiGrpcClient({
 			packages: {
 				'@local-pkg/your-package': YOUR_PACKAGE_ID,
 			},
+			types: {
+				'@local-pkg/your-package::module::YourType': '0xTYPE_ORIGIN::module::YourType',
+			},
 		},
 	},
 });
 ```
+
+Package overrides select the package version used for Move calls. Named types are resolved
+separately because their introducing package can differ after an upgrade. Add a first-level `types`
+override for each local type used in transaction type arguments, query filters, or `resolveTypeTag`.
+Registered MVR names resolve both automatically.
 
 If you are using `dapp-kit-core`, you can configure package overrides when creating your dApp Kit
 instance:
@@ -124,6 +143,7 @@ const GRPC_URLS = {
 const PACKAGE_IDS = {
 	testnet: {
 		yourPackage: YOUR_TESTNET_PACKAGE_ID,
+		yourType: '0xTESTNET_TYPE_ORIGIN::module::YourType',
 	},
 };
 
@@ -137,6 +157,9 @@ const dAppKit = createDAppKit({
 				overrides: {
 					packages: {
 						'@local-pkg/your-package': PACKAGE_IDS[network].yourPackage,
+					},
+					types: {
+						'@local-pkg/your-package::module::YourType': PACKAGE_IDS[network].yourType,
 					},
 				},
 			},

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -30,6 +30,29 @@ const config: SuiCodegenConfig = {
 export default config;
 ```
 
+To generate from an on-chain package, provide its package ID or published MVR name and network. You
+can also override the default fullnode URL for either supported network:
+
+```ts
+const config: SuiCodegenConfig = {
+	output: './src/generated',
+	fullnodeUrls: {
+		testnet: 'https://your-testnet-fullnode.example.com',
+	},
+	packages: [
+		{
+			package: '@deepbook/core',
+			packageName: 'deepbook',
+			network: 'testnet',
+		},
+	],
+};
+```
+
+`fullnodeUrls` can override the default mainnet or testnet fullnode used to fetch summaries for
+on-chain packages. It does not change the configured `package` value used in generated code. Local
+or unpublished MVR names can still be resolved at runtime through client overrides.
+
 The `package` field should be the MVR name for your move package. If you have not registered your
 package on MVR yet, you can use the `@local-pkg` scope, and set up an override in your
 `SuiGrpcClient` to resolve it to the correct address.

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -7,7 +7,7 @@ import { loadConfig, type GenerateBase, type PackageGenerate } from '../../../co
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { isValidNamedPackage, isValidSuiObjectId } from '@mysten/sui/utils';
 import { execFileSync, execSync } from 'node:child_process';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -26,6 +26,7 @@ export interface SubdirCommandFlags {
 export async function resolveOnChainPackageId(
 	packageNameOrId: string,
 	network: 'mainnet' | 'testnet',
+	fullnodeUrl: string,
 ) {
 	if (isValidSuiObjectId(packageNameOrId)) {
 		return packageNameOrId;
@@ -33,7 +34,7 @@ export async function resolveOnChainPackageId(
 
 	const client = new SuiGrpcClient({
 		network,
-		baseUrl: `https://fullnode.${network}.sui.io:443`,
+		baseUrl: fullnodeUrl,
 	});
 	const { package: packageId } = await client.mvr.resolvePackage({ package: packageNameOrId });
 
@@ -42,19 +43,48 @@ export async function resolveOnChainPackageId(
 
 export function getOnChainSummaryArgs(
 	packageId: string,
-	network: 'mainnet' | 'testnet',
+	clientConfig: string,
 	outputDirectory: string,
 ) {
 	return [
 		'move',
+		'--client.config',
+		clientConfig,
 		'--client.env',
-		network,
+		'codegen',
 		'summary',
 		'--package-id',
 		packageId,
 		'--output-directory',
 		outputDirectory,
 	];
+}
+
+export function writeSuiClientConfig(directory: string, fullnodeUrl: string) {
+	const configPath = join(directory, 'client.json');
+	writeFileSync(
+		configPath,
+		JSON.stringify(
+			{
+				keystore: { File: join(directory, 'sui.keystore') },
+				external_keys: null,
+				envs: [
+					{
+						alias: 'codegen',
+						rpc: fullnodeUrl,
+						ws: null,
+						basic_auth: null,
+					},
+				],
+				active_env: 'codegen',
+				active_address: null,
+			},
+			null,
+			2,
+		),
+	);
+
+	return configPath;
 }
 
 export default async function generate(
@@ -124,16 +154,20 @@ export default async function generate(
 		// Generate summaries for on-chain packages using --package-id
 		if (isOnChainPackage) {
 			const packageNameOrId = 'packageId' in pkg && pkg.packageId ? pkg.packageId : pkg.package;
-			const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network);
+			const fullnodeUrl = config.fullnodeUrls[pkg.network];
+			const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network, fullnodeUrl);
 			const tempDir = mkdtempSync(join(tmpdir(), 'sui-codegen-'));
-			console.log(`Generating summary for on-chain package ${packageId} to ${tempDir}`);
+			const summaryDir = join(tempDir, 'summary');
+			mkdirSync(summaryDir);
+			const clientConfig = writeSuiClientConfig(tempDir, fullnodeUrl);
+			console.log(`Generating summary for on-chain package ${packageId} to ${summaryDir}`);
 
-			execFileSync('sui', getOnChainSummaryArgs(packageId, pkg.network, tempDir), {
+			execFileSync('sui', getOnChainSummaryArgs(packageId, clientConfig, summaryDir), {
 				stdio: 'inherit',
 			});
 
 			// Set the path to use the generated summary directory
-			(pkg as { path?: string }).path = tempDir;
+			(pkg as { path?: string }).path = summaryDir;
 		} else if (generateSummaries && pkg.path) {
 			if (!existsSync(pkg.path)) {
 				throw new Error(`Package path does not exist: ${pkg.path}`);

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -115,7 +115,7 @@ export default async function generate(
 							network: flags.network ?? 'testnet',
 							packageName: isValidSuiObjectId(trimmed) ? trimmed : trimmed.split('/')[1],
 							package: trimmed,
-							packageId: isValidSuiObjectId(trimmed) ? trimmed : undefined,
+							sourcePackageId: isValidSuiObjectId(trimmed) ? trimmed : undefined,
 						};
 					} else {
 						return {
@@ -160,8 +160,7 @@ export default async function generate(
 
 	for (const pkg of normalizedPackages) {
 		// Detect on-chain packages: they have 'network' field and no 'path'
-		const isOnChainPackage =
-			('packageId' in pkg && pkg.packageId) || ('network' in pkg && !('path' in pkg));
+		const isOnChainPackage = 'network' in pkg && !('path' in pkg);
 
 		const generatePackage = async (tempDir?: string) => {
 			// Generate summaries for on-chain packages using --package-id
@@ -170,7 +169,8 @@ export default async function generate(
 					throw new Error('Temporary directory is required for on-chain packages');
 				}
 
-				const packageNameOrId = 'packageId' in pkg && pkg.packageId ? pkg.packageId : pkg.package;
+				const packageNameOrId =
+					'sourcePackageId' in pkg && pkg.sourcePackageId ? pkg.sourcePackageId : pkg.package;
 				const fullnodeUrl = config.fullnodeUrls[pkg.network];
 				const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network, fullnodeUrl);
 				const summaryDir = join(tempDir, 'summary');

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -7,7 +7,7 @@ import { loadConfig, type GenerateBase, type PackageGenerate } from '../../../co
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { isValidNamedPackage, isValidSuiObjectId } from '@mysten/sui/utils';
 import { execFileSync, execSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -87,6 +87,18 @@ export function writeSuiClientConfig(directory: string, fullnodeUrl: string) {
 	return configPath;
 }
 
+export async function withTemporaryDirectory<T>(
+	callback: (directory: string) => T | Promise<T>,
+): Promise<T> {
+	const directory = mkdtempSync(join(tmpdir(), 'sui-codegen-'));
+
+	try {
+		return await callback(directory);
+	} finally {
+		rmSync(directory, { recursive: true, force: true });
+	}
+}
+
 export default async function generate(
 	this: LocalContext,
 	flags: SubdirCommandFlags,
@@ -151,74 +163,85 @@ export default async function generate(
 		const isOnChainPackage =
 			('packageId' in pkg && pkg.packageId) || ('network' in pkg && !('path' in pkg));
 
-		// Generate summaries for on-chain packages using --package-id
-		if (isOnChainPackage) {
-			const packageNameOrId = 'packageId' in pkg && pkg.packageId ? pkg.packageId : pkg.package;
-			const fullnodeUrl = config.fullnodeUrls[pkg.network];
-			const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network, fullnodeUrl);
-			const tempDir = mkdtempSync(join(tmpdir(), 'sui-codegen-'));
-			const summaryDir = join(tempDir, 'summary');
-			mkdirSync(summaryDir);
-			const clientConfig = writeSuiClientConfig(tempDir, fullnodeUrl);
-			console.log(`Generating summary for on-chain package ${packageId} to ${summaryDir}`);
-
-			execFileSync('sui', getOnChainSummaryArgs(packageId, clientConfig, summaryDir), {
-				stdio: 'inherit',
-			});
-
-			// Set the path to use the generated summary directory
-			(pkg as { path?: string }).path = summaryDir;
-		} else if (generateSummaries && pkg.path) {
-			if (!existsSync(pkg.path)) {
-				throw new Error(`Package path does not exist: ${pkg.path}`);
-			}
-
-			execSync('sui move summary', {
-				cwd: pkg.path,
-				stdio: 'inherit',
-			});
-		}
-		const importExtension =
-			flags.importExtension === undefined
-				? config.importExtension
-				: flags.importExtension === 'none'
-					? ''
-					: flags.importExtension;
-
-		const pkgWithOverrides = cliGenerate
-			? {
-					...pkg,
-					generate: {
-						...('generate' in pkg ? pkg.generate : {}),
-						...cliGenerate,
-					},
+		const generatePackage = async (tempDir?: string) => {
+			// Generate summaries for on-chain packages using --package-id
+			if (isOnChainPackage) {
+				if (!tempDir) {
+					throw new Error('Temporary directory is required for on-chain packages');
 				}
-			: pkg;
 
-		// Fold deprecated privateMethods into globalGenerate
-		const globalGenerate: GenerateBase | undefined =
-			config.privateMethods && !config.generate?.functions
+				const packageNameOrId = 'packageId' in pkg && pkg.packageId ? pkg.packageId : pkg.package;
+				const fullnodeUrl = config.fullnodeUrls[pkg.network];
+				const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network, fullnodeUrl);
+				const summaryDir = join(tempDir, 'summary');
+				mkdirSync(summaryDir);
+				const clientConfig = writeSuiClientConfig(tempDir, fullnodeUrl);
+				console.log(`Generating summary for on-chain package ${packageId} to ${summaryDir}`);
+
+				execFileSync('sui', getOnChainSummaryArgs(packageId, clientConfig, summaryDir), {
+					stdio: 'inherit',
+				});
+
+				// Set the path to use the generated summary directory
+				(pkg as { path?: string }).path = summaryDir;
+			} else if (generateSummaries && pkg.path) {
+				if (!existsSync(pkg.path)) {
+					throw new Error(`Package path does not exist: ${pkg.path}`);
+				}
+
+				execSync('sui move summary', {
+					cwd: pkg.path,
+					stdio: 'inherit',
+				});
+			}
+			const importExtension =
+				flags.importExtension === undefined
+					? config.importExtension
+					: flags.importExtension === 'none'
+						? ''
+						: flags.importExtension;
+
+			const pkgWithOverrides = cliGenerate
 				? {
-						...config.generate,
-						functions: {
-							private:
-								config.privateMethods === 'all'
-									? true
-									: config.privateMethods === 'none'
-										? false
-										: 'entry',
+						...pkg,
+						generate: {
+							...('generate' in pkg ? pkg.generate : {}),
+							...cliGenerate,
 						},
 					}
-				: config.generate;
+				: pkg;
 
-		await generateFromPackageSummary({
-			package: pkgWithOverrides,
-			prune: flags.noPrune === undefined ? config.prune : !flags.noPrune,
-			outputDir: flags.outputDir ?? config.output,
-			globalGenerate,
-			importExtension,
-			includePhantomTypeParameters: config.includePhantomTypeParameters,
-			errorClass: config.errorClass,
-		});
+			// Fold deprecated privateMethods into globalGenerate
+			const globalGenerate: GenerateBase | undefined =
+				config.privateMethods && !config.generate?.functions
+					? {
+							...config.generate,
+							functions: {
+								private:
+									config.privateMethods === 'all'
+										? true
+										: config.privateMethods === 'none'
+											? false
+											: 'entry',
+							},
+						}
+					: config.generate;
+
+			await generateFromPackageSummary({
+				package: pkgWithOverrides,
+				prune: flags.noPrune === undefined ? config.prune : !flags.noPrune,
+				outputDir: flags.outputDir ?? config.output,
+				globalGenerate,
+				importExtension,
+				includePhantomTypeParameters: config.includePhantomTypeParameters,
+				errorClass: config.errorClass,
+			});
+		};
+
+		if (isOnChainPackage) {
+			await withTemporaryDirectory(generatePackage);
+		} else {
+			await generatePackage();
+		}
 	}
 }

--- a/packages/codegen/src/cli/commands/generate/impl.ts
+++ b/packages/codegen/src/cli/commands/generate/impl.ts
@@ -4,8 +4,9 @@
 import type { LocalContext } from '../../context.js';
 import { generateFromPackageSummary } from '../../../index.js';
 import { loadConfig, type GenerateBase, type PackageGenerate } from '../../../config.js';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { isValidNamedPackage, isValidSuiObjectId } from '@mysten/sui/utils';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -20,6 +21,40 @@ export interface SubdirCommandFlags {
 	noTypes?: boolean;
 	noFunctions?: boolean;
 	private?: 'none' | 'entry' | 'all';
+}
+
+export async function resolveOnChainPackageId(
+	packageNameOrId: string,
+	network: 'mainnet' | 'testnet',
+) {
+	if (isValidSuiObjectId(packageNameOrId)) {
+		return packageNameOrId;
+	}
+
+	const client = new SuiGrpcClient({
+		network,
+		baseUrl: `https://fullnode.${network}.sui.io:443`,
+	});
+	const { package: packageId } = await client.mvr.resolvePackage({ package: packageNameOrId });
+
+	return packageId;
+}
+
+export function getOnChainSummaryArgs(
+	packageId: string,
+	network: 'mainnet' | 'testnet',
+	outputDirectory: string,
+) {
+	return [
+		'move',
+		'--client.env',
+		network,
+		'summary',
+		'--package-id',
+		packageId,
+		'--output-directory',
+		outputDirectory,
+	];
 }
 
 export default async function generate(
@@ -88,11 +123,12 @@ export default async function generate(
 
 		// Generate summaries for on-chain packages using --package-id
 		if (isOnChainPackage) {
-			const packageId = 'packageId' in pkg ? pkg.packageId : pkg.package;
+			const packageNameOrId = 'packageId' in pkg && pkg.packageId ? pkg.packageId : pkg.package;
+			const packageId = await resolveOnChainPackageId(packageNameOrId, pkg.network);
 			const tempDir = mkdtempSync(join(tmpdir(), 'sui-codegen-'));
 			console.log(`Generating summary for on-chain package ${packageId} to ${tempDir}`);
 
-			execSync(`sui move summary --package-id ${packageId} --output-directory ${tempDir}`, {
+			execFileSync('sui', getOnChainSummaryArgs(packageId, pkg.network, tempDir), {
 				stdio: 'inherit',
 			});
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -63,6 +63,16 @@ export const packageConfigSchema = z.union([onChainPackageSchema, localPackageSc
 export const importExtensionSchema = z.union([z.literal('.js'), z.literal('.ts'), z.literal('')]);
 export type ImportExtension = z.infer<typeof importExtensionSchema>;
 
+export const DEFAULT_FULLNODE_URLS = {
+	mainnet: 'https://fullnode.mainnet.sui.io:443',
+	testnet: 'https://fullnode.testnet.sui.io:443',
+};
+
+export const fullnodeUrlsSchema = z.object({
+	mainnet: z.string().url().default(DEFAULT_FULLNODE_URLS.mainnet),
+	testnet: z.string().url().default(DEFAULT_FULLNODE_URLS.testnet),
+});
+
 export type GenerateBase = z.infer<typeof globalGenerateSchema>;
 export type PackageGenerate = z.infer<typeof packageGenerateSchema>;
 export type FunctionsOption = z.infer<typeof functionsOptionSchema>;
@@ -88,6 +98,8 @@ export const configSchema = z.object({
 	privateMethods: z.union([z.literal('none'), z.literal('entry'), z.literal('all')]).optional(),
 	importExtension: importExtensionSchema.optional().default('.js'),
 	includePhantomTypeParameters: z.boolean().optional().default(false),
+	/** Fullnode URLs used to fetch summaries for on-chain packages. */
+	fullnodeUrls: fullnodeUrlsSchema.optional().default(DEFAULT_FULLNODE_URLS),
 	/**
 	 * Custom error class for `normalizeMoveArguments` in the generated `utils/index.ts`.
 	 * Defaults to the built-in `Error`.
@@ -112,6 +124,7 @@ export async function loadConfig(): Promise<ParsedSuiCodegenConfig> {
 			generateSummaries: true,
 			importExtension: '.js',
 			includePhantomTypeParameters: false,
+			fullnodeUrls: DEFAULT_FULLNODE_URLS,
 		};
 	}
 

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -68,9 +68,16 @@ export const DEFAULT_FULLNODE_URLS = {
 	testnet: 'https://fullnode.testnet.sui.io:443',
 };
 
+const fullnodeUrlSchema = z
+	.string()
+	.url()
+	.refine((url) => ['http:', 'https:'].includes(new URL(url).protocol), {
+		message: 'Fullnode URL must use HTTP or HTTPS',
+	});
+
 export const fullnodeUrlsSchema = z.object({
-	mainnet: z.string().url().default(DEFAULT_FULLNODE_URLS.mainnet),
-	testnet: z.string().url().default(DEFAULT_FULLNODE_URLS.testnet),
+	mainnet: fullnodeUrlSchema.default(DEFAULT_FULLNODE_URLS.mainnet),
+	testnet: fullnodeUrlSchema.default(DEFAULT_FULLNODE_URLS.testnet),
 });
 
 export type GenerateBase = z.infer<typeof globalGenerateSchema>;

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidNamedPackage, isValidSuiObjectId } from '@mysten/sui/utils';
+import { isValidNamedPackage, isValidSuiObjectId, normalizeSuiObjectId } from '@mysten/sui/utils';
 import { cosmiconfig } from 'cosmiconfig';
 import * as z from 'zod/v4';
 
@@ -41,19 +41,33 @@ export const packageGenerateSchema = globalGenerateSchema.extend({
 		.optional(),
 });
 
-export const onChainPackageSchema = z.object({
-	package: z.string().refine((name) => isValidNamedPackage(name) || isValidSuiObjectId(name), {
-		message: 'Invalid package name or package ID',
-	}),
-	sourcePackageId: z
-		.string()
-		.refine((id) => isValidSuiObjectId(id), { message: 'Invalid source package ID' })
-		.optional(),
-	packageName: z.string(),
-	path: z.never().optional(),
-	network: z.enum(['mainnet', 'testnet']),
-	generate: packageGenerateSchema.optional(),
-});
+export const onChainPackageSchema = z
+	.object({
+		package: z.string().refine((name) => isValidNamedPackage(name) || isValidSuiObjectId(name), {
+			message: 'Invalid package name or package ID',
+		}),
+		sourcePackageId: z
+			.string()
+			.refine((id) => isValidSuiObjectId(id), { message: 'Invalid source package ID' })
+			.optional(),
+		packageName: z.string(),
+		path: z.never().optional(),
+		network: z.enum(['mainnet', 'testnet']),
+		generate: packageGenerateSchema.optional(),
+	})
+	.superRefine((config, context) => {
+		if (
+			config.sourcePackageId &&
+			isValidSuiObjectId(config.package) &&
+			normalizeSuiObjectId(config.package) !== normalizeSuiObjectId(config.sourcePackageId)
+		) {
+			context.addIssue({
+				code: 'custom',
+				path: ['sourcePackageId'],
+				message: 'sourcePackageId must match package when package is a package ID',
+			});
+		}
+	});
 
 export const localPackageSchema = z.object({
 	path: z.string(),

--- a/packages/codegen/src/config.ts
+++ b/packages/codegen/src/config.ts
@@ -45,6 +45,10 @@ export const onChainPackageSchema = z.object({
 	package: z.string().refine((name) => isValidNamedPackage(name) || isValidSuiObjectId(name), {
 		message: 'Invalid package name or package ID',
 	}),
+	sourcePackageId: z
+		.string()
+		.refine((id) => isValidSuiObjectId(id), { message: 'Invalid source package ID' })
+		.optional(),
 	packageName: z.string(),
 	path: z.never().optional(),
 	network: z.enum(['mainnet', 'testnet']),

--- a/packages/codegen/src/move-module-builder.ts
+++ b/packages/codegen/src/move-module-builder.ts
@@ -106,22 +106,31 @@ export class MoveModuleBuilder extends FileBuilder {
 		return this.registry.resolveAddress(address);
 	}
 
+	#hasNamedPackage() {
+		return Boolean(this.#mvrNameOrAddress && !isValidSuiObjectId(this.#mvrNameOrAddress));
+	}
+
 	#getModuleTypeName() {
 		const resolvedAddress = this.#resolveAddress(this.summary.id.address);
 		if (resolvedAddress === SUI_FRAMEWORK_ADDRESS) {
 			return '0x2';
 		} else if (resolvedAddress === SUI_SYSTEM_ADDRESS) {
 			return '0x3';
+		} else if (this.#hasNamedPackage()) {
+			return this.#mvrNameOrAddress!;
 		} else if (this.#rootPackageId) {
 			return this.#rootPackageId;
-		} else if (this.#mvrNameOrAddress && !isValidSuiObjectId(this.#mvrNameOrAddress)) {
-			return this.#mvrNameOrAddress;
 		} else {
 			return this.summary.id.address;
 		}
 	}
 
 	#getTypePrefix(datatypeName: string): string | null {
+		// MVR resolves named types independently from package call targets, so keep every type owned by
+		// a named package portable across networks and upgrades. Concrete type origins are only emitted
+		// when generation was explicitly pinned to a package ID.
+		if (this.#hasNamedPackage()) return null;
+
 		const originPackageId = this.#typeOrigins?.[datatypeName];
 		if (originPackageId === undefined) return null;
 		if (this.#resolveAddress(originPackageId) === this.#resolveAddress(this.summary.id.address)) {

--- a/packages/codegen/tests/cli.test.ts
+++ b/packages/codegen/tests/cli.test.ts
@@ -87,28 +87,32 @@ describe('CLI', () => {
 	});
 
 	describe('config invocation', () => {
-		it('preserves unpublished MVR names for runtime client overrides', async () => {
-			const dir = await mkdtemp(join(tmpdir(), 'codegen-cli-config-'));
-			try {
-				await cp(FIXTURE, join(dir, 'testpkg'), { recursive: true });
-				await writeFile(
-					join(dir, '.sui-codegenrc.json'),
-					JSON.stringify({
-						output: './out',
-						generateSummaries: false,
-						fullnodeUrls: { testnet: 'https://custom.testnet.example' },
-						packages: [{ package: '@local-pkg/testpkg', path: './testpkg' }],
-					}),
-				);
+		it(
+			'preserves unpublished MVR names for runtime client overrides',
+			{ timeout: 30_000 },
+			async () => {
+				const dir = await mkdtemp(join(tmpdir(), 'codegen-cli-config-'));
+				try {
+					await cp(FIXTURE, join(dir, 'testpkg'), { recursive: true });
+					await writeFile(
+						join(dir, '.sui-codegenrc.json'),
+						JSON.stringify({
+							output: './out',
+							generateSummaries: false,
+							fullnodeUrls: { testnet: 'https://custom.testnet.example' },
+							packages: [{ package: '@local-pkg/testpkg', path: './testpkg' }],
+						}),
+					);
 
-				const { code, stderr } = run(['generate'], dir);
-				expect(code, `stderr: ${stderr}`).toBe(0);
+					const { code, stderr } = run(['generate'], dir);
+					expect(code, `stderr: ${stderr}`).toBe(0);
 
-				const counter = await readFile(join(dir, 'out', 'testpkg', 'counter.ts'), 'utf-8');
-				expect(counter).toContain("options.package ?? '@local-pkg/testpkg'");
-			} finally {
-				await rm(dir, { recursive: true, force: true });
-			}
-		});
+					const counter = await readFile(join(dir, 'out', 'testpkg', 'counter.ts'), 'utf-8');
+					expect(counter).toContain("options.package ?? '@local-pkg/testpkg'");
+				} finally {
+					await rm(dir, { recursive: true, force: true });
+				}
+			},
+		);
 	});
 });

--- a/packages/codegen/tests/cli.test.ts
+++ b/packages/codegen/tests/cli.test.ts
@@ -85,4 +85,30 @@ describe('CLI', () => {
 			}
 		});
 	});
+
+	describe('config invocation', () => {
+		it('preserves unpublished MVR names for runtime client overrides', async () => {
+			const dir = await mkdtemp(join(tmpdir(), 'codegen-cli-config-'));
+			try {
+				await cp(FIXTURE, join(dir, 'testpkg'), { recursive: true });
+				await writeFile(
+					join(dir, '.sui-codegenrc.json'),
+					JSON.stringify({
+						output: './out',
+						generateSummaries: false,
+						fullnodeUrls: { testnet: 'https://custom.testnet.example' },
+						packages: [{ package: '@local-pkg/testpkg', path: './testpkg' }],
+					}),
+				);
+
+				const { code, stderr } = run(['generate'], dir);
+				expect(code, `stderr: ${stderr}`).toBe(0);
+
+				const counter = await readFile(join(dir, 'out', 'testpkg', 'counter.ts'), 'utf-8');
+				expect(counter).toContain("options.package ?? '@local-pkg/testpkg'");
+			} finally {
+				await rm(dir, { recursive: true, force: true });
+			}
+		});
+	});
 });

--- a/packages/codegen/tests/codegen-output.test.ts
+++ b/packages/codegen/tests/codegen-output.test.ts
@@ -1118,10 +1118,11 @@ describe('typeOrigins (upgraded packages)', () => {
 		const builder = await MoveModuleBuilder.fromSummaryFile(
 			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
 			new ModuleRegistry(ADDRESS_MAPPINGS),
-			'@test/testpkg',
+			ORIGIN_V2,
 			'.js',
 			false,
 			{ Counter: ORIGIN_V1, AdminCap: ORIGIN_V1 },
+			ORIGIN_V2,
 		);
 		builder.includeTypes(['Counter', 'AdminCap']);
 		const output = await render(builder, { types: true, functions: false });
@@ -1139,16 +1140,17 @@ describe('typeOrigins (upgraded packages)', () => {
 		const builder = await MoveModuleBuilder.fromSummaryFile(
 			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
 			new ModuleRegistry(ADDRESS_MAPPINGS),
-			'@test/testpkg',
+			ORIGIN_V2,
 			'.js',
 			false,
 			{ AdminCap: ORIGIN_V1 },
+			ORIGIN_V2,
 		);
 		builder.includeTypes(['Counter', 'AdminCap']);
 		const output = await render(builder, { types: true, functions: false });
 		const body = extractBody(output);
 
-		expect(body).toContain(`const $moduleName = '@test/testpkg::counter';`);
+		expect(body).toContain(`const $moduleName = '${ORIGIN_V2}::counter';`);
 		expect(body).toContain(`name: \`${ORIGIN_V1}::counter::AdminCap\``);
 		expect(body).toContain('name: `${$moduleName}::Counter`');
 	});
@@ -1157,10 +1159,11 @@ describe('typeOrigins (upgraded packages)', () => {
 		const builder = await MoveModuleBuilder.fromSummaryFile(
 			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
 			new ModuleRegistry(ADDRESS_MAPPINGS),
-			'@test/testpkg',
+			ORIGIN_V2,
 			'.js',
 			false,
 			{ Wrapper: ORIGIN_V2 },
+			ORIGIN_V2,
 		);
 		builder.includeTypes(['Wrapper']);
 		const output = await render(builder, { types: true, functions: false });
@@ -1179,21 +1182,22 @@ describe('typeOrigins (upgraded packages)', () => {
 		const builder = await MoveModuleBuilder.fromSummaryFile(
 			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
 			new ModuleRegistry(ADDRESS_MAPPINGS),
-			'@test/testpkg',
+			ORIGIN_V2,
 			'.js',
 			false,
 			{ AdminCap: ORIGIN_V1 },
+			ORIGIN_V2,
 		);
 		builder.includeTypes(['AdminCap']);
 		builder.includeTypes(['Counter']);
 		const output = await render(builder, { types: true, functions: false });
 		const body = extractBody(output);
 
-		expect(body).toContain(`const $moduleName = '@test/testpkg::counter';`);
+		expect(body).toContain(`const $moduleName = '${ORIGIN_V2}::counter';`);
 		expect(body).toContain('name: `${$moduleName}::Counter`');
 	});
 
-	it('falls back to rootPackageId for type names (introducing version, not MVR name) when no per-type origin', async () => {
+	it('prefers a named package over rootPackageId for portable type names', async () => {
 		const ROOT_V1 = '0x' + 'b'.repeat(64);
 		const builder = await MoveModuleBuilder.fromSummaryFile(
 			join(SUMMARIES_DIR, 'testpkg', 'counter.json'),
@@ -1201,13 +1205,14 @@ describe('typeOrigins (upgraded packages)', () => {
 			'@upgraded/pkg',
 			'.js',
 			false,
-			undefined,
+			{ Counter: ORIGIN_V1 },
 			ROOT_V1,
 		);
 		builder.includeTypes(['Counter']);
 		const output = await render(builder, { types: true, functions: false });
 		const body = extractBody(output);
 
-		expect(body).toContain(`const $moduleName = '${ROOT_V1}::counter';`);
+		expect(body).toContain(`const $moduleName = '@upgraded/pkg::counter';`);
+		expect(body).not.toContain(ORIGIN_V1);
 	});
 });

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -856,7 +856,7 @@ describe('generate options', () => {
 			expect(counter).toContain(`options.package ?? '${LATEST_ID}'`);
 		});
 
-		it('uses original id for type names even when queried by MVR name', async () => {
+		it('preserves an unpublished MVR name for runtime client overrides', async () => {
 			onChainPath = await buildOnChainFixture({
 				rootPackageId: LATEST_ID,
 				rootPackageOriginalId: V1_ID,
@@ -865,7 +865,7 @@ describe('generate options', () => {
 			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
 
 			await generateFromPackageSummary({
-				package: { package: '@test/testpkg', packageName: 'testpkg', path: onChainPath },
+				package: { package: '@local-pkg/testpkg', packageName: 'testpkg', path: onChainPath },
 				prune: true,
 				outputDir,
 			});
@@ -874,8 +874,8 @@ describe('generate options', () => {
 			// MVR names resolve to the latest version at runtime — that wouldn't match on-chain
 			// type tags for upgraded packages. Type names must always use the original id.
 			expect(counter).toContain(`const $moduleName = '${V1_ID}::counter';`);
-			// Function helpers can use the MVR name (it resolves to latest at call time).
-			expect(counter).toContain(`options.package ?? '@test/testpkg'`);
+			// Function helpers keep the unpublished name so client-side MVR overrides can resolve it.
+			expect(counter).toContain(`options.package ?? '@local-pkg/testpkg'`);
 		});
 
 		it('inlines per-type origin addresses from type_origins (across multiple versions)', async () => {

--- a/packages/codegen/tests/generate-options.test.ts
+++ b/packages/codegen/tests/generate-options.test.ts
@@ -856,11 +856,17 @@ describe('generate options', () => {
 			expect(counter).toContain(`options.package ?? '${LATEST_ID}'`);
 		});
 
-		it('preserves an unpublished MVR name for runtime client overrides', async () => {
+		it('preserves a named package for runtime package and type resolution', async () => {
 			onChainPath = await buildOnChainFixture({
 				rootPackageId: LATEST_ID,
 				rootPackageOriginalId: V1_ID,
 				dependencies: { [STD_ID]: STD_ID, [SUI_ID]: SUI_ID },
+				typeOrigins: {
+					[V1_ID]: [
+						{ module_name: 'counter', datatype_name: 'Counter', package: V1_ID },
+						{ module_name: 'counter', datatype_name: 'AdminCap', package: LATEST_ID },
+					],
+				},
 			});
 			outputDir = await mkdtemp(join(tmpdir(), 'codegen-test-'));
 
@@ -871,10 +877,13 @@ describe('generate options', () => {
 			});
 
 			const counter = await getFileContent(outputDir, 'testpkg/counter.ts');
-			// MVR names resolve to the latest version at runtime — that wouldn't match on-chain
-			// type tags for upgraded packages. Type names must always use the original id.
-			expect(counter).toContain(`const $moduleName = '${V1_ID}::counter';`);
-			// Function helpers keep the unpublished name so client-side MVR overrides can resolve it.
+			// MVR resolves named types separately from package call targets, preserving the correct
+			// introducing version for every type on the client's network.
+			expect(counter).toContain(`const $moduleName = '@local-pkg/testpkg::counter';`);
+			expect(counter).toContain('name: `${$moduleName}::Counter`');
+			expect(counter).toContain('name: `${$moduleName}::AdminCap`');
+			expect(counter).not.toContain(`name: \`${LATEST_ID}::counter::AdminCap\``);
+			// Function helpers use the same name so client-side package overrides can resolve it.
 			expect(counter).toContain(`options.package ?? '@local-pkg/testpkg'`);
 		});
 

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -109,6 +109,42 @@ describe('resolveOnChainPackageId', () => {
 			}),
 		).toThrow('Fullnode URL must use HTTP or HTTPS');
 	});
+
+	it('accepts a separate source package ID for a generated package name', () => {
+		const sourcePackageId = `0x${'3'.repeat(64)}`;
+		const config = configSchema.parse({
+			output: './generated',
+			packages: [
+				{
+					package: '@local-pkg/counter',
+					sourcePackageId,
+					packageName: 'counter',
+					network: 'testnet',
+				},
+			],
+		});
+
+		expect(config.packages[0]).toMatchObject({
+			package: '@local-pkg/counter',
+			sourcePackageId,
+		});
+	});
+
+	it('rejects an invalid source package ID', () => {
+		expect(() =>
+			configSchema.parse({
+				output: './generated',
+				packages: [
+					{
+						package: '@local-pkg/counter',
+						sourcePackageId: 'not-an-object-id',
+						packageName: 'counter',
+						network: 'testnet',
+					},
+				],
+			}),
+		).toThrow('Invalid source package ID');
+	});
 });
 
 describe('withTemporaryDirectory', () => {

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -21,10 +21,11 @@ describe('resolveOnChainPackageId', () => {
 	it('returns package IDs without resolving them', async () => {
 		const fetch = vi.fn();
 		vi.stubGlobal('fetch', fetch);
+		const packageId = `0x${'2'.repeat(64)}`;
 
 		await expect(
-			resolveOnChainPackageId('0x2', 'testnet', DEFAULT_FULLNODE_URLS.testnet),
-		).resolves.toBe('0x2');
+			resolveOnChainPackageId(packageId, 'testnet', DEFAULT_FULLNODE_URLS.testnet),
+		).resolves.toBe(packageId);
 		expect(fetch).not.toHaveBeenCalled();
 	});
 

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	getOnChainSummaryArgs,
+	resolveOnChainPackageId,
+} from '../src/cli/commands/generate/impl.js';
+
+describe('resolveOnChainPackageId', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns package IDs without resolving them', async () => {
+		const fetch = vi.fn();
+		vi.stubGlobal('fetch', fetch);
+
+		await expect(resolveOnChainPackageId('0x2', 'testnet')).resolves.toBe('0x2');
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it('resolves MVR names on the configured network', async () => {
+		const fetch = vi.fn(async () =>
+			Response.json({
+				resolution: {
+					'@deepbook/core': { package_id: '0x123' },
+				},
+			}),
+		);
+		vi.stubGlobal('fetch', fetch);
+
+		await expect(resolveOnChainPackageId('@deepbook/core', 'testnet')).resolves.toBe('0x123');
+		expect(fetch).toHaveBeenCalledWith(
+			'https://testnet.mvr.mystenlabs.com/v1/resolution/bulk',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ names: ['@deepbook/core'] }),
+			}),
+		);
+	});
+
+	it('generates summaries on the configured network', () => {
+		expect(getOnChainSummaryArgs('0x123', 'testnet', '/tmp/output')).toEqual([
+			'move',
+			'--client.env',
+			'testnet',
+			'summary',
+			'--package-id',
+			'0x123',
+			'--output-directory',
+			'/tmp/output',
+		]);
+	});
+});

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
 	getOnChainSummaryArgs,
 	resolveOnChainPackageId,
+	withTemporaryDirectory,
 	writeSuiClientConfig,
 } from '../src/cli/commands/generate/impl.js';
 import { configSchema, DEFAULT_FULLNODE_URLS } from '../src/config.js';
@@ -30,10 +32,11 @@ describe('resolveOnChainPackageId', () => {
 	});
 
 	it('resolves MVR names on the configured network', async () => {
+		const packageId = `0x${'1'.repeat(64)}`;
 		const fetch = vi.fn(async () =>
 			Response.json({
 				resolution: {
-					'@deepbook/core': { package_id: '0x123' },
+					'@deepbook/core': { package_id: packageId },
 				},
 			}),
 		);
@@ -41,7 +44,7 @@ describe('resolveOnChainPackageId', () => {
 
 		await expect(
 			resolveOnChainPackageId('@deepbook/core', 'testnet', 'https://custom.testnet.example'),
-		).resolves.toBe('0x123');
+		).resolves.toBe(packageId);
 		expect(fetch).toHaveBeenCalledWith(
 			'https://testnet.mvr.mystenlabs.com/v1/resolution/bulk',
 			expect.objectContaining({
@@ -95,5 +98,33 @@ describe('resolveOnChainPackageId', () => {
 			mainnet: DEFAULT_FULLNODE_URLS.mainnet,
 			testnet: 'https://custom.testnet.example',
 		});
+	});
+});
+
+describe('withTemporaryDirectory', () => {
+	it('removes the directory after the callback succeeds', async () => {
+		let directory = '';
+
+		await withTemporaryDirectory(async (tempDir) => {
+			directory = tempDir;
+			await writeFile(join(tempDir, 'client.json'), 'secret');
+			expect(existsSync(tempDir)).toBe(true);
+		});
+
+		expect(existsSync(directory)).toBe(false);
+	});
+
+	it('removes the directory after the callback fails', async () => {
+		let directory = '';
+
+		await expect(
+			withTemporaryDirectory(async (tempDir) => {
+				directory = tempDir;
+				await writeFile(join(tempDir, 'client.json'), 'secret');
+				throw new Error('summary generation failed');
+			}),
+		).rejects.toThrow('summary generation failed');
+
+		expect(existsSync(directory)).toBe(false);
 	});
 });

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -145,6 +145,22 @@ describe('resolveOnChainPackageId', () => {
 			}),
 		).toThrow('Invalid source package ID');
 	});
+
+	it('rejects a source package ID that differs from a raw package ID', () => {
+		expect(() =>
+			configSchema.parse({
+				output: './generated',
+				packages: [
+					{
+						package: `0x${'2'.repeat(64)}`,
+						sourcePackageId: `0x${'3'.repeat(64)}`,
+						packageName: 'counter',
+						network: 'testnet',
+					},
+				],
+			}),
+		).toThrow('sourcePackageId must match package when package is a package ID');
+	});
 });
 
 describe('withTemporaryDirectory', () => {

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -99,6 +99,16 @@ describe('resolveOnChainPackageId', () => {
 			testnet: 'https://custom.testnet.example',
 		});
 	});
+
+	it('rejects non-HTTP fullnode URLs', () => {
+		expect(() =>
+			configSchema.parse({
+				output: './generated',
+				packages: [],
+				fullnodeUrls: { testnet: 'ftp://custom.testnet.example' },
+			}),
+		).toThrow('Fullnode URL must use HTTP or HTTPS');
+	});
 });
 
 describe('withTemporaryDirectory', () => {

--- a/packages/codegen/tests/resolve-on-chain-package.test.ts
+++ b/packages/codegen/tests/resolve-on-chain-package.test.ts
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
 	getOnChainSummaryArgs,
 	resolveOnChainPackageId,
+	writeSuiClientConfig,
 } from '../src/cli/commands/generate/impl.js';
+import { configSchema, DEFAULT_FULLNODE_URLS } from '../src/config.js';
 
 describe('resolveOnChainPackageId', () => {
 	afterEach(() => {
@@ -17,7 +22,9 @@ describe('resolveOnChainPackageId', () => {
 		const fetch = vi.fn();
 		vi.stubGlobal('fetch', fetch);
 
-		await expect(resolveOnChainPackageId('0x2', 'testnet')).resolves.toBe('0x2');
+		await expect(
+			resolveOnChainPackageId('0x2', 'testnet', DEFAULT_FULLNODE_URLS.testnet),
+		).resolves.toBe('0x2');
 		expect(fetch).not.toHaveBeenCalled();
 	});
 
@@ -31,7 +38,9 @@ describe('resolveOnChainPackageId', () => {
 		);
 		vi.stubGlobal('fetch', fetch);
 
-		await expect(resolveOnChainPackageId('@deepbook/core', 'testnet')).resolves.toBe('0x123');
+		await expect(
+			resolveOnChainPackageId('@deepbook/core', 'testnet', 'https://custom.testnet.example'),
+		).resolves.toBe('0x123');
 		expect(fetch).toHaveBeenCalledWith(
 			'https://testnet.mvr.mystenlabs.com/v1/resolution/bulk',
 			expect.objectContaining({
@@ -41,16 +50,49 @@ describe('resolveOnChainPackageId', () => {
 		);
 	});
 
-	it('generates summaries on the configured network', () => {
-		expect(getOnChainSummaryArgs('0x123', 'testnet', '/tmp/output')).toEqual([
+	it('uses a temporary client config when generating summaries', () => {
+		expect(getOnChainSummaryArgs('0x123', '/tmp/client.json', '/tmp/output')).toEqual([
 			'move',
+			'--client.config',
+			'/tmp/client.json',
 			'--client.env',
-			'testnet',
+			'codegen',
 			'summary',
 			'--package-id',
 			'0x123',
 			'--output-directory',
 			'/tmp/output',
 		]);
+	});
+
+	it('writes the configured fullnode URL to the temporary client config', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'codegen-client-config-'));
+		try {
+			const configPath = writeSuiClientConfig(directory, 'https://custom.testnet.example');
+			const config = JSON.parse(await readFile(configPath, 'utf8'));
+
+			expect(config.envs).toEqual([
+				expect.objectContaining({
+					alias: 'codegen',
+					rpc: 'https://custom.testnet.example',
+				}),
+			]);
+			expect(config.active_env).toBe('codegen');
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it('provides default fullnode URLs and accepts per-network overrides', () => {
+		const config = configSchema.parse({
+			output: './generated',
+			packages: [],
+			fullnodeUrls: { testnet: 'https://custom.testnet.example' },
+		});
+
+		expect(config.fullnodeUrls).toEqual({
+			mainnet: DEFAULT_FULLNODE_URLS.mainnet,
+			testnet: 'https://custom.testnet.example',
+		});
 	});
 });

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -85,15 +85,16 @@ This generates TypeScript code in your configured output directory (for example,
 
 The `SuiCodegenConfig` type supports the following options:
 
-| Option                         | Type                   | Default | Description                                                                                                                                                           |
-| ------------------------------ | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output`                       | `string`               | -       | The directory where generated code will be written                                                                                                                    |
-| `packages`                     | `PackageConfig[]`      | -       | Array of Move packages to generate code for                                                                                                                           |
-| `prune`                        | `boolean`              | `true`  | When enabled, only generates code for the main package and omits dependency modules (dependency types referenced by included types are still generated under `deps/`) |
-| `generateSummaries`            | `boolean`              | `true`  | Automatically run `sui move summary` before generating code. Creates a `package_summaries` directory in your Move package which can be added to `.gitignore`          |
-| `generate`                     | `GenerateOptions`      | -       | Default [generate options](#the-generate-option) (types, functions) for all packages                                                                                  |
-| `importExtension`              | `'.js' \| '.ts' \| ''` | `'.js'` | File extension used in generated import statements                                                                                                                    |
-| `includePhantomTypeParameters` | `boolean`              | `false` | Include [phantom type parameters](#phantom-types) as function arguments in generated BCS types                                                                        |
+| Option                         | Type                   | Default              | Description                                                                                                                                                           |
+| ------------------------------ | ---------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output`                       | `string`               | -                    | The directory where generated code will be written                                                                                                                    |
+| `packages`                     | `PackageConfig[]`      | -                    | Array of Move packages to generate code for                                                                                                                           |
+| `prune`                        | `boolean`              | `true`               | When enabled, only generates code for the main package and omits dependency modules (dependency types referenced by included types are still generated under `deps/`) |
+| `generateSummaries`            | `boolean`              | `true`               | Automatically run `sui move summary` before generating code. Creates a `package_summaries` directory in your Move package which can be added to `.gitignore`          |
+| `generate`                     | `GenerateOptions`      | -                    | Default [generate options](#the-generate-option) (types, functions) for all packages                                                                                  |
+| `importExtension`              | `'.js' \| '.ts' \| ''` | `'.js'`              | File extension used in generated import statements                                                                                                                    |
+| `includePhantomTypeParameters` | `boolean`              | `false`              | Include [phantom type parameters](#phantom-types) as function arguments in generated BCS types                                                                        |
+| `fullnodeUrls`                 | network URL map        | Sui public fullnodes | Override the mainnet or testnet fullnode used to fetch onchain package summaries                                                                                      |
 
 ### Package configuration
 
@@ -121,12 +122,13 @@ local (from source) or onchain (fetched from a network).
 For packages already deployed onchain, generate code directly from a package ID or MVR name without
 needing local source code:
 
-| Option        | Type                     | Required | Description                                   |
-| ------------- | ------------------------ | -------- | --------------------------------------------- |
-| `package`     | `string`                 | yes      | Package ID or MVR name                        |
-| `packageName` | `string`                 | yes      | Name for the generated code directory         |
-| `network`     | `'mainnet' \| 'testnet'` | yes      | Network to fetch the package from             |
-| `generate`    | `PackageGenerateOptions` | no       | Control what gets generated from this package |
+| Option            | Type                     | Required | Description                                                     |
+| ----------------- | ------------------------ | -------- | --------------------------------------------------------------- |
+| `package`         | `string`                 | yes      | Package ID or name emitted into generated code                  |
+| `sourcePackageId` | `string`                 | no       | Package ID to fetch when generating an unpublished package name |
+| `packageName`     | `string`                 | yes      | Name for the generated code directory                           |
+| `network`         | `'mainnet' \| 'testnet'` | yes      | Network to resolve and fetch the package from                   |
+| `generate`        | `PackageGenerateOptions` | no       | Control what gets generated from this package                   |
 
 ```typescript
 {
@@ -470,11 +472,15 @@ const balanceType = await Balance.resolveTypeTag({
 
 ### Using with MVR (Move Version Registry)
 
-If your package is registered on MVR, the generated code works without additional configuration.
+If your package is registered on MVR, the generated code works without additional configuration. The
+configured name is preserved in generated function targets and type tags. At runtime MVR resolves
+function packages and type origins independently for the client's network.
 
 ### Local packages
 
-For local packages using `@local-pkg/*` identifiers, configure your client with package overrides:
+For local packages using `@local-pkg/*` identifiers, configure package overrides for Move calls and
+first-level type overrides for each local type used as a transaction type argument or resolved for a
+query:
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';
@@ -486,6 +492,9 @@ const client = new SuiGrpcClient({
 		overrides: {
 			packages: {
 				'@local-pkg/counter': '0xYOUR_PACKAGE_ID',
+			},
+			types: {
+				'@local-pkg/counter::counter::Counter': '0xTYPE_ORIGIN::counter::Counter',
 			},
 		},
 	},
@@ -507,6 +516,7 @@ const GRPC_URLS = {
 const PACKAGE_IDS = {
 	testnet: {
 		counter: '0xYOUR_PACKAGE_ID',
+		counterType: '0xTYPE_ORIGIN::counter::Counter',
 	},
 };
 
@@ -520,6 +530,9 @@ const dAppKit = createDAppKit({
 				overrides: {
 					packages: {
 						'@local-pkg/counter': PACKAGE_IDS[network].counter,
+					},
+					types: {
+						'@local-pkg/counter::counter::Counter': PACKAGE_IDS[network].counterType,
 					},
 				},
 			},

--- a/packages/docs/content/codegen/index.mdx
+++ b/packages/docs/content/codegen/index.mdx
@@ -87,14 +87,14 @@ The `SuiCodegenConfig` type supports the following options:
 
 | Option                         | Type                   | Default              | Description                                                                                                                                                           |
 | ------------------------------ | ---------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `output`                       | `string`               | -                    | The directory where generated code will be written                                                                                                                    |
+| `output`                       | `string`               | -                    | The directory where codegen writes generated code                                                                                                                     |
 | `packages`                     | `PackageConfig[]`      | -                    | Array of Move packages to generate code for                                                                                                                           |
 | `prune`                        | `boolean`              | `true`               | When enabled, only generates code for the main package and omits dependency modules (dependency types referenced by included types are still generated under `deps/`) |
 | `generateSummaries`            | `boolean`              | `true`               | Automatically run `sui move summary` before generating code. Creates a `package_summaries` directory in your Move package which can be added to `.gitignore`          |
 | `generate`                     | `GenerateOptions`      | -                    | Default [generate options](#the-generate-option) (types, functions) for all packages                                                                                  |
 | `importExtension`              | `'.js' \| '.ts' \| ''` | `'.js'`              | File extension used in generated import statements                                                                                                                    |
 | `includePhantomTypeParameters` | `boolean`              | `false`              | Include [phantom type parameters](#phantom-types) as function arguments in generated BCS types                                                                        |
-| `fullnodeUrls`                 | network URL map        | Sui public fullnodes | Override the mainnet or testnet fullnode used to fetch onchain package summaries                                                                                      |
+| `fullnodeUrls`                 | network URL map        | Sui public fullnodes | Override the Mainnet or Testnet fullnode used to fetch onchain package summaries                                                                                      |
 
 ### Package configuration
 


### PR DESCRIPTION
## Description

Resolve MVR package names through the configured network before passing the resulting package ID to `sui move summary`.

Add a `fullnodeUrls` codegen config option for overriding the mainnet and testnet fullnodes used to fetch on-chain summaries. Codegen writes an isolated temporary Sui client config for the summary command, so generation uses the configured URL instead of depending on the user's active CLI environment.

The configured package name remains unchanged in generated function helpers. This preserves unpublished MVR names such as `@local-pkg/...` for runtime resolution through client overrides.

Closes #1200.

## Test plan

- `pnpm turbo build --filter=@mysten/codegen...`
- `pnpm --filter @mysten/codegen test` (131 tests)
- `pnpm --filter @mysten/codegen lint`
- Ran config-based generation for `@deepbook/core` with `fullnodeUrls.testnet` while the active Sui CLI environment was devnet; summary and TypeScript generation completed successfully, and generated helpers retained `@deepbook/core`.
- Added CLI coverage proving a local unpublished MVR name remains in generated move-call helpers when `fullnodeUrls` is configured.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
