### PR TITLE
feat(sui): unify lookup errors across Core API clients

### DIFF
--- a/.changeset/tidy-lookup-errors.md
+++ b/.changeset/tidy-lookup-errors.md
@@ -3,3 +3,5 @@
 ---
 
 Add transport-neutral `ObjectError` and `TransactionError` lookup details across the Core API clients.
+The existing transport-specific `ObjectError.code` field and `(code, message)` constructor remain
+supported but are deprecated in favor of the explicit `reason` field and options constructor.

--- a/.changeset/tidy-lookup-errors.md
+++ b/.changeset/tidy-lookup-errors.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add transport-neutral `ObjectError` and `TransactionError` lookup details across the Core API clients.

--- a/.changeset/tidy-lookup-errors.md
+++ b/.changeset/tidy-lookup-errors.md
@@ -4,4 +4,4 @@
 
 Add transport-neutral `ObjectError` and `TransactionError` lookup details across the Core API clients.
 The existing transport-specific `ObjectError.code` field and `(code, message)` constructor remain
-supported but are deprecated in favor of the explicit `reason` field and options constructor.
+supported; the transport-neutral `reason`, resource identity, and `cause` fields are additive.

--- a/packages/sui/src/client/errors.ts
+++ b/packages/sui/src/client/errors.ts
@@ -19,23 +19,46 @@ export class SimulationError extends SuiClientError {
 
 export type ObjectErrorReason = 'notFound' | 'deleted' | 'unknown';
 
+export interface ObjectErrorOptions {
+	/** A transport-neutral reason shared by all Core API clients. */
+	reason: ObjectErrorReason;
+	/** The requested object ID, when the lookup identifies one. */
+	objectId?: string;
+	/**
+	 * The transport's error code, when it supplies one.
+	 *
+	 * @deprecated New callers should not supply transport-specific codes. Preserve the original
+	 * transport error through `cause` instead.
+	 */
+	code?: string;
+	/** The original transport error or response. */
+	cause?: unknown;
+}
+
 /** An error returned for an individual object lookup. */
 export class ObjectError extends SuiClientError {
-	/** The transport's existing error code. Use `reason` for transport-neutral handling. */
-	readonly code: string;
+	/**
+	 * The transport's error code.
+	 *
+	 * @deprecated Use `reason` for transport-neutral handling. Transport-specific detail is
+	 * available through `cause`.
+	 */
+	code: string;
 	/** A transport-neutral reason shared by all Core API clients. */
 	readonly reason: ObjectErrorReason;
 	/** The requested object ID, when the lookup identifies one. */
 	readonly objectId?: string;
 
-	constructor(
-		code: string,
-		message: string,
-		options?: { cause?: unknown; reason?: ObjectErrorReason; objectId?: string },
-	) {
-		super(message, options);
-		this.code = code;
-		this.reason = options?.reason ?? inferObjectErrorReason(code);
+	constructor(message: string, options: ObjectErrorOptions);
+	/** @deprecated Use `new ObjectError(message, { reason, objectId, cause })`. */
+	constructor(code: string, message: string);
+	constructor(messageOrCode: string, optionsOrMessage: ObjectErrorOptions | string) {
+		const options = typeof optionsOrMessage === 'string' ? undefined : optionsOrMessage;
+		const message = typeof optionsOrMessage === 'string' ? optionsOrMessage : messageOrCode;
+
+		super(message, { cause: options?.cause });
+		this.code = options ? (options.code ?? options.reason) : messageOrCode;
+		this.reason = options?.reason ?? 'unknown';
 		this.objectId = options?.objectId;
 	}
 }
@@ -53,20 +76,5 @@ export class TransactionError extends SuiClientError {
 		super(`Transaction ${digest} not found`, options);
 		this.reason = reason;
 		this.digest = digest;
-	}
-}
-
-function inferObjectErrorReason(code: string): ObjectErrorReason {
-	switch (code) {
-		case 'notExists':
-		case 'dynamicFieldNotFound':
-		case 'notFound':
-			return 'notFound';
-		case 'deleted':
-			return 'deleted';
-		case 'displayError':
-		case 'unknown':
-		default:
-			return 'unknown';
 	}
 }

--- a/packages/sui/src/client/errors.ts
+++ b/packages/sui/src/client/errors.ts
@@ -24,40 +24,22 @@ export interface ObjectErrorOptions {
 	reason: ObjectErrorReason;
 	/** The requested object ID, when the lookup identifies one. */
 	objectId?: string;
-	/**
-	 * The transport's error code, when it supplies one.
-	 *
-	 * @deprecated New callers should not supply transport-specific codes. Preserve the original
-	 * transport error through `cause` instead.
-	 */
-	code?: string;
 	/** The original transport error or response. */
 	cause?: unknown;
 }
 
 /** An error returned for an individual object lookup. */
 export class ObjectError extends SuiClientError {
-	/**
-	 * The transport's error code.
-	 *
-	 * @deprecated Use `reason` for transport-neutral handling. Transport-specific detail is
-	 * available through `cause`.
-	 */
+	/** The transport's error code. Use `reason` for transport-neutral handling. */
 	code: string;
 	/** A transport-neutral reason shared by all Core API clients. */
 	readonly reason: ObjectErrorReason;
 	/** The requested object ID, when the lookup identifies one. */
 	readonly objectId?: string;
 
-	constructor(message: string, options: ObjectErrorOptions);
-	/** @deprecated Use `new ObjectError(message, { reason, objectId, cause })`. */
-	constructor(code: string, message: string);
-	constructor(messageOrCode: string, optionsOrMessage: ObjectErrorOptions | string) {
-		const options = typeof optionsOrMessage === 'string' ? undefined : optionsOrMessage;
-		const message = typeof optionsOrMessage === 'string' ? optionsOrMessage : messageOrCode;
-
+	constructor(code: string, message: string, options?: ObjectErrorOptions) {
 		super(message, { cause: options?.cause });
-		this.code = options ? (options.code ?? options.reason) : messageOrCode;
+		this.code = code;
 		this.reason = options?.reason ?? 'unknown';
 		this.objectId = options?.objectId;
 	}

--- a/packages/sui/src/client/errors.ts
+++ b/packages/sui/src/client/errors.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ObjectResponseError } from '../jsonRpc/index.js';
 import type { SuiClientTypes } from './types.js';
 
 export class SuiClientError extends Error {}
@@ -18,33 +17,56 @@ export class SimulationError extends SuiClientError {
 	}
 }
 
+export type ObjectErrorReason = 'notFound' | 'deleted' | 'unknown';
+
+/** An error returned for an individual object lookup. */
 export class ObjectError extends SuiClientError {
-	code: string;
+	/** The transport's existing error code. Use `reason` for transport-neutral handling. */
+	readonly code: string;
+	/** A transport-neutral reason shared by all Core API clients. */
+	readonly reason: ObjectErrorReason;
+	/** The requested object ID, when the lookup identifies one. */
+	readonly objectId?: string;
 
-	constructor(code: string, message: string) {
-		super(message);
+	constructor(
+		code: string,
+		message: string,
+		options?: { cause?: unknown; reason?: ObjectErrorReason; objectId?: string },
+	) {
+		super(message, options);
 		this.code = code;
+		this.reason = options?.reason ?? inferObjectErrorReason(code);
+		this.objectId = options?.objectId;
 	}
+}
 
-	static fromResponse(response: ObjectResponseError, objectId?: string): ObjectError {
-		switch (response.code) {
-			case 'notExists':
-				return new ObjectError(response.code, `Object ${response.object_id} does not exist`);
-			case 'dynamicFieldNotFound':
-				return new ObjectError(
-					response.code,
-					`Dynamic field not found for object ${response.parent_object_id}`,
-				);
-			case 'deleted':
-				return new ObjectError(response.code, `Object ${response.object_id} has been deleted`);
-			case 'displayError':
-				return new ObjectError(response.code, `Display error: ${response.error}`);
-			case 'unknown':
-			default:
-				return new ObjectError(
-					response.code,
-					`Unknown error while loading object${objectId ? ` ${objectId}` : ''}`,
-				);
-		}
+export type TransactionErrorReason = 'notFound';
+
+/** An error returned by a transaction lookup. */
+export class TransactionError extends SuiClientError {
+	/** A transport-neutral reason shared by all Core API clients. */
+	readonly reason: TransactionErrorReason;
+	/** The requested transaction digest. */
+	readonly digest: string;
+
+	constructor(reason: TransactionErrorReason, digest: string, options?: { cause?: unknown }) {
+		super(`Transaction ${digest} not found`, options);
+		this.reason = reason;
+		this.digest = digest;
+	}
+}
+
+function inferObjectErrorReason(code: string): ObjectErrorReason {
+	switch (code) {
+		case 'notExists':
+		case 'dynamicFieldNotFound':
+		case 'notFound':
+			return 'notFound';
+		case 'deleted':
+			return 'deleted';
+		case 'displayError':
+		case 'unknown':
+		default:
+			return 'unknown';
 	}
 }

--- a/packages/sui/src/client/errors.ts
+++ b/packages/sui/src/client/errors.ts
@@ -47,6 +47,10 @@ export class ObjectError extends SuiClientError {
 
 export type TransactionErrorReason = 'notFound';
 
+const TRANSACTION_ERROR_MESSAGES: Record<TransactionErrorReason, (digest: string) => string> = {
+	notFound: (digest) => `Transaction ${digest} not found`,
+};
+
 /** An error returned by a transaction lookup. */
 export class TransactionError extends SuiClientError {
 	/** A transport-neutral reason shared by all Core API clients. */
@@ -55,7 +59,7 @@ export class TransactionError extends SuiClientError {
 	readonly digest: string;
 
 	constructor(reason: TransactionErrorReason, digest: string, options?: { cause?: unknown }) {
-		super(`Transaction ${digest} not found`, options);
+		super(TRANSACTION_ERROR_MESSAGES[reason](digest), options);
 		this.reason = reason;
 		this.digest = digest;
 	}

--- a/packages/sui/src/client/index.ts
+++ b/packages/sui/src/client/index.ts
@@ -22,7 +22,14 @@ export {
 	type ClientWithCoreApi,
 };
 
-export { SimulationError } from './errors.js';
+export {
+	ObjectError,
+	SimulationError,
+	SuiClientError,
+	TransactionError,
+	type ObjectErrorReason,
+	type TransactionErrorReason,
+} from './errors.js';
 
 export { ClientCache, type ClientCacheOptions } from './cache.js';
 export { type NamedPackagesOverrides } from './mvr.js';

--- a/packages/sui/src/client/index.ts
+++ b/packages/sui/src/client/index.ts
@@ -27,6 +27,7 @@ export {
 	SimulationError,
 	SuiClientError,
 	TransactionError,
+	type ObjectErrorOptions,
 	type ObjectErrorReason,
 	type TransactionErrorReason,
 } from './errors.js';

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -129,7 +129,7 @@ export class GraphQLCoreClient extends CoreClient {
 					.map(
 						({ objectId, normalized }) =>
 							page.find((obj) => obj?.address === normalized) ??
-							new ObjectError('notFound', `Object ${objectId} not found`, {
+							new ObjectError(`Object ${normalized} not found`, {
 								reason: 'notFound',
 								objectId,
 							}),

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -38,7 +38,7 @@ import {
 	VerifyZkLoginSignatureDocument,
 	ZkLoginIntentScope,
 } from './generated/queries.js';
-import { ObjectError, SimulationError } from '../client/errors.js';
+import { ObjectError, SimulationError, TransactionError } from '../client/errors.js';
 import { chunk, fromBase64, toBase64 } from '@mysten/utils';
 import { normalizeStructTag, normalizeSuiAddress } from '../utils/sui-types.js';
 import {
@@ -86,6 +86,7 @@ export class GraphQLCoreClient extends CoreClient {
 	>(
 		options: GraphQLQueryOptions<Result, Variables>,
 		getData?: (result: Result) => Data,
+		createMissingDataError?: () => Error,
 	): Promise<NonNullable<Data>> {
 		const { data, errors } = await this.#graphqlClient.query(options);
 
@@ -94,7 +95,7 @@ export class GraphQLCoreClient extends CoreClient {
 		const extractedData = data && (getData ? getData(data) : data);
 
 		if (extractedData == null) {
-			throw new Error('Missing response data');
+			throw createMissingDataError?.() ?? new Error('Missing response data');
 		}
 
 		return extractedData as NonNullable<Data>;
@@ -124,11 +125,14 @@ export class GraphQLCoreClient extends CoreClient {
 			);
 			results.push(
 				...batch
-					.map((id) => normalizeSuiAddress(id))
+					.map((objectId) => ({ objectId, normalized: normalizeSuiAddress(objectId) }))
 					.map(
-						(id) =>
-							page.find((obj) => obj?.address === id) ??
-							new ObjectError('notFound', `Object ${id} not found`),
+						({ objectId, normalized }) =>
+							page.find((obj) => obj?.address === normalized) ??
+							new ObjectError('notFound', `Object ${objectId} not found`, {
+								reason: 'notFound',
+								objectId,
+							}),
 					)
 					.map((obj) => {
 						if (obj instanceof ObjectError) {
@@ -385,6 +389,7 @@ export class GraphQLCoreClient extends CoreClient {
 				},
 			},
 			(result) => result.transaction,
+			() => new TransactionError('notFound', options.digest),
 		);
 
 		return parseTransaction(result, options.include);

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -129,7 +129,7 @@ export class GraphQLCoreClient extends CoreClient {
 					.map(
 						({ objectId, normalized }) =>
 							page.find((obj) => obj?.address === normalized) ??
-							new ObjectError(`Object ${normalized} not found`, {
+							new ObjectError('notFound', `Object ${normalized} not found`, {
 								reason: 'notFound',
 								objectId,
 							}),

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CoreClientOptions, SuiClientTypes } from '../client/index.js';
-import { CoreClient, formatMoveAbortMessage, SimulationError } from '../client/index.js';
+import type { CoreClientOptions, ObjectErrorReason, SuiClientTypes } from '../client/index.js';
+import {
+	CoreClient,
+	formatMoveAbortMessage,
+	ObjectError,
+	SimulationError,
+	TransactionError,
+} from '../client/index.js';
 import { raceSignal } from '../client/mvr.js';
 import type { SuiGrpcClient } from './client.js';
 import type { Owner } from './proto/sui/rpc/v2/owner.js';
@@ -67,6 +73,8 @@ export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
 }
 
+const GRPC_NOT_FOUND_CODE = 5;
+
 function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (!(error instanceof RpcError)) return false;
 	if (error.code === 'NOT_FOUND') return true;
@@ -124,51 +132,62 @@ export class GrpcCoreClient extends CoreClient {
 			);
 
 			results.push(
-				...response.response.objects.map((object): SuiClientTypes.Object<Include> | Error => {
-					if (object.result.oneofKind === 'error') {
-						// TODO: improve error handling
-						return new Error(object.result.error.message);
-					}
+				...response.response.objects.map(
+					(object, index): SuiClientTypes.Object<Include> | ObjectError => {
+						if (object.result.oneofKind === 'error') {
+							const error = object.result.error;
+							const reason: ObjectErrorReason =
+								error.code === GRPC_NOT_FOUND_CODE ? 'notFound' : 'unknown';
+							return new ObjectError(String(error.code), error.message, {
+								cause: error,
+								reason,
+								objectId: batch[index],
+							});
+						}
 
-					if (object.result.oneofKind !== 'object') {
-						return new Error('Unexpected result type');
-					}
+						if (object.result.oneofKind !== 'object') {
+							return new ObjectError('unknown', 'Unexpected result type', {
+								reason: 'unknown',
+								objectId: batch[index],
+							});
+						}
 
-					const bcsContent = object.result.object.contents?.value ?? undefined;
-					const objectBcs = object.result.object.bcs?.value ?? undefined;
+						const bcsContent = object.result.object.contents?.value ?? undefined;
+						const objectBcs = object.result.object.bcs?.value ?? undefined;
 
-					// Package objects have type "package" which is not a struct tag, so don't normalize it
-					const objectType = object.result.object.objectType;
-					const type =
-						objectType && objectType.includes('::')
-							? normalizeStructTag(objectType)
-							: (objectType ?? '');
+						// Package objects have type "package" which is not a struct tag, so don't normalize it
+						const objectType = object.result.object.objectType;
+						const type =
+							objectType && objectType.includes('::')
+								? normalizeStructTag(objectType)
+								: (objectType ?? '');
 
-					const jsonContent = options.include?.json
-						? object.result.object.json
-							? (Value.toJson(object.result.object.json) as Record<string, unknown>)
-							: null
-						: undefined;
+						const jsonContent = options.include?.json
+							? object.result.object.json
+								? (Value.toJson(object.result.object.json) as Record<string, unknown>)
+								: null
+							: undefined;
 
-					const displayData = mapDisplayProto(
-						options.include?.display,
-						object.result.object.display,
-					);
+						const displayData = mapDisplayProto(
+							options.include?.display,
+							object.result.object.display,
+						);
 
-					return {
-						objectId: object.result.object.objectId!,
-						version: object.result.object.version?.toString()!,
-						digest: object.result.object.digest!,
-						content: bcsContent as SuiClientTypes.Object<Include>['content'],
-						owner: mapOwner(object.result.object.owner)!,
-						type,
-						previousTransaction: (object.result.object.previousTransaction ??
-							undefined) as SuiClientTypes.Object<Include>['previousTransaction'],
-						objectBcs: objectBcs as SuiClientTypes.Object<Include>['objectBcs'],
-						json: jsonContent as SuiClientTypes.Object<Include>['json'],
-						display: displayData as SuiClientTypes.Object<Include>['display'],
-					};
-				}),
+						return {
+							objectId: object.result.object.objectId!,
+							version: object.result.object.version?.toString()!,
+							digest: object.result.object.digest!,
+							content: bcsContent as SuiClientTypes.Object<Include>['content'],
+							owner: mapOwner(object.result.object.owner)!,
+							type,
+							previousTransaction: (object.result.object.previousTransaction ??
+								undefined) as SuiClientTypes.Object<Include>['previousTransaction'],
+							objectBcs: objectBcs as SuiClientTypes.Object<Include>['objectBcs'],
+							json: jsonContent as SuiClientTypes.Object<Include>['json'],
+							display: displayData as SuiClientTypes.Object<Include>['display'],
+						};
+					},
+				),
 			);
 		}
 
@@ -362,25 +381,32 @@ export class GrpcCoreClient extends CoreClient {
 	async getTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.GetTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		const { response } = await this.#client.ledgerService.getTransaction(
-			{
-				digest: options.digest,
-				readMask: {
-					paths: transactionReadMaskPaths(options.include),
+		try {
+			const { response } = await this.#client.ledgerService.getTransaction(
+				{
+					digest: options.digest,
+					readMask: {
+						paths: transactionReadMaskPaths(options.include),
+					},
 				},
-			},
-			{ abort: options.signal },
-		);
+				{ abort: options.signal },
+			);
 
-		if (!response.transaction) {
-			throw new Error(`Transaction ${options.digest} not found`);
+			if (!response.transaction) {
+				throw new TransactionError('notFound', options.digest);
+			}
+
+			return withProtoJson(
+				parseGrpcTransactionResponse(response.transaction, { include: options.include }),
+				options.include,
+				() => ExecutedTransaction.toJson(response.transaction!),
+			);
+		} catch (error) {
+			if (error instanceof RpcError && error.code === 'NOT_FOUND') {
+				throw new TransactionError('notFound', options.digest, { cause: error });
+			}
+			throw error;
 		}
-
-		return withProtoJson(
-			parseGrpcTransactionResponse(response.transaction, { include: options.include }),
-			options.include,
-			() => ExecutedTransaction.toJson(response.transaction!),
-		);
 	}
 	async executeTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.ExecuteTransactionOptions<Include>,

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -137,8 +137,7 @@ export class GrpcCoreClient extends CoreClient {
 							const error = object.result.error;
 							const reason: ObjectErrorReason =
 								error.code === GrpcStatusCode.NOT_FOUND ? 'notFound' : 'unknown';
-							return new ObjectError(error.message, {
-								code: String(error.code),
+							return new ObjectError(String(error.code), error.message, {
 								cause: error,
 								reason,
 								objectId: batch[index],
@@ -146,7 +145,7 @@ export class GrpcCoreClient extends CoreClient {
 						}
 
 						if (object.result.oneofKind !== 'object') {
-							return new ObjectError('Unexpected result type', {
+							return new ObjectError('unknown', 'Unexpected result type', {
 								reason: 'unknown',
 								objectId: batch[index],
 							});

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -61,6 +61,7 @@ import type { QueryEnd, QueryOptions } from './proto/sui/rpc/v2/query_options.js
 import { Ordering, QueryEndReason } from './proto/sui/rpc/v2/query_options.js';
 import type { ResolvedPagination } from '../client/query-filters.js';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
+import { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
 import {
 	resolveEventFilter,
 	resolvePagination,
@@ -73,12 +74,10 @@ export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
 }
 
-const GRPC_NOT_FOUND_CODE = 5;
-
 function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (!(error instanceof RpcError)) return false;
-	if (error.code === 'NOT_FOUND') return true;
-	if (error.code !== 'RESOURCE_EXHAUSTED') return false;
+	if (error.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) return true;
+	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
 	try {
 		// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a
@@ -137,8 +136,9 @@ export class GrpcCoreClient extends CoreClient {
 						if (object.result.oneofKind === 'error') {
 							const error = object.result.error;
 							const reason: ObjectErrorReason =
-								error.code === GRPC_NOT_FOUND_CODE ? 'notFound' : 'unknown';
-							return new ObjectError(String(error.code), error.message, {
+								error.code === GrpcStatusCode.NOT_FOUND ? 'notFound' : 'unknown';
+							return new ObjectError(error.message, {
+								code: String(error.code),
 								cause: error,
 								reason,
 								objectId: batch[index],
@@ -146,7 +146,7 @@ export class GrpcCoreClient extends CoreClient {
 						}
 
 						if (object.result.oneofKind !== 'object') {
-							return new ObjectError('unknown', 'Unexpected result type', {
+							return new ObjectError('Unexpected result type', {
 								reason: 'unknown',
 								objectId: batch[index],
 							});
@@ -402,7 +402,7 @@ export class GrpcCoreClient extends CoreClient {
 				() => ExecutedTransaction.toJson(response.transaction!),
 			);
 		} catch (error) {
-			if (error instanceof RpcError && error.code === 'NOT_FOUND') {
+			if (error instanceof RpcError && error.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) {
 				throw new TransactionError('notFound', options.digest, { cause: error });
 			}
 			throw error;

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -10,6 +10,7 @@ import type {
 	EventId,
 	ExecutionStatus as JsonRpcExecutionStatus,
 	ObjectOwner,
+	ObjectResponseError,
 	SuiMoveAbilitySet,
 	SuiMoveAbort,
 	SuiMoveNormalizedType,
@@ -36,15 +37,74 @@ import { deriveDynamicFieldID } from '../utils/dynamic-fields.js';
 import { SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_ADDRESS } from '../utils/constants.js';
 import { CoreClient } from '../client/core.js';
 import type { SuiClientTypes } from '../client/types.js';
-import { ObjectError } from '../client/errors.js';
+import { ObjectError, TransactionError } from '../client/errors.js';
 import {
 	formatMoveAbortMessage,
 	parseTransactionBcs,
 	parseTransactionEffectsBcs,
 } from '../client/index.js';
 import type { SuiJsonRpcClient } from './client.js';
+import { JsonRpcError } from './errors.js';
 
 const MAX_GAS = 50_000_000_000;
+
+function mapJsonRpcObjectError(
+	response: ObjectResponseError,
+	requestedObjectId?: string,
+): ObjectError {
+	switch (response.code) {
+		case 'notExists':
+			return new ObjectError(response.code, `Object ${response.object_id} does not exist`, {
+				cause: response,
+				reason: 'notFound',
+				objectId: requestedObjectId ?? response.object_id,
+			});
+		case 'dynamicFieldNotFound':
+			return new ObjectError(
+				response.code,
+				`Dynamic field not found for object ${response.parent_object_id}`,
+				{
+					cause: response,
+					reason: 'notFound',
+					objectId: requestedObjectId ?? response.parent_object_id,
+				},
+			);
+		case 'deleted':
+			return new ObjectError(response.code, `Object ${response.object_id} has been deleted`, {
+				cause: response,
+				reason: 'deleted',
+				objectId: requestedObjectId ?? response.object_id,
+			});
+		case 'displayError':
+			return new ObjectError(response.code, `Display error: ${response.error}`, {
+				cause: response,
+				reason: 'unknown',
+				objectId: requestedObjectId,
+			});
+		case 'unknown':
+			return new ObjectError(
+				response.code,
+				`Unknown error while loading object${requestedObjectId ? ` ${requestedObjectId}` : ''}`,
+				{
+					cause: response,
+					reason: 'unknown',
+					objectId: requestedObjectId,
+				},
+			);
+		default:
+			response satisfies never;
+			throw new Error('Unknown JSON-RPC object error');
+	}
+}
+
+function isJsonRpcTransactionNotFound(error: unknown, digest: string): boolean {
+	if (!(error instanceof JsonRpcError) || error.code !== -32602) return false;
+
+	return (
+		error.message === `Invalid Params: Transaction ${digest} not found` ||
+		error.message === `Could not find the referenced transaction [TransactionDigest(${digest})].`
+	);
+}
 
 function parseJsonRpcExecutionStatus(
 	status: JsonRpcExecutionStatus,
@@ -160,7 +220,7 @@ export class JSONRpcCoreClient extends CoreClient {
 
 			for (const [idx, object] of objects.entries()) {
 				if (object.error) {
-					results.push(ObjectError.fromResponse(object.error, batch[idx]));
+					results.push(mapJsonRpcObjectError(object.error, batch[idx]));
 				} else {
 					results.push(parseObject(object.data!, options.include));
 				}
@@ -211,7 +271,7 @@ export class JSONRpcCoreClient extends CoreClient {
 		return {
 			objects: objects.data.map((result) => {
 				if (result.error) {
-					throw ObjectError.fromResponse(result.error);
+					throw mapJsonRpcObjectError(result.error);
 				}
 
 				return parseObject(result.data!, options.include);
@@ -340,22 +400,29 @@ export class JSONRpcCoreClient extends CoreClient {
 	async getTransaction<Include extends SuiClientTypes.TransactionInclude = {}>(
 		options: SuiClientTypes.GetTransactionOptions<Include>,
 	): Promise<SuiClientTypes.TransactionResult<Include>> {
-		const transaction = await this.#jsonRpcClient.getTransactionBlock({
-			digest: options.digest,
-			options: {
-				// showRawInput is always needed to extract signatures from SenderSignedData
-				showRawInput: true,
-				// showEffects is always needed to get status
-				showEffects: true,
-				showObjectChanges: options.include?.objectTypes ?? false,
-				showRawEffects: options.include?.effects ?? false,
-				showEvents: options.include?.events ?? false,
-				showBalanceChanges: options.include?.balanceChanges ?? false,
-			},
-			signal: options.signal,
-		});
+		try {
+			const transaction = await this.#jsonRpcClient.getTransactionBlock({
+				digest: options.digest,
+				options: {
+					// showRawInput is always needed to extract signatures from SenderSignedData
+					showRawInput: true,
+					// showEffects is always needed to get status
+					showEffects: true,
+					showObjectChanges: options.include?.objectTypes ?? false,
+					showRawEffects: options.include?.effects ?? false,
+					showEvents: options.include?.events ?? false,
+					showBalanceChanges: options.include?.balanceChanges ?? false,
+				},
+				signal: options.signal,
+			});
 
-		return parseTransaction(transaction, options.include);
+			return parseTransaction(transaction, options.include);
+		} catch (error) {
+			if (isJsonRpcTransactionNotFound(error, options.digest)) {
+				throw new TransactionError('notFound', options.digest, { cause: error });
+			}
+			throw error;
+		}
 	}
 	/**
 	 * @deprecated JSON-RPC APIs are deprecated in the Sui TypeScript SDK. Use `SuiGrpcClient`

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -54,38 +54,38 @@ function mapJsonRpcObjectError(
 ): ObjectError {
 	switch (response.code) {
 		case 'notExists':
-			return new ObjectError(`Object ${response.object_id} does not exist`, {
-				code: response.code,
+			return new ObjectError(response.code, `Object ${response.object_id} does not exist`, {
 				cause: response,
 				reason: 'notFound',
 				objectId: requestedObjectId ?? response.object_id,
 			});
 		case 'dynamicFieldNotFound':
-			return new ObjectError(`Dynamic field not found for object ${response.parent_object_id}`, {
-				code: response.code,
-				cause: response,
-				reason: 'notFound',
-				objectId: requestedObjectId ?? response.parent_object_id,
-			});
+			return new ObjectError(
+				response.code,
+				`Dynamic field not found for object ${response.parent_object_id}`,
+				{
+					cause: response,
+					reason: 'notFound',
+					objectId: requestedObjectId ?? response.parent_object_id,
+				},
+			);
 		case 'deleted':
-			return new ObjectError(`Object ${response.object_id} has been deleted`, {
-				code: response.code,
+			return new ObjectError(response.code, `Object ${response.object_id} has been deleted`, {
 				cause: response,
 				reason: 'deleted',
 				objectId: requestedObjectId ?? response.object_id,
 			});
 		case 'displayError':
-			return new ObjectError(`Display error: ${response.error}`, {
-				code: response.code,
+			return new ObjectError(response.code, `Display error: ${response.error}`, {
 				cause: response,
 				reason: 'unknown',
 				objectId: requestedObjectId,
 			});
 		case 'unknown':
 			return new ObjectError(
+				response.code,
 				`Unknown error while loading object${requestedObjectId ? ` ${requestedObjectId}` : ''}`,
 				{
-					code: response.code,
 					cause: response,
 					reason: 'unknown',
 					objectId: requestedObjectId,

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -54,38 +54,38 @@ function mapJsonRpcObjectError(
 ): ObjectError {
 	switch (response.code) {
 		case 'notExists':
-			return new ObjectError(response.code, `Object ${response.object_id} does not exist`, {
+			return new ObjectError(`Object ${response.object_id} does not exist`, {
+				code: response.code,
 				cause: response,
 				reason: 'notFound',
 				objectId: requestedObjectId ?? response.object_id,
 			});
 		case 'dynamicFieldNotFound':
-			return new ObjectError(
-				response.code,
-				`Dynamic field not found for object ${response.parent_object_id}`,
-				{
-					cause: response,
-					reason: 'notFound',
-					objectId: requestedObjectId ?? response.parent_object_id,
-				},
-			);
+			return new ObjectError(`Dynamic field not found for object ${response.parent_object_id}`, {
+				code: response.code,
+				cause: response,
+				reason: 'notFound',
+				objectId: requestedObjectId ?? response.parent_object_id,
+			});
 		case 'deleted':
-			return new ObjectError(response.code, `Object ${response.object_id} has been deleted`, {
+			return new ObjectError(`Object ${response.object_id} has been deleted`, {
+				code: response.code,
 				cause: response,
 				reason: 'deleted',
 				objectId: requestedObjectId ?? response.object_id,
 			});
 		case 'displayError':
-			return new ObjectError(response.code, `Display error: ${response.error}`, {
+			return new ObjectError(`Display error: ${response.error}`, {
+				code: response.code,
 				cause: response,
 				reason: 'unknown',
 				objectId: requestedObjectId,
 			});
 		case 'unknown':
 			return new ObjectError(
-				response.code,
 				`Unknown error while loading object${requestedObjectId ? ` ${requestedObjectId}` : ''}`,
 				{
+					code: response.code,
 					cause: response,
 					reason: 'unknown',
 					objectId: requestedObjectId,

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -82,6 +82,7 @@ function mapJsonRpcObjectError(
 				objectId: requestedObjectId,
 			});
 		case 'unknown':
+		default:
 			return new ObjectError(
 				response.code,
 				`Unknown error while loading object${requestedObjectId ? ` ${requestedObjectId}` : ''}`,
@@ -91,9 +92,6 @@ function mapJsonRpcObjectError(
 					objectId: requestedObjectId,
 				},
 			);
-		default:
-			response satisfies never;
-			throw new Error('Unknown JSON-RPC object error');
 	}
 }
 

--- a/packages/sui/test/e2e/clients/core/objects.test.ts
+++ b/packages/sui/test/e2e/clients/core/objects.test.ts
@@ -7,6 +7,7 @@ import { Transaction } from '../../../../src/transactions/index.js';
 import { setup, TestToolbox, createTestWithAllClients } from '../../utils/setup.js';
 import { normalizeSuiAddress, SUI_TYPE_ARG } from '../../../../src/utils/index.js';
 import { bcs } from '../../../../src/bcs/index.js';
+import { ObjectError } from '../../../../src/client/index.js';
 
 const SimpleObject = bcs.struct('SimpleObject', {
 	id: bcs.Address,
@@ -106,7 +107,10 @@ describe('Core API - Objects', () => {
 
 		testWithAllClients('should throw error for non-existent object', async (client) => {
 			const fakeObjectId = normalizeSuiAddress('0x9999');
-			await expect(client.core.getObject({ objectId: fakeObjectId })).rejects.toThrow();
+			const error = await client.core.getObject({ objectId: fakeObjectId }).catch((error) => error);
+
+			expect(error).toBeInstanceOf(ObjectError);
+			expect(error).toMatchObject({ reason: 'notFound', objectId: fakeObjectId });
 		});
 
 		testWithAllClients('should verify owner is correct', async (client) => {
@@ -158,7 +162,8 @@ describe('Core API - Objects', () => {
 			expect(objects[0]).not.toBeInstanceOf(Error);
 
 			// Second should be error
-			expect(objects[1]).toBeInstanceOf(Error);
+			expect(objects[1]).toBeInstanceOf(ObjectError);
+			expect(objects[1]).toMatchObject({ reason: 'notFound', objectId: objectIds[1] });
 		});
 
 		testWithAllClients('should handle empty array', async (client) => {

--- a/packages/sui/test/e2e/clients/core/transactions.test.ts
+++ b/packages/sui/test/e2e/clients/core/transactions.test.ts
@@ -11,6 +11,7 @@ import {
 import { Transaction } from '../../../../src/transactions/index.js';
 import { SUI_TYPE_ARG } from '../../../../src/utils/index.js';
 import { Ed25519Keypair } from '../../../../src/keypairs/ed25519/keypair.js';
+import { TransactionError } from '../../../../src/client/index.js';
 
 describe('Core API - Transactions', () => {
 	let toolbox: TestToolbox;
@@ -97,9 +98,13 @@ describe('Core API - Transactions', () => {
 		});
 
 		testWithAllClients('should throw error for non-existent digest', async (client) => {
-			const fakeDigest = 'ABCDEFabcdef1234567890123456789012345678901234567890123456789012';
+			const fakeDigest = '11111111111111111111111111111111';
+			const error = await client.core
+				.getTransaction({ digest: fakeDigest })
+				.catch((error) => error);
 
-			await expect(client.core.getTransaction({ digest: fakeDigest })).rejects.toThrow();
+			expect(error).toBeInstanceOf(TransactionError);
+			expect(error).toMatchObject({ reason: 'notFound', digest: fakeDigest });
 		});
 
 		testWithAllClients('should throw error for invalid digest format', async (client) => {

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -54,6 +54,7 @@ describe('client lookup errors', () => {
 		expect(error).toBeInstanceOf(SuiClientError);
 		expect(error.reason).toBe('notFound');
 		expect(error.digest).toBe(digest);
+		expect(error.message).toBe(`Transaction ${digest} not found`);
 		expect(error.cause).toBe(cause);
 	});
 });
@@ -108,6 +109,8 @@ describe('getObjects', () => {
 			'deleted',
 		],
 		[{ code: 'unknown' }, 'unknown', 'unknown'],
+		// Codes the SDK doesn't know about yet still map to an ObjectError entry.
+		[{ code: 'futureCode' }, 'futureCode', 'unknown'],
 	] as const)('preserves JSON-RPC code %s and adds reason %s', async (wireError, code, reason) => {
 		const transport: JsonRpcTransport = {
 			request: vi.fn().mockResolvedValue([{ error: wireError }]),

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RpcError } from '@protobuf-ts/runtime-rpc';
+import { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ObjectError, SuiClientError, TransactionError } from '../../../src/client/index.js';
@@ -25,13 +26,26 @@ async function captureError(promise: Promise<unknown>): Promise<Error> {
 }
 
 describe('client lookup errors', () => {
-	it('keeps the existing ObjectError constructor and adds a normalized reason', () => {
+	it('keeps the deprecated ObjectError constructor without guessing a normalized reason', () => {
 		const error = new ObjectError('notExists', 'Object 0x1 does not exist');
 
 		expect(error).toBeInstanceOf(SuiClientError);
 		expect(error.code).toBe('notExists');
-		expect(error.reason).toBe('notFound');
+		expect(error.reason).toBe('unknown');
 		expect(error.message).toBe('Object 0x1 does not exist');
+
+		error.code = 'deleted';
+		expect(error.code).toBe('deleted');
+	});
+
+	it('requires an explicit normalized reason in the new ObjectError constructor', () => {
+		const error = new ObjectError('Object 0x1 does not exist', {
+			code: 'notExists',
+			reason: 'notFound',
+			objectId: '0x1',
+		});
+
+		expect(error).toMatchObject({ code: 'notExists', reason: 'notFound', objectId: '0x1' });
 	});
 
 	it('exposes a transport-neutral transaction lookup error', () => {
@@ -47,8 +61,8 @@ describe('client lookup errors', () => {
 
 describe('getObjects', () => {
 	it.each([
-		[5, 'notFound'],
-		[13, 'unknown'],
+		[GrpcStatusCode.NOT_FOUND, 'notFound'],
+		[GrpcStatusCode.INTERNAL, 'unknown'],
 	] as const)('maps gRPC status %i to ObjectError reason %s', async (status, reason) => {
 		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
 		const wireError = { code: status, message: 'object lookup failed', details: [] };
@@ -113,7 +127,10 @@ describe('getObjects', () => {
 describe('getTransaction', () => {
 	it('maps gRPC NOT_FOUND and preserves the RpcError as cause', async () => {
 		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
-		const wireError = new RpcError(`Transaction%20${digest}%20not%20found`, 'NOT_FOUND');
+		const wireError = new RpcError(
+			`Transaction%20${digest}%20not%20found`,
+			GrpcStatusCode[GrpcStatusCode.NOT_FOUND],
+		);
 		client.ledgerService.getTransaction = vi.fn().mockRejectedValue(wireError) as never;
 
 		const error = await captureError(client.core.getTransaction({ digest }));
@@ -125,7 +142,10 @@ describe('getTransaction', () => {
 
 	it('preserves unrelated gRPC errors', async () => {
 		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
-		const wireError = new RpcError('temporarily unavailable', 'UNAVAILABLE');
+		const wireError = new RpcError(
+			'temporarily unavailable',
+			GrpcStatusCode[GrpcStatusCode.UNAVAILABLE],
+		);
 		client.ledgerService.getTransaction = vi.fn().mockRejectedValue(wireError) as never;
 
 		await expect(client.core.getTransaction({ digest })).rejects.toBe(wireError);

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -1,0 +1,173 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RpcError } from '@protobuf-ts/runtime-rpc';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ObjectError, SuiClientError, TransactionError } from '../../../src/client/index.js';
+import { SuiGraphQLClient } from '../../../src/graphql/index.js';
+import { SuiGrpcClient } from '../../../src/grpc/index.js';
+import {
+	JsonRpcError,
+	SuiJsonRpcClient,
+	type JsonRpcTransport,
+} from '../../../src/jsonRpc/index.js';
+const digest = '11111111111111111111111111111111';
+
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+	try {
+		await promise;
+	} catch (error) {
+		return error as Error;
+	}
+
+	throw new Error('Expected promise to reject');
+}
+
+describe('client lookup errors', () => {
+	it('keeps the existing ObjectError constructor and adds a normalized reason', () => {
+		const error = new ObjectError('notExists', 'Object 0x1 does not exist');
+
+		expect(error).toBeInstanceOf(SuiClientError);
+		expect(error.code).toBe('notExists');
+		expect(error.reason).toBe('notFound');
+		expect(error.message).toBe('Object 0x1 does not exist');
+	});
+
+	it('exposes a transport-neutral transaction lookup error', () => {
+		const cause = new Error('wire error');
+		const error = new TransactionError('notFound', digest, { cause });
+
+		expect(error).toBeInstanceOf(SuiClientError);
+		expect(error.reason).toBe('notFound');
+		expect(error.digest).toBe(digest);
+		expect(error.cause).toBe(cause);
+	});
+});
+
+describe('getObjects', () => {
+	it.each([
+		[5, 'notFound'],
+		[13, 'unknown'],
+	] as const)('maps gRPC status %i to ObjectError reason %s', async (status, reason) => {
+		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
+		const wireError = { code: status, message: 'object lookup failed', details: [] };
+		client.ledgerService.batchGetObjects = vi.fn().mockResolvedValue({
+			response: {
+				objects: [{ result: { oneofKind: 'error', error: wireError } }],
+			},
+		}) as never;
+
+		const { objects } = await client.core.getObjects({ objectIds: ['0x123'] });
+		const error = objects[0];
+
+		expect(error).toBeInstanceOf(ObjectError);
+		expect(error).toMatchObject({
+			code: String(status),
+			reason,
+			objectId: '0x123',
+		});
+		expect((error as ObjectError).cause).toBe(wireError);
+	});
+
+	it('maps a missing GraphQL object without normalizing the reported input ID', async () => {
+		const client = new SuiGraphQLClient({
+			network: 'testnet',
+			url: 'http://localhost/graphql',
+			fetch: async () => Response.json({ data: { multiGetObjects: [] } }),
+		});
+
+		const { objects } = await client.core.getObjects({ objectIds: ['0x123'] });
+
+		expect(objects[0]).toBeInstanceOf(ObjectError);
+		expect(objects[0]).toMatchObject({
+			code: 'notFound',
+			reason: 'notFound',
+			objectId: '0x123',
+		});
+	});
+
+	it.each([
+		[{ code: 'notExists', object_id: '0x999' }, 'notExists', 'notFound'],
+		[
+			{ code: 'deleted', object_id: '0x999', digest: 'deleted', version: '1' },
+			'deleted',
+			'deleted',
+		],
+		[{ code: 'unknown' }, 'unknown', 'unknown'],
+	] as const)('preserves JSON-RPC code %s and adds reason %s', async (wireError, code, reason) => {
+		const transport: JsonRpcTransport = {
+			request: vi.fn().mockResolvedValue([{ error: wireError }]),
+		};
+		const client = new SuiJsonRpcClient({ network: 'testnet', transport });
+
+		const { objects } = await client.core.getObjects({ objectIds: ['0x123'] });
+		const error = objects[0];
+
+		expect(error).toBeInstanceOf(ObjectError);
+		expect(error).toMatchObject({ code, reason, objectId: '0x123' });
+		expect((error as ObjectError).cause).toBe(wireError);
+	});
+});
+
+describe('getTransaction', () => {
+	it('maps gRPC NOT_FOUND and preserves the RpcError as cause', async () => {
+		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
+		const wireError = new RpcError(`Transaction%20${digest}%20not%20found`, 'NOT_FOUND');
+		client.ledgerService.getTransaction = vi.fn().mockRejectedValue(wireError) as never;
+
+		const error = await captureError(client.core.getTransaction({ digest }));
+
+		expect(error).toBeInstanceOf(TransactionError);
+		expect(error).toMatchObject({ reason: 'notFound', digest });
+		expect(error.cause).toBe(wireError);
+	});
+
+	it('preserves unrelated gRPC errors', async () => {
+		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
+		const wireError = new RpcError('temporarily unavailable', 'UNAVAILABLE');
+		client.ledgerService.getTransaction = vi.fn().mockRejectedValue(wireError) as never;
+
+		await expect(client.core.getTransaction({ digest })).rejects.toBe(wireError);
+	});
+
+	it('maps a null GraphQL transaction result', async () => {
+		const client = new SuiGraphQLClient({
+			network: 'testnet',
+			url: 'http://localhost/graphql',
+			fetch: async () => Response.json({ data: { transaction: null } }),
+		});
+
+		const error = await captureError(client.core.getTransaction({ digest }));
+
+		expect(error).toBeInstanceOf(TransactionError);
+		expect(error).toMatchObject({ reason: 'notFound', digest });
+	});
+
+	it.each([
+		`Invalid Params: Transaction ${digest} not found`,
+		`Could not find the referenced transaction [TransactionDigest(${digest})].`,
+	])('maps a known JSON-RPC missing-transaction response', async (message) => {
+		const wireError = new JsonRpcError(message, -32602);
+		const transport: JsonRpcTransport = {
+			request: vi.fn().mockRejectedValue(wireError),
+		};
+		const client = new SuiJsonRpcClient({ network: 'testnet', transport });
+
+		const error = await captureError(client.core.getTransaction({ digest }));
+
+		expect(error).toBeInstanceOf(TransactionError);
+		expect(error).toMatchObject({ reason: 'notFound', digest });
+		expect(error.cause).toBe(wireError);
+	});
+
+	it('preserves unrelated JSON-RPC invalid-parameter errors', async () => {
+		const wireError = new JsonRpcError('Invalid Params: another validation failure', -32602);
+		const transport: JsonRpcTransport = {
+			request: vi.fn().mockRejectedValue(wireError),
+		};
+		const client = new SuiJsonRpcClient({ network: 'testnet', transport });
+
+		await expect(client.core.getTransaction({ digest })).rejects.toBe(wireError);
+	});
+});

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -26,7 +26,7 @@ async function captureError(promise: Promise<unknown>): Promise<Error> {
 }
 
 describe('client lookup errors', () => {
-	it('keeps the deprecated ObjectError constructor without guessing a normalized reason', () => {
+	it('keeps the existing ObjectError constructor without guessing a normalized reason', () => {
 		const error = new ObjectError('notExists', 'Object 0x1 does not exist');
 
 		expect(error).toBeInstanceOf(SuiClientError);
@@ -38,9 +38,8 @@ describe('client lookup errors', () => {
 		expect(error.code).toBe('deleted');
 	});
 
-	it('requires an explicit normalized reason in the new ObjectError constructor', () => {
-		const error = new ObjectError('Object 0x1 does not exist', {
-			code: 'notExists',
+	it('accepts an explicit normalized reason without changing the existing arguments', () => {
+		const error = new ObjectError('notExists', 'Object 0x1 does not exist', {
 			reason: 'notFound',
 			objectId: '0x1',
 		});


### PR DESCRIPTION
## Description

Builds on the transport-neutral error direction developed by @Danny-Devs in #988. Daniel is also credited as a co-author in the commit history.

Standardize object and transaction lookup misses across the gRPC, GraphQL, and JSON-RPC Core API implementations:

- Export `SuiClientError`, `ObjectError`, and a new `TransactionError` from `@mysten/sui/client`.
- Add transport-neutral `reason` and resource identity fields so consumers can use `instanceof` plus `reason` without knowing the underlying RPC.
- Return `ObjectError` for per-object gRPC failures, matching the existing GraphQL and JSON-RPC behavior.
- Throw `TransactionError` for confirmed missing transactions on all three transports.
- Preserve raw transport detail in the standard `cause` field where the transport supplies it.
- Use the existing typed `GrpcStatusCode` enum for numeric and string gRPC status mapping.

This intentionally keeps the scope smaller than #988. It does not introduce a transport-detail class hierarchy, change GraphQL error handling globally, or alter resolver aggregation.

### Compatibility

The existing required `ObjectError.code`, message, mutability, and `(code, message)` constructor are preserved. `reason`, `objectId`, `cause`, and the optional third constructor argument are additive. When the new options object is supplied, `reason` is required; the SDK always maps it explicitly rather than guessing portable semantics from a transport-specific code. Existing two-argument construction remains valid and conservatively produces `reason: "unknown"`.

Existing JSON-RPC object-error codes and messages, the GraphQL object-error message format, and the broad `(Object | Error)[]` response type remain unchanged.

Transaction mapping is deliberately narrow:

- gRPC: only `RpcError.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]`
- GraphQL: only a null transaction result after GraphQL errors have been handled
- JSON-RPC: only the two known `-32602` missing-transaction message shapes emitted by the legacy and current local implementations

Other transport and validation failures remain unchanged. The standardized transaction subclasses intentionally replace transport-specific missing-transaction error identities; the original errors remain available as `cause`.

## Test plan

- `pnpm turbo build --filter=@mysten/sui`
- `pnpm --filter @mysten/sui test` — 487 tests pass
- `pnpm --filter @mysten/sui vitest run --config test/e2e/vitest.config.mts test/e2e/clients/core/objects.test.ts test/e2e/clients/core/transactions.test.ts` — 308 pass, 4 skipped
- `pnpm --filter @mysten/sui oxlint:check`
- `pnpm prettier:check`
- Live Testnet smoke against the built branch:
  - gRPC percent-encoded `NOT_FOUND` becomes `TransactionError` with the original `RpcError` as `cause`
  - GraphQL null transaction becomes the same `TransactionError`
  - missing objects become `ObjectError` with `reason: "notFound"` on both transports

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
