### PR TITLE
fix(sui): use gRPC status names for ObjectError codes; fix hashi not-found detection

### DIFF
--- a/.changeset/grpc-object-error-codes.md
+++ b/.changeset/grpc-object-error-codes.md
@@ -1,0 +1,8 @@
+---
+'@mysten/sui': patch
+---
+
+Use stable gRPC status names (for example `'NOT_FOUND'`, `'INTERNAL'`) as the `ObjectError.code` for
+gRPC object lookup errors instead of the raw status number (`'5'`), mapping unrecognized statuses to
+`'unknown'`. Codes are fixed, human-readable identifiers; use the transport-neutral `reason` field to
+detect missing objects across transports.

--- a/.changeset/grpc-object-error-codes.md
+++ b/.changeset/grpc-object-error-codes.md
@@ -2,7 +2,9 @@
 '@mysten/sui': patch
 ---
 
-Use stable gRPC status names (for example `'NOT_FOUND'`, `'INTERNAL'`) as the `ObjectError.code` for
-gRPC object lookup errors instead of the raw status number (`'5'`), mapping unrecognized statuses to
-`'unknown'`. Codes are fixed, human-readable identifiers; use the transport-neutral `reason` field to
-detect missing objects across transports.
+Restore backwards-compatible `ObjectError.code` values for gRPC object lookups. Missing objects now
+report the long-standing `notExists` code (instead of the raw gRPC status number `'5'` introduced in
+2.26.0), so handlers written against earlier releases keep working on every transport. Other gRPC
+statuses use the status name (for example `'INTERNAL'`) as the code, and unrecognized statuses map to
+`'unknown'`. The transport-neutral `reason` field is unchanged and remains the preferred way to
+detect missing objects.

--- a/.changeset/hashi-object-error-reason.md
+++ b/.changeset/hashi-object-error-reason.md
@@ -1,0 +1,8 @@
+---
+'@mysten/hashi': patch
+---
+
+Detect missing objects via the transport-neutral `ObjectError.reason` (`'notFound'`) introduced in
+`@mysten/sui`, restoring `findUsedUtxos`, deposit status, and withdrawal status behavior on the gRPC
+transport. The legacy JSON-RPC code and gRPC message checks remain as fallbacks for older
+`@mysten/sui` versions.

--- a/packages/hashi/src/client.ts
+++ b/packages/hashi/src/client.ts
@@ -118,14 +118,16 @@ function defaultGraphqlUrl(network: string): string {
  * unknown) must propagate so other per-object failures can't be silently
  * downgraded to "not used."
  *
- * Two transports, two shapes:
- * - JSON-RPC returns a typed `ObjectError` whose `.code` is `notExists` or
- *   `dynamicFieldNotFound`. `ObjectError` is not re-exported from
- *   `@mysten/sui/client`, so the guard duck-types the field.
- * - gRPC stringifies the per-object error into `new Error(message)` with no
- *   code (see the `TODO: improve error handling` in `@mysten/sui/grpc/core.ts`).
- *   For now the only signal is the message, which the Sui ledger service
- *   returns as exactly `Object <id> not found` for missing objects.
+ * Current `@mysten/sui` versions return a typed `ObjectError` on every
+ * transport with a transport-neutral `.reason` (`notFound` for missing
+ * objects), which is the preferred signal. The guard duck-types `reason` and
+ * `code` instead of using `instanceof` so it keeps working when the app and
+ * this package resolve different copies of `@mysten/sui`.
+ *
+ * Fallbacks for older `@mysten/sui` versions without `reason`:
+ * - JSON-RPC: `ObjectError.code` is `notExists` or `dynamicFieldNotFound`.
+ * - gRPC: a plain `new Error(message)` with no code, where the only signal is
+ *   the ledger service's message, exactly `Object <id> not found`.
  *
  * Transport-level failures don't show up here — they reject the whole
  * `getObjects` promise rather than appearing in the result array.
@@ -133,7 +135,8 @@ function defaultGraphqlUrl(network: string): string {
 const GRPC_NOT_FOUND_MESSAGE_RE = /^Object 0x[0-9a-f]+ not found$/i;
 
 function isObjectNotFoundError(err: Error): boolean {
-	const code = (err as Error & { code?: unknown }).code;
+	const { code, reason } = err as Error & { code?: unknown; reason?: unknown };
+	if (reason === 'notFound') return true;
 	if (code === 'notExists' || code === 'dynamicFieldNotFound') return true;
 	return code === undefined && GRPC_NOT_FOUND_MESSAGE_RE.test(err.message);
 }

--- a/packages/hashi/test/unit/client.test.ts
+++ b/packages/hashi/test/unit/client.test.ts
@@ -1158,7 +1158,7 @@ describe('HashiClient', () => {
 		it("treats an ObjectError with reason 'notFound' as a miss", async () => {
 			mockFetchBitcoinState();
 			const objectErrorNotFound = () =>
-				new ObjectError('NOT_FOUND', 'Object 0x123 not found', {
+				new ObjectError('notExists', 'Object 0x123 not found', {
 					reason: 'notFound',
 					objectId: '0x123',
 				});

--- a/packages/hashi/test/unit/client.test.ts
+++ b/packages/hashi/test/unit/client.test.ts
@@ -22,6 +22,7 @@ import {
 import { Bag } from '../../src/contracts/hashi/deps/sui/bag.js';
 import { generateDepositAddress } from '../../src/bitcoin.js';
 import { reverseTxidBytes } from '../../src/util.js';
+import { ObjectError } from '@mysten/sui/client';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
 import { SuiGraphQLClient } from '@mysten/sui/graphql';
 import { bcs } from '@mysten/sui/bcs';
@@ -1152,6 +1153,41 @@ describe('HashiClient', () => {
 				inSpentPool: false,
 				isUsed: false,
 			});
+		});
+
+		it("treats an ObjectError with reason 'notFound' as a miss", async () => {
+			mockFetchBitcoinState();
+			const objectErrorNotFound = () =>
+				new ObjectError('NOT_FOUND', 'Object 0x123 not found', {
+					reason: 'notFound',
+					objectId: '0x123',
+				});
+			vi.spyOn(client.core, 'getObjects').mockResolvedValueOnce({
+				objects: [objectErrorNotFound(), objectErrorNotFound()],
+			} as never);
+
+			const result = await client.hashi.view.findUsedUtxos([
+				{ txid: '0x' + 'ab'.repeat(32), vout: 0 },
+			]);
+			expect(result[0]).toMatchObject({
+				inActivePool: false,
+				inSpentPool: false,
+				isUsed: false,
+			});
+		});
+
+		it("rethrows an ObjectError whose reason isn't 'notFound'", async () => {
+			mockFetchBitcoinState();
+			vi.spyOn(client.core, 'getObjects').mockResolvedValueOnce({
+				objects: [
+					new ObjectError('INTERNAL', 'internal server error', { reason: 'unknown' }),
+					new ObjectError('notExists', 'Object 0x123 not found', { reason: 'notFound' }),
+				],
+			} as never);
+
+			await expect(
+				client.hashi.view.findUsedUtxos([{ txid: '0x' + 'ab'.repeat(32), vout: 0 }]),
+			).rejects.toThrow('internal server error');
 		});
 
 		it("rethrows a plain Error whose message isn't the gRPC not-found pattern", async () => {

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CoreClientOptions, ObjectErrorReason, SuiClientTypes } from '../client/index.js';
+import type { CoreClientOptions, SuiClientTypes } from '../client/index.js';
 import {
 	CoreClient,
 	formatMoveAbortMessage,
@@ -135,11 +135,11 @@ export class GrpcCoreClient extends CoreClient {
 					(object, index): SuiClientTypes.Object<Include> | ObjectError => {
 						if (object.result.oneofKind === 'error') {
 							const error = object.result.error;
-							const reason: ObjectErrorReason =
-								error.code === GrpcStatusCode.NOT_FOUND ? 'notFound' : 'unknown';
-							return new ObjectError(String(error.code), error.message, {
+							// The code is the gRPC status name (for example `NOT_FOUND`), never
+							// the raw status number. Use `reason` for transport-neutral handling.
+							return new ObjectError(GrpcStatusCode[error.code] ?? 'unknown', error.message, {
 								cause: error,
-								reason,
+								reason: error.code === GrpcStatusCode.NOT_FOUND ? 'notFound' : 'unknown',
 								objectId: batch[index],
 							});
 						}

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -136,9 +136,10 @@ export class GrpcCoreClient extends CoreClient {
 						if (object.result.oneofKind === 'error') {
 							const error = object.result.error;
 							if (error.code === GrpcStatusCode.NOT_FOUND) {
-								// Reuse the long-standing JSON-RPC `notExists` code so handlers
-								// written against earlier releases keep working. `code` is a stable
-								// identifier, not the raw transport status.
+								// Special case for backwards compatibility: missing objects reuse
+								// the long-standing JSON-RPC `notExists` code instead of the gRPC
+								// status name, so handlers written against earlier releases keep
+								// working.
 								return new ObjectError('notExists', error.message, {
 									cause: error,
 									reason: 'notFound',

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -135,11 +135,21 @@ export class GrpcCoreClient extends CoreClient {
 					(object, index): SuiClientTypes.Object<Include> | ObjectError => {
 						if (object.result.oneofKind === 'error') {
 							const error = object.result.error;
-							// The code is the gRPC status name (for example `NOT_FOUND`), never
-							// the raw status number. Use `reason` for transport-neutral handling.
+							if (error.code === GrpcStatusCode.NOT_FOUND) {
+								// Reuse the long-standing JSON-RPC `notExists` code so handlers
+								// written against earlier releases keep working. `code` is a stable
+								// identifier, not the raw transport status.
+								return new ObjectError('notExists', error.message, {
+									cause: error,
+									reason: 'notFound',
+									objectId: batch[index],
+								});
+							}
+							// Other statuses use the gRPC status name (for example `INTERNAL`),
+							// never the raw status number.
 							return new ObjectError(GrpcStatusCode[error.code] ?? 'unknown', error.message, {
 								cause: error,
-								reason: error.code === GrpcStatusCode.NOT_FOUND ? 'notFound' : 'unknown',
+								reason: 'unknown',
 								objectId: batch[index],
 							});
 						}

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -61,8 +61,10 @@ describe('client lookup errors', () => {
 
 describe('getObjects', () => {
 	it.each([
-		// Codes are stable gRPC status names, never the raw status number.
-		[GrpcStatusCode.NOT_FOUND, 'NOT_FOUND', 'notFound'],
+		// Missing objects reuse the JSON-RPC `notExists` code so handlers written
+		// against earlier releases keep working on every transport.
+		[GrpcStatusCode.NOT_FOUND, 'notExists', 'notFound'],
+		// Other statuses use stable gRPC status names, never the raw status number.
 		[GrpcStatusCode.INTERNAL, 'INTERNAL', 'unknown'],
 		// Statuses outside the GrpcStatusCode enum never leak a numeric code.
 		[999 as GrpcStatusCode, 'unknown', 'unknown'],

--- a/packages/sui/test/unit/client/lookup-errors.test.ts
+++ b/packages/sui/test/unit/client/lookup-errors.test.ts
@@ -61,9 +61,12 @@ describe('client lookup errors', () => {
 
 describe('getObjects', () => {
 	it.each([
-		[GrpcStatusCode.NOT_FOUND, 'notFound'],
-		[GrpcStatusCode.INTERNAL, 'unknown'],
-	] as const)('maps gRPC status %i to ObjectError reason %s', async (status, reason) => {
+		// Codes are stable gRPC status names, never the raw status number.
+		[GrpcStatusCode.NOT_FOUND, 'NOT_FOUND', 'notFound'],
+		[GrpcStatusCode.INTERNAL, 'INTERNAL', 'unknown'],
+		// Statuses outside the GrpcStatusCode enum never leak a numeric code.
+		[999 as GrpcStatusCode, 'unknown', 'unknown'],
+	] as const)('maps gRPC status %i to ObjectError code %s', async (status, code, reason) => {
 		const client = new SuiGrpcClient({ network: 'testnet', baseUrl: 'http://localhost' });
 		const wireError = { code: status, message: 'object lookup failed', details: [] };
 		client.ledgerService.batchGetObjects = vi.fn().mockResolvedValue({
@@ -77,7 +80,7 @@ describe('getObjects', () => {
 
 		expect(error).toBeInstanceOf(ObjectError);
 		expect(error).toMatchObject({
-			code: String(status),
+			code,
 			reason,
 			objectId: '0x123',
 		});


### PR DESCRIPTION
## Description

The lookup-error unification (#1203, released in `@mysten/sui` 2.26.0) broke `@mysten/hashi` on the gRPC transport, which surfaced as the `Localnet Integration` failure on main ([run](https://github.com/MystenLabs/ts-sdks/actions/runs/31999401627/job/95299765685)): gRPC `getObjects` misses became `ObjectError` entries whose `code` was the stringified numeric gRPC status (`'5'`), and hashi's not-found guard only recognized the legacy JSON-RPC codes (`notExists`/`dynamicFieldNotFound`) or the code-less plain-Error shape gRPC used to return — so genuine not-found results were re-thrown. Since hashi 0.6.7 and sui 2.26.0 are both published, this combination is broken in the wild, not just in CI.

Two fixes:

- **`@mysten/sui` (patch):** gRPC object misses now report the long-standing JSON-RPC `notExists` code instead of the raw status number, so handlers written against pre-2.26 releases keep working on every transport — including already-installed `@mysten/hashi` ≤0.6.7, which is un-broken by this sui patch alone. `code` is treated as a stable, human-readable identifier rather than a raw wire value: other gRPC statuses use the status name (`'INTERNAL'`, ...), and statuses outside the enum map to `'unknown'`. The transport-neutral `reason` field is unchanged and remains the sanctioned cross-transport signal.
- **`@mysten/hashi` (patch):** `isObjectNotFoundError` now keys off `ObjectError.reason === 'notFound'` (duck-typed, so it survives duplicated `@mysten/sui` module instances), keeping the legacy code/message checks as fallbacks for older `@mysten/sui` versions. This makes the guard independent of transport-specific codes, and incidentally makes it work on GraphQL (code `'notFound'`), which the old checks never matched.

### Backwards-compat notes

- Treating pre-#1203 (≤2.25.x) as the compat baseline, since this fix releases before anyone depends on 2.26.0's numeric codes: the only `ObjectError.code` values consumers could have learned are the JSON-RPC ones, and `notExists` preserves them across transports.
- Pre-#1203 gRPC misses were plain `Error`s with **no `code` at all**; sniffers that required `code === undefined` plus a message match can't be satisfied by any `ObjectError`, which is why hashi also moves to the `reason` field.
- JSON-RPC codes (`notExists`, `deleted`, ...), GraphQL's `notFound` code, and all error messages are untouched.

## Test plan

- `pnpm --filter @mysten/sui vitest run test/unit/client/lookup-errors.test.ts` — updated the gRPC expectations (`notExists` for misses, status names otherwise) and added an out-of-enum status case (17 passing).
- `pnpm --filter @mysten/hashi vitest run --project=unit` — added cases for the new `ObjectError` shape (`reason: 'notFound'` treated as a miss, non-not-found `ObjectError` re-thrown) alongside the existing legacy-shape cases (188 passing).
- The hashi localnet integration suite (the failing CI job) runs in CI; not run locally.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)