### PR TITLE
feat(deepbook-account): adopt codegen config arguments and BCS overrides

### DIFF
--- a/packages/deepbook-account/README.md
+++ b/packages/deepbook-account/README.md
@@ -31,8 +31,8 @@ import { Transaction } from '@mysten/sui/transactions';
 import { AccountContract } from '@mysten/deepbook-account';
 
 const account = new AccountContract({
-	ACCOUNT_PACKAGE_ID: '0x…',
-	ACCOUNT_REGISTRY_ID: '0x…',
+	accountPackageId: '0x…',
+	accountRegistry: '0x…',
 });
 
 // The owner's canonical wrapper id — derived, no chain read.
@@ -47,8 +47,9 @@ tx.add(account.depositFunds({ wrapperId, coin, coinType: USDC }));
 const withdrawn = tx.add(account.withdrawFunds({ wrapperId, amount: 1_000_000n, coinType: USDC }));
 ```
 
-`AccountConfig` is ids-only by design: any config object carrying these two fields satisfies it
-directly. `DeepBookConfig` will once DeepBook's own account wrapper is deployed and ships its ids.
+`AccountConfig` is ids-only by design, and its keys are the codegen-generated config keys — the same
+object drives the generated move-call bindings' `config` option directly. Any config object carrying
+these two fields satisfies it.
 
 ## What's in the box
 

--- a/packages/deepbook-account/src/account.ts
+++ b/packages/deepbook-account/src/account.ts
@@ -10,10 +10,13 @@ import { deriveObjectID } from '@mysten/sui/utils';
 
 import * as account from './contracts/account/account.js';
 import * as accountRegistry from './contracts/account/account_registry.js';
+import type { AccountConfig as GeneratedAccountConfig } from './contracts/account/config-arguments.js';
 
 /**
  * The framework's well-known accumulator-root singleton, which settles the address
- * balances an account's custody funds move through.
+ * balances an account's custody funds move through. The generated bindings supply it
+ * automatically; it stays exported for PTBs that compose accounts with packages this
+ * SDK has no bindings for.
  */
 export const ACCUMULATOR_ROOT_ID = '0xacc';
 
@@ -22,15 +25,20 @@ export const ACCUMULATOR_ROOT_ID = '0xacc';
  *
  * Kept deliberately minimal — ids only — so any consumer of the shared account primitive
  * (DeepBook core's account wrapper, Predict, …) can drive these builders with its OWN
- * deployment's ids without constructing a full product-SDK config. It is shaped so that a
- * config carrying these two fields satisfies it directly; `DeepBookConfig` will once
- * DeepBook's own account wrapper is deployed and ships its ids.
+ * deployment's ids without constructing a full product-SDK config.
+ *
+ * Extends the codegen-generated config interface so there is exactly one config shape and
+ * casing: the generated bindings resolve `options.config` against these same keys, and if
+ * codegen adds, drops, or renames a key this file stops compiling instead of silently
+ * building a PTB against the wrong object. The ids are narrowed to `string` — codegen types
+ * the package id as optional and the registry as the wider `ConfigValue`, but the
+ * wrapper-address derivation needs plain ids.
  */
-export interface AccountConfig {
+export interface AccountConfig extends GeneratedAccountConfig {
 	/** The `account` Move package id. */
-	ACCOUNT_PACKAGE_ID: string;
+	accountPackageId: string;
 	/** The shared `AccountRegistry` object id. */
-	ACCOUNT_REGISTRY_ID: string;
+	accountRegistry: string;
 }
 
 // `AccountWrapperKey(address)` is a one-field positional struct, so its BCS is just the
@@ -68,8 +76,8 @@ export class AccountContract {
 	deriveAccountWrapperId(owner: string): string {
 		const key = AccountWrapperKey.serialize({ pos0: owner }).toBytes();
 		return deriveObjectID(
-			this.#config.ACCOUNT_REGISTRY_ID,
-			`${this.#config.ACCOUNT_PACKAGE_ID}::account_registry::AccountWrapperKey`,
+			this.#config.accountRegistry,
+			`${this.#config.accountPackageId}::account_registry::AccountWrapperKey`,
 			key,
 		);
 	}
@@ -82,7 +90,7 @@ export class AccountContract {
 	 */
 	generateAuth() {
 		return (tx: Transaction): TransactionResult =>
-			tx.add(account.generateAuth({ package: this.#config.ACCOUNT_PACKAGE_ID }));
+			tx.add(account.generateAuth({ config: this.#config }));
 	}
 
 	/**
@@ -93,18 +101,8 @@ export class AccountContract {
 	 */
 	createAccount() {
 		return (tx: Transaction): void => {
-			const wrapper = tx.add(
-				accountRegistry._new({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { registry: this.#config.ACCOUNT_REGISTRY_ID },
-				}),
-			);
-			tx.add(
-				account.share({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { self: wrapper },
-				}),
-			);
+			const wrapper = tx.add(accountRegistry._new({ config: this.#config }));
+			tx.add(account.share({ config: this.#config, arguments: { self: wrapper } }));
 		};
 	}
 
@@ -119,33 +117,23 @@ export class AccountContract {
 	 */
 	createAccountAndDeposit(params: { coin: TransactionObjectArgument; coinType: string }) {
 		return (tx: Transaction): void => {
-			const wrapper = tx.add(
-				accountRegistry._new({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { registry: this.#config.ACCOUNT_REGISTRY_ID },
-				}),
-			);
+			const wrapper = tx.add(accountRegistry._new({ config: this.#config }));
 			const auth = tx.add(this.generateAuth());
 			tx.add(
 				account.depositFunds({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { wrapper, auth, coin: params.coin, root: ACCUMULATOR_ROOT_ID },
+					config: this.#config,
+					arguments: { wrapper, auth, coin: params.coin },
 					typeArguments: [params.coinType],
 				}),
 			);
-			tx.add(
-				account.share({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { self: wrapper },
-				}),
-			);
+			tx.add(account.share({ config: this.#config, arguments: { self: wrapper } }));
 		};
 	}
 
 	/**
 	 * @description Deposit a caller-provided `coin` into the account's stored balance via the
-	 * PTB-callable `deposit_funds` (folds settle → authorize → load → deposit; clock
-	 * auto-injected). The caller owns coin sourcing.
+	 * PTB-callable `deposit_funds` (folds settle → authorize → load → deposit; clock and
+	 * accumulator root auto-injected). The caller owns coin sourcing.
 	 * @param {object} params Wrapper id, coin to deposit, and its coin type
 	 * @returns A function that takes a Transaction object
 	 */
@@ -154,13 +142,8 @@ export class AccountContract {
 			const auth = tx.add(this.generateAuth());
 			tx.add(
 				account.depositFunds({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: {
-						wrapper: params.wrapperId,
-						auth,
-						coin: params.coin,
-						root: ACCUMULATOR_ROOT_ID,
-					},
+					config: this.#config,
+					arguments: { wrapper: params.wrapperId, auth, coin: params.coin },
 					typeArguments: [params.coinType],
 				}),
 			);
@@ -170,7 +153,8 @@ export class AccountContract {
 	/**
 	 * @description Withdraw `amount` (raw u64 units) from the account's stored balance via
 	 * the PTB-callable `withdraw_funds` (folds settle → authorize → load → withdraw; clock
-	 * auto-injected), returning the minted `Coin<T>` for the caller to transfer or compose.
+	 * and accumulator root auto-injected), returning the minted `Coin<T>` for the caller to
+	 * transfer or compose.
 	 * @param {object} params Wrapper id, raw amount, and coin type
 	 * @returns A function that takes a Transaction object and returns the `Coin<T>`
 	 */
@@ -179,13 +163,8 @@ export class AccountContract {
 			const auth = tx.add(this.generateAuth());
 			return tx.add(
 				account.withdrawFunds({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: {
-						wrapper: params.wrapperId,
-						auth,
-						amount: params.amount,
-						root: ACCUMULATOR_ROOT_ID,
-					},
+					config: this.#config,
+					arguments: { wrapper: params.wrapperId, auth, amount: params.amount },
 					typeArguments: [params.coinType],
 				}),
 			);
@@ -200,12 +179,7 @@ export class AccountContract {
 	 */
 	loadAccount(params: { wrapperId: string }) {
 		return (tx: Transaction): TransactionResult =>
-			tx.add(
-				account.loadAccount({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
-					arguments: { self: params.wrapperId },
-				}),
-			);
+			tx.add(account.loadAccount({ config: this.#config, arguments: { self: params.wrapperId } }));
 	}
 
 	/**
@@ -222,9 +196,9 @@ export class AccountContract {
 			);
 			return tx.add(
 				account.balance({
-					package: this.#config.ACCOUNT_PACKAGE_ID,
+					config: this.#config,
 					typeArguments: [params.coinType],
-					arguments: { self: acct, root: ACCUMULATOR_ROOT_ID },
+					arguments: { self: acct },
 				}),
 			);
 		};

--- a/packages/deepbook-account/src/bcs/integers.ts
+++ b/packages/deepbook-account/src/bcs/integers.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Replacement BCS integer types for the generated Move bindings (wired up in
+// `sui-codegen.config.ts` under `bcsOverrides`).
+//
+// `@mysten/sui/bcs` parses the wide integers to decimal *strings*; these parse straight to bigint
+// instead. Serialization still accepts what the plain types accept, so tx builders and test
+// fixtures are unaffected.
+//
+// Representation only — deliberately no scaling. A field's Move type does not determine its
+// scale (custody balances are raw coin units while an app's own fields may be rates), and the
+// exact on-chain integers are what consumers decoding account state and events want.
+
+import { bcs } from '@mysten/sui/bcs';
+
+const toBigInt = (value: string) => BigInt(value);
+
+/** `u64` parsed as a bigint rather than a decimal string. */
+export const U64 = bcs.u64().transform({
+	input: (value: number | bigint | string) => value.toString(),
+	output: toBigInt,
+});
+
+/** `u128` parsed as a bigint rather than a decimal string. */
+export const U128 = bcs.u128().transform({
+	input: (value: number | bigint | string) => value.toString(),
+	output: toBigInt,
+});
+
+/** `u256` parsed as a bigint rather than a decimal string. */
+export const U256 = bcs.u256().transform({
+	input: (value: number | bigint | string) => value.toString(),
+	output: toBigInt,
+});

--- a/packages/deepbook-account/src/contracts/account/account.ts
+++ b/packages/deepbook-account/src/contracts/account/account.ts
@@ -68,10 +68,14 @@ export interface IdArguments {
 export interface IdOptions {
 	package?: string;
 	arguments: IdArguments | [self: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Returns the wrapper object ID. */
 export function id(options: IdOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -88,10 +92,14 @@ export interface LoadAccountArguments {
 export interface LoadAccountOptions {
 	package?: string;
 	arguments: LoadAccountArguments | [self: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Borrows the wrapped account for read-only composition. */
 export function loadAccount(options: LoadAccountOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -104,11 +112,13 @@ export function loadAccount(options: LoadAccountOptions) {
 }
 export interface BalanceArguments {
 	self: TransactionArgument;
-	root: RawTransactionArgument<string>;
 }
 export interface BalanceOptions {
 	package?: string;
-	arguments: BalanceArguments | [self: TransactionArgument, root: RawTransactionArgument<string>];
+	arguments: BalanceArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -116,9 +126,14 @@ export interface BalanceOptions {
  * delivered through the ambient accumulator but not yet settled into the account.
  */
 export function balance(options: BalanceOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
-	const argumentsTypes = [null, null, '0x2::clock::Clock'] satisfies (string | null)[];
-	const parameterNames = ['self', 'root'];
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
+	const argumentsTypes = [
+		null,
+		'0x2::accumulator::AccumulatorRoot',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['self'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -134,13 +149,17 @@ export interface OwnerArguments {
 export interface OwnerOptions {
 	package?: string;
 	arguments: OwnerArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /**
  * Returns the account owner address. This may be an EOA address or an
  * object-ID-as-address.
  */
 export function owner(options: OwnerOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -157,10 +176,14 @@ export interface AccountIdArguments {
 export interface AccountIdOptions {
 	package?: string;
 	arguments: AccountIdArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Returns the canonical account ID. */
 export function accountId(options: AccountIdOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -177,13 +200,17 @@ export interface ReferrerAccountIdArguments {
 export interface ReferrerAccountIdOptions {
 	package?: string;
 	arguments: ReferrerAccountIdArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /**
  * Returns the canonical referrer account ID recorded at creation for external Move
  * composition.
  */
 export function referrerAccountId(options: ReferrerAccountIdOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -200,10 +227,14 @@ export interface ReceiveAddressArguments {
 export interface ReceiveAddressOptions {
 	package?: string;
 	arguments: ReceiveAddressArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Returns the accumulator receive address for this account (the wrapper address). */
 export function receiveAddress(options: ReceiveAddressOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -217,10 +248,14 @@ export function receiveAddress(options: ReceiveAddressOptions) {
 export interface GenerateAuthOptions {
 	package?: string;
 	arguments?: [];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Creates owner authority bound to the transaction sender. */
 export function generateAuth(options: GenerateAuthOptions = {}) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -234,10 +269,14 @@ export interface GenerateAuthAsObjectArguments {
 export interface GenerateAuthAsObjectOptions {
 	package?: string;
 	arguments: GenerateAuthAsObjectArguments | [uid: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Creates owner authority bound to an owning object's address. */
 export function generateAuthAsObject(options: GenerateAuthAsObjectOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = ['0x2::object::ID'] satisfies (string | null)[];
 	const parameterNames = ['uid'];
 	return (tx: Transaction) =>
@@ -254,10 +293,14 @@ export interface ShareArguments {
 export interface ShareOptions {
 	package?: string;
 	arguments: ShareArguments | [self: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /** Shares a newly created account wrapper. */
 export function share(options: ShareOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -277,6 +320,9 @@ export interface LoadAccountMutOptions {
 	arguments:
 		| LoadAccountMutArguments
 		| [self: RawTransactionArgument<string>, auth: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 }
 /**
  * Consumes owner or app authority and returns the account's full mutable surface.
@@ -284,7 +330,8 @@ export interface LoadAccountMutOptions {
  * after registry authorization and carries no owner or operation restriction.
  */
 export function loadAccountMut(options: LoadAccountMutOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['self', 'auth'];
 	return (tx: Transaction) =>
@@ -297,13 +344,13 @@ export function loadAccountMut(options: LoadAccountMutOptions) {
 }
 export interface SettleArguments {
 	wrapper: RawTransactionArgument<string>;
-	root: RawTransactionArgument<string>;
 }
 export interface SettleOptions {
 	package?: string;
-	arguments:
-		| SettleArguments
-		| [wrapper: RawTransactionArgument<string>, root: RawTransactionArgument<string>];
+	arguments: SettleArguments | [wrapper: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -315,9 +362,14 @@ export interface SettleOptions {
  * borrow through `Auth`.
  */
 export function settle(options: SettleOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
-	const argumentsTypes = [null, null, '0x2::clock::Clock'] satisfies (string | null)[];
-	const parameterNames = ['wrapper', 'root'];
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
+	const argumentsTypes = [
+		null,
+		'0x2::accumulator::AccumulatorRoot',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['wrapper'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -334,6 +386,9 @@ export interface DepositArguments {
 export interface DepositOptions {
 	package?: string;
 	arguments: DepositArguments | [self: TransactionArgument, coin: RawTransactionArgument<string>];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -341,7 +396,8 @@ export interface DepositOptions {
  * settle through the wrapper first.
  */
 export function deposit(options: DepositOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['self', 'coin'];
 	return (tx: Transaction) =>
@@ -362,6 +418,9 @@ export interface WithdrawOptions {
 	arguments:
 		| WithdrawArguments
 		| [self: TransactionArgument, amount: RawTransactionArgument<number | bigint>];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -369,7 +428,8 @@ export interface WithdrawOptions {
  * settle through the wrapper first.
  */
 export function withdraw(options: WithdrawOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, 'u64'] satisfies (string | null)[];
 	const parameterNames = ['self', 'amount'];
 	return (tx: Transaction) =>
@@ -385,7 +445,6 @@ export interface DepositFundsArguments {
 	wrapper: RawTransactionArgument<string>;
 	auth: TransactionArgument;
 	coin: RawTransactionArgument<string>;
-	root: RawTransactionArgument<string>;
 }
 export interface DepositFundsOptions {
 	package?: string;
@@ -395,8 +454,10 @@ export interface DepositFundsOptions {
 				wrapper: RawTransactionArgument<string>,
 				auth: TransactionArgument,
 				coin: RawTransactionArgument<string>,
-				root: RawTransactionArgument<string>,
 		  ];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -404,9 +465,16 @@ export interface DepositFundsOptions {
  * into stored balance in one call.
  */
 export function depositFunds(options: DepositFundsOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
-	const argumentsTypes = [null, null, null, null, '0x2::clock::Clock'] satisfies (string | null)[];
-	const parameterNames = ['wrapper', 'auth', 'coin', 'root'];
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
+	const argumentsTypes = [
+		null,
+		null,
+		null,
+		'0x2::accumulator::AccumulatorRoot',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['wrapper', 'auth', 'coin'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -420,7 +488,6 @@ export interface WithdrawFundsArguments {
 	wrapper: RawTransactionArgument<string>;
 	auth: TransactionArgument;
 	amount: RawTransactionArgument<number | bigint>;
-	root: RawTransactionArgument<string>;
 }
 export interface WithdrawFundsOptions {
 	package?: string;
@@ -430,8 +497,10 @@ export interface WithdrawFundsOptions {
 				wrapper: RawTransactionArgument<string>,
 				auth: TransactionArgument,
 				amount: RawTransactionArgument<number | bigint>,
-				root: RawTransactionArgument<string>,
 		  ];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -439,9 +508,16 @@ export interface WithdrawFundsOptions {
  * from stored balance in one call.
  */
 export function withdrawFunds(options: WithdrawFundsOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
-	const argumentsTypes = [null, null, 'u64', null, '0x2::clock::Clock'] satisfies (string | null)[];
-	const parameterNames = ['wrapper', 'auth', 'amount', 'root'];
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
+	const argumentsTypes = [
+		null,
+		null,
+		'u64',
+		'0x2::accumulator::AccumulatorRoot',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['wrapper', 'auth', 'amount'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -461,6 +537,9 @@ export interface AttachOptions<Data extends BcsType<any>> {
 	arguments:
 		| AttachArguments<Data>
 		| [self: TransactionArgument, Permit: TransactionArgument, data: RawTransactionArgument<Data>];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string, string];
 }
 /**
@@ -468,7 +547,8 @@ export interface AttachOptions<Data extends BcsType<any>> {
  * Aborts if `App` already has data attached.
  */
 export function attach<Data extends BcsType<any>>(options: AttachOptions<Data>) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null, `${options.typeArguments[1]}`] satisfies (string | null)[];
 	const parameterNames = ['self', 'Permit', 'data'];
 	return (tx: Transaction) =>
@@ -486,11 +566,15 @@ export interface HasDataArguments {
 export interface HasDataOptions {
 	package?: string;
 	arguments: HasDataArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /** Whether `App` has data attached to this account. */
 export function hasData(options: HasDataOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -508,6 +592,9 @@ export interface BorrowDataArguments {
 export interface BorrowDataOptions {
 	package?: string;
 	arguments: BorrowDataArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string, string];
 }
 /**
@@ -516,7 +603,8 @@ export interface BorrowDataOptions {
  * nothing is attached.
  */
 export function borrowData(options: BorrowDataOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['self'];
 	return (tx: Transaction) =>
@@ -535,6 +623,9 @@ export interface BorrowDataMutArguments {
 export interface BorrowDataMutOptions {
 	package?: string;
 	arguments: BorrowDataMutArguments | [self: TransactionArgument, Permit: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string, string];
 }
 /**
@@ -542,7 +633,8 @@ export interface BorrowDataMutOptions {
  * nothing is attached.
  */
 export function borrowDataMut(options: BorrowDataMutOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['self', 'Permit'];
 	return (tx: Transaction) =>
@@ -561,6 +653,9 @@ export interface DetachArguments {
 export interface DetachOptions {
 	package?: string;
 	arguments: DetachArguments | [self: TransactionArgument, Permit: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
 	typeArguments: [string, string];
 }
 /**
@@ -568,7 +663,8 @@ export interface DetachOptions {
  * attached.
  */
 export function detach(options: DetachOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['self', 'Permit'];
 	return (tx: Transaction) =>

--- a/packages/deepbook-account/src/contracts/account/account_events.ts
+++ b/packages/deepbook-account/src/contracts/account/account_events.ts
@@ -10,6 +10,7 @@
 
 import { MoveStruct } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
+import { U64 } from '../../bcs/integers.js';
 const $moduleName = '@local-pkg/account::account_events';
 export const AccountCreated = new MoveStruct({
 	name: `${$moduleName}::AccountCreated`,
@@ -39,8 +40,8 @@ export const Deposited = new MoveStruct({
 	fields: {
 		account_id: bcs.Address,
 		coin_type: bcs.string(),
-		amount: bcs.u64(),
-		new_balance: bcs.u64(),
+		amount: U64,
+		new_balance: U64,
 	},
 });
 export const Withdrawn = new MoveStruct({
@@ -48,8 +49,8 @@ export const Withdrawn = new MoveStruct({
 	fields: {
 		account_id: bcs.Address,
 		coin_type: bcs.string(),
-		amount: bcs.u64(),
-		new_balance: bcs.u64(),
+		amount: U64,
+		new_balance: U64,
 	},
 });
 export const FundsSettled = new MoveStruct({
@@ -57,7 +58,7 @@ export const FundsSettled = new MoveStruct({
 	fields: {
 		account_id: bcs.Address,
 		coin_type: bcs.string(),
-		amount: bcs.u64(),
-		new_balance: bcs.u64(),
+		amount: U64,
+		new_balance: U64,
 	},
 });

--- a/packages/deepbook-account/src/contracts/account/account_registry.ts
+++ b/packages/deepbook-account/src/contracts/account/account_registry.ts
@@ -15,6 +15,7 @@ import {
 	MoveTuple,
 	normalizeMoveArguments,
 	type RawTransactionArgument,
+	type ConfigValue,
 } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
 import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
@@ -44,21 +45,24 @@ export const AppKey = new MoveTuple({
 	fields: [bcs.bool()],
 });
 export interface DerivedAddressArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	owner: RawTransactionArgument<string>;
 }
 export interface DerivedAddressOptions {
 	package?: string;
-	arguments:
-		| DerivedAddressArguments
-		| [registry: RawTransactionArgument<string>, owner: RawTransactionArgument<string>];
+	arguments: DerivedAddressArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /**
  * Returns the deterministic canonical account address for external discovery and
  * PTB construction.
  */
 export function derivedAddress(options: DerivedAddressOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, 'address'] satisfies (string | null)[];
 	const parameterNames = ['registry', 'owner'];
 	return (tx: Transaction) =>
@@ -66,25 +70,35 @@ export function derivedAddress(options: DerivedAddressOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'derived_address',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface DerivedWrapperAddressArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	owner: RawTransactionArgument<string>;
 }
 export interface DerivedWrapperAddressOptions {
 	package?: string;
-	arguments:
-		| DerivedWrapperAddressArguments
-		| [registry: RawTransactionArgument<string>, owner: RawTransactionArgument<string>];
+	arguments: DerivedWrapperAddressArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /**
  * Returns the deterministic wrapper address for external discovery, accumulator
  * delivery, and PTB construction.
  */
 export function derivedWrapperAddress(options: DerivedWrapperAddressOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, 'address'] satisfies (string | null)[];
 	const parameterNames = ['registry', 'owner'];
 	return (tx: Transaction) =>
@@ -92,22 +106,32 @@ export function derivedWrapperAddress(options: DerivedWrapperAddressOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'derived_wrapper_address',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface DerivedExistsArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	owner: RawTransactionArgument<string>;
 }
 export interface DerivedExistsOptions {
 	package?: string;
-	arguments:
-		| DerivedExistsArguments
-		| [registry: RawTransactionArgument<string>, owner: RawTransactionArgument<string>];
+	arguments: DerivedExistsArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /** Returns whether the canonical account identity has been claimed. */
 export function derivedExists(options: DerivedExistsOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, 'address'] satisfies (string | null)[];
 	const parameterNames = ['registry', 'owner'];
 	return (tx: Transaction) =>
@@ -115,22 +139,32 @@ export function derivedExists(options: DerivedExistsOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'derived_exists',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface DerivedWrapperExistsArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	owner: RawTransactionArgument<string>;
 }
 export interface DerivedWrapperExistsOptions {
 	package?: string;
-	arguments:
-		| DerivedWrapperExistsArguments
-		| [registry: RawTransactionArgument<string>, owner: RawTransactionArgument<string>];
+	arguments: DerivedWrapperExistsArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /** Returns whether the canonical wrapper has been claimed. */
 export function derivedWrapperExists(options: DerivedWrapperExistsOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, 'address'] satisfies (string | null)[];
 	const parameterNames = ['registry', 'owner'];
 	return (tx: Transaction) =>
@@ -138,22 +172,34 @@ export function derivedWrapperExists(options: DerivedWrapperExistsOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'derived_wrapper_exists',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface NewArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 }
 export interface NewOptions {
 	package?: string;
-	arguments: NewArguments | [registry: RawTransactionArgument<string>];
+	arguments?: NewArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /**
  * Creates the sender's canonical account and wrapper, aborting if either derived
  * ID is already claimed.
  */
 export function _new(options: NewOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['registry'];
 	return (tx: Transaction) =>
@@ -161,25 +207,35 @@ export function _new(options: NewOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'new',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface NewWithReferrerArguments {
-	registry: RawTransactionArgument<string>;
-	referrer: TransactionArgument;
+	registry?: RawTransactionArgument<string>;
+	referrer: RawTransactionArgument<string>;
 }
 export interface NewWithReferrerOptions {
 	package?: string;
-	arguments:
-		| NewWithReferrerArguments
-		| [registry: RawTransactionArgument<string>, referrer: TransactionArgument];
+	arguments: NewWithReferrerArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /**
  * Creates the sender's canonical account and permanently records the supplied
- * account as its referrer.
+ * wrapper's account as its referrer.
  */
 export function newWithReferrer(options: NewWithReferrerOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['registry', 'referrer'];
 	return (tx: Transaction) =>
@@ -187,25 +243,35 @@ export function newWithReferrer(options: NewWithReferrerOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'new_with_referrer',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface NewSelfOwnedArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	ownerUid: RawTransactionArgument<string>;
 }
 export interface NewSelfOwnedOptions {
 	package?: string;
-	arguments:
-		| NewSelfOwnedArguments
-		| [registry: RawTransactionArgument<string>, ownerUid: RawTransactionArgument<string>];
+	arguments: NewSelfOwnedArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 }
 /**
  * Creates the canonical account owned by `owner_uid`'s object address, aborting if
  * either derived ID is already claimed.
  */
 export function newSelfOwned(options: NewSelfOwnedOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, '0x2::object::ID'] satisfies (string | null)[];
 	const parameterNames = ['registry', 'ownerUid'];
 	return (tx: Transaction) =>
@@ -213,20 +279,32 @@ export function newSelfOwned(options: NewSelfOwnedOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'new_self_owned',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 		});
 }
 export interface IsAppAuthorizedArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 }
 export interface IsAppAuthorizedOptions {
 	package?: string;
-	arguments: IsAppAuthorizedArguments | [registry: RawTransactionArgument<string>];
+	arguments?: IsAppAuthorizedArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /** Returns whether `App` may request package-issued mutable account authority. */
 export function isAppAuthorized(options: IsAppAuthorizedOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['registry'];
 	return (tx: Transaction) =>
@@ -234,24 +312,34 @@ export function isAppAuthorized(options: IsAppAuthorizedOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'is_app_authorized',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 			typeArguments: options.typeArguments,
 		});
 }
 export interface AuthorizeAppArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	Cap: RawTransactionArgument<string>;
 }
 export interface AuthorizeAppOptions {
 	package?: string;
-	arguments:
-		| AuthorizeAppArguments
-		| [registry: RawTransactionArgument<string>, Cap: RawTransactionArgument<string>];
+	arguments: AuthorizeAppArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /** Globally authorizes `App` to request mutable authority for account wrappers. */
 export function authorizeApp(options: AuthorizeAppOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['registry', 'Cap'];
 	return (tx: Transaction) =>
@@ -259,24 +347,34 @@ export function authorizeApp(options: AuthorizeAppOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'authorize_app',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 			typeArguments: options.typeArguments,
 		});
 }
 export interface DeauthorizeAppArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	Cap: RawTransactionArgument<string>;
 }
 export interface DeauthorizeAppOptions {
 	package?: string;
-	arguments:
-		| DeauthorizeAppArguments
-		| [registry: RawTransactionArgument<string>, Cap: RawTransactionArgument<string>];
+	arguments: DeauthorizeAppArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /** Revokes `App` from requesting new mutable account authority. */
 export function deauthorizeApp(options: DeauthorizeAppOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['registry', 'Cap'];
 	return (tx: Transaction) =>
@@ -284,21 +382,33 @@ export function deauthorizeApp(options: DeauthorizeAppOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'deauthorize_app',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 			typeArguments: options.typeArguments,
 		});
 }
 export interface AssertAppIsAuthorizedArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 }
 export interface AssertAppIsAuthorizedOptions {
 	package?: string;
-	arguments: AssertAppIsAuthorizedArguments | [registry: RawTransactionArgument<string>];
+	arguments?: AssertAppIsAuthorizedArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /** Aborts unless `App` is currently authorized for app-driven account access. */
 export function assertAppIsAuthorized(options: AssertAppIsAuthorizedOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null] satisfies (string | null)[];
 	const parameterNames = ['registry'];
 	return (tx: Transaction) =>
@@ -306,19 +416,28 @@ export function assertAppIsAuthorized(options: AssertAppIsAuthorizedOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'assert_app_is_authorized',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 			typeArguments: options.typeArguments,
 		});
 }
 export interface GenerateAuthAsAppArguments {
-	registry: RawTransactionArgument<string>;
+	registry?: RawTransactionArgument<string>;
 	Permit: TransactionArgument;
 }
 export interface GenerateAuthAsAppOptions {
 	package?: string;
-	arguments:
-		| GenerateAuthAsAppArguments
-		| [registry: RawTransactionArgument<string>, Permit: TransactionArgument];
+	arguments: GenerateAuthAsAppArguments;
+	config?: {
+		accountRegistry: ConfigValue;
+		accountPackageId?: string;
+	};
 	typeArguments: [string];
 }
 /**
@@ -327,7 +446,8 @@ export interface GenerateAuthAsAppOptions {
  * the returned authority is not bound to an owner, wrapper, or operation.
  */
 export function generateAuthAsApp(options: GenerateAuthAsAppOptions) {
-	const packageAddress = options.package ?? '@local-pkg/account';
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
 	const parameterNames = ['registry', 'Permit'];
 	return (tx: Transaction) =>
@@ -335,7 +455,14 @@ export function generateAuthAsApp(options: GenerateAuthAsAppOptions) {
 			package: packageAddress,
 			module: 'account_registry',
 			function: 'generate_auth_as_app',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.accountRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
 			typeArguments: options.typeArguments,
 		});
 }

--- a/packages/deepbook-account/src/contracts/account/config-arguments.ts
+++ b/packages/deepbook-account/src/contracts/account/config-arguments.ts
@@ -1,0 +1,8 @@
+/**************************************************************
+ * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+ **************************************************************/
+import { type ConfigValue } from '../utils/index.js';
+export interface AccountConfig {
+	accountPackageId?: string;
+	accountRegistry: ConfigValue;
+}

--- a/packages/deepbook-account/src/contracts/account/deps/sui/bag.ts
+++ b/packages/deepbook-account/src/contracts/account/deps/sui/bag.ts
@@ -29,6 +29,7 @@
 
 import { MoveStruct } from '../../../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
+import { U64 } from '../../../../bcs/integers.js';
 const $moduleName = '0x2::bag';
 export const Bag = new MoveStruct({
 	name: `${$moduleName}::Bag`,
@@ -36,6 +37,6 @@ export const Bag = new MoveStruct({
 		/** the ID of this bag */
 		id: bcs.Address,
 		/** the number of key-value pairs in the bag */
-		size: bcs.u64(),
+		size: U64,
 	},
 });

--- a/packages/deepbook-account/src/contracts/utils/index.ts
+++ b/packages/deepbook-account/src/contracts/utils/index.ts
@@ -8,7 +8,11 @@ import {
 	BcsTuple,
 } from '@mysten/sui/bcs';
 import { normalizeStructTag, normalizeSuiAddress } from '@mysten/sui/utils';
-import { type TransactionArgument, isArgument } from '@mysten/sui/transactions';
+import {
+	type TransactionArgument,
+	type TransactionObjectArgument,
+	isArgument,
+} from '@mysten/sui/transactions';
 import { type ClientWithCoreApi, type SuiClientTypes } from '@mysten/sui/client';
 
 const MOVE_STDLIB_ADDRESS = normalizeSuiAddress('0x1');
@@ -106,6 +110,12 @@ export function normalizeMoveArguments(
 			continue;
 		}
 
+		if (argType === '0x2::accumulator::AccumulatorRoot') {
+			// Chain-wide shared singleton at a fixed address (SUI_ACCUMULATOR_ROOT_OBJECT_ID).
+			normalizedArgs.push((tx) => tx.object('0xacc'));
+			continue;
+		}
+
 		if (argType === '0x3::sui_system::SuiSystemState') {
 			normalizedArgs.push((tx) => tx.object.system());
 			continue;
@@ -124,7 +134,10 @@ export function normalizeMoveArguments(
 				throw new Error(`Expected arguments to be passed as an array`);
 			}
 			const name = parameterNames[index];
-			arg = args[name as keyof typeof args];
+			arg =
+				name !== undefined && Object.prototype.hasOwnProperty.call(args, name)
+					? args[name as keyof typeof args]
+					: undefined;
 
 			if (arg === undefined) {
 				throw new Error(`Parameter ${name} is required`);
@@ -156,6 +169,40 @@ export function normalizeMoveArguments(
 
 	return normalizedArgs;
 }
+
+/* -------------------------- Config-mapped arguments -------------------------- */
+
+/** Context passed to config resolver functions. */
+export interface ConfigResolverContext {
+	/**
+	 * The matched parameter's own instantiated type arguments (not the whole function's type
+	 * argument tuple). Concrete instantiations are canonical type tags; generic positions pass
+	 * the caller's `typeArguments` strings through as provided.
+	 */
+	typeArguments: string[];
+	/** The package address the generated call will be sent to. */
+	packageAddress: string;
+	/** The Move module of the generated call. */
+	moduleName: string;
+	/** The Move function of the generated call. */
+	functionName: string;
+	/** The Move name of the matched parameter, when the summary includes parameter names. */
+	parameterName?: string;
+	/** The matched parameter's position in the generated function's arguments. */
+	parameterIndex: number;
+}
+
+/**
+ * A non-callback transaction argument in a generated config object, used for keys whose matched
+ * parameter can't be supplied as an object id string.
+ */
+export type ConfigObjectValue = Exclude<TransactionObjectArgument, (...args: never[]) => unknown>;
+
+/**
+ * A plain value in a generated config object: an object id or a non-callback transaction
+ * argument. Keys that can resolve multiple bindings are typed as resolver functions instead.
+ */
+export type ConfigValue = string | ConfigObjectValue;
 
 /* -------------------------- Move type tags -------------------------- */
 

--- a/packages/deepbook-account/sui-codegen.config.ts
+++ b/packages/deepbook-account/sui-codegen.config.ts
@@ -9,6 +9,21 @@ const config: SuiCodegenConfig = {
 		{
 			package: '@local-pkg/account',
 			path: '../../../deepbookv3/packages/account',
+			// The package address and the per-network `AccountRegistry` singleton come from a
+			// config object instead of being threaded through every call site. The generated
+			// `AccountConfig` interface makes a deployment id that stops matching the deployed
+			// signature a compile error rather than a runtime abort.
+			configArguments: {
+				accountPackageId: { package: '@local-pkg/account' },
+				accountRegistry: { type: 'account_registry::AccountRegistry' },
+			},
+			// Parse `u64`/`u128`/`u256` straight to bigint rather than the decimal strings
+			// `@mysten/sui/bcs` yields. Representation only — no scaling is applied.
+			bcsOverrides: [
+				{ type: 'u64', source: './src/bcs/integers.ts#U64' },
+				{ type: 'u128', source: './src/bcs/integers.ts#U128' },
+				{ type: 'u256', source: './src/bcs/integers.ts#U256' },
+			],
 		},
 	],
 };

--- a/packages/deepbook-account/tests/account.test.ts
+++ b/packages/deepbook-account/tests/account.test.ts
@@ -11,7 +11,7 @@ const REGISTRY = '0x' + '22'.repeat(32);
 const OWNER = '0x' + 'ab'.repeat(32);
 const COIN_TYPE = '0x2::sui::SUI';
 
-const account = new AccountContract({ ACCOUNT_PACKAGE_ID: PKG, ACCOUNT_REGISTRY_ID: REGISTRY });
+const account = new AccountContract({ accountPackageId: PKG, accountRegistry: REGISTRY });
 
 // The move-call targets, in the order the builder emitted them.
 function targets(tx: Transaction): string[] {
@@ -129,8 +129,8 @@ describe('deriveAccountWrapperId', () => {
 
 	test('registry-specific: the same owner derives differently under another registry', () => {
 		const other = new AccountContract({
-			ACCOUNT_PACKAGE_ID: PKG,
-			ACCOUNT_REGISTRY_ID: '0x' + '33'.repeat(32),
+			accountPackageId: PKG,
+			accountRegistry: '0x' + '33'.repeat(32),
 		});
 		expect(other.deriveAccountWrapperId(OWNER)).not.toBe(account.deriveAccountWrapperId(OWNER));
 	});

--- a/packages/deepbook-predict/src/tx/common.ts
+++ b/packages/deepbook-predict/src/tx/common.ts
@@ -9,8 +9,8 @@ import type { PredictConfig } from '../config/index.js';
 // here in `(cfg) => (tx)` thunk form rather than callers reaching for the contract directly.
 export function accountContract(cfg: PredictConfig): AccountContract {
 	return new AccountContract({
-		ACCOUNT_PACKAGE_ID: cfg.packages.account,
-		ACCOUNT_REGISTRY_ID: cfg.objects.accountRegistry,
+		accountPackageId: cfg.packages.account,
+		accountRegistry: cfg.objects.accountRegistry,
 	});
 }
 


### PR DESCRIPTION
## Description

Stacked on #1198. Brings the new `@mysten/deepbook-account` package onto the codegen features that landed in #1163/#1201, mirroring what #1192 did for `deepbook-predict` — #1198 branched before those merged, so its bindings were generated old-style.

- **`configArguments`** maps the `account` package address and the shared `AccountRegistry` singleton onto config keys, so generated calls resolve them from a config object instead of each call site threading `package:` and the registry id by hand.
- **One config shape, one casing**: the public `AccountConfig` now extends the codegen-generated interface (with the ids narrowed to `string`), so the config keys are `accountPackageId` / `accountRegistry` everywhere rather than a SCREAMING_SNAKE public shape projected onto a camelCase generated one. The same object drives both `AccountContract` and the exported generated bindings' `config` option directly, and codegen renaming a key becomes a compile error. Predict's thin adapter in #1198 updates to the new key names; the transactions built are unchanged.
- **Accumulator root is auto-injected**: the regenerated bindings treat `0x2::accumulator::AccumulatorRoot` as a well-known object, so the explicit `root: ACCUMULATOR_ROOT_ID` arguments are gone from the hand-written builders. The argument is still passed — the generated layer supplies it — and the tests asserting `0xacc` at specific argument slots pass unchanged. `ACCUMULATOR_ROOT_ID` stays exported for PTBs composing accounts with packages this SDK has no bindings for.
- **`bcsOverrides`** (`src/bcs/integers.ts`) parse `u64`/`u128`/`u256` straight to bigint rather than the decimal strings `@mysten/sui/bcs` yields. In this package that reaches the exported `accountEvents` layouts (`amount` / `new_balance` on the deposit/withdraw events) and `Bag.size`. Representation only — no scaling.

Note on tooling: the bindings were regenerated with `@mysten/codegen` built from current `main` (this branch's workspace copy predates #1163). Generation is offline-only, so nothing in the branch depends on the newer tool at build or run time; once #1198 rebases onto `main`, the in-workspace `pnpm codegen` matches what's committed here.

## Test plan

- `@mysten/deepbook-account`: **8/8** unit tests pass — the only edits are the config key renames; the assertions pinning the accumulator root at its exact argument slot in `deposit_funds` / `withdraw_funds` and the registry id at `new`'s slot are unchanged and now satisfied by the generated layer instead of the hand-written builders.
- `@mysten/deepbook-predict`: **143/143** pass unchanged, including the byte-for-byte `deposit` regression pin — the config-driven builders emit identical transactions.
- Generated `contracts/utils/index.ts` is byte-identical to the copy #1192 generated on `main` for predict.
- `tsc --noEmit`, `turbo build` (deepbook-account + deepbook-predict), oxlint, and prettier all clean.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)