### PR TITLE
fix(deepbook-account): regenerate bindings against the deployed 1f79fe87 account

### DIFF
--- a/.changeset/deepbook-account-repin-8-21.md
+++ b/.changeset/deepbook-account-repin-8-21.md
@@ -1,0 +1,10 @@
+---
+'@mysten/deepbook-account': patch
+---
+
+Regenerate the Move bindings against the deployed `predict-testnet-8-21` account package (sourceCommit `1f79fe87`). The bindings were pinned to the older `predict-testnet-7-29` sources, where `Account` had no `referrer_receive_address`.
+
+- `Account` gains its trailing `referrer_receive_address: Option<address>` field, and the `referrerReceiveAddress` getter is now generated. Because BCS is positional, a struct missing a field silently mis-parses everything after it — harmless while the omission is the last field and callers read earlier ones, but it is corrected here rather than left latent.
+- A round-trip test pins the `Account` / `AccountWrapper` field sets and order, so a future regeneration that drops or reorders a field fails in this package instead of in a consumer's decoded output.
+
+No API or behavior change to `AccountContract`: the builders, their argument slots, and `deriveAccountWrapperId` are unchanged, and `AccountConfig` still supplies the deployed ids, so consumers targeting either deployment keep working.

--- a/.changeset/deepbook-account-repin-8-21.md
+++ b/.changeset/deepbook-account-repin-8-21.md
@@ -1,10 +1,10 @@
 ---
-'@mysten/deepbook-account': patch
+'@mysten/deepbook-account': minor
 ---
 
 Regenerate the Move bindings against the deployed `predict-testnet-8-21` account package (sourceCommit `1f79fe87`). The bindings were pinned to the older `predict-testnet-7-29` sources, where `Account` had no `referrer_receive_address`.
 
-- `Account` gains its trailing `referrer_receive_address: Option<address>` field, and the `referrerReceiveAddress` getter is now generated. Because BCS is positional, a struct missing a field silently mis-parses everything after it — harmless while the omission is the last field and callers read earlier ones, but it is corrected here rather than left latent.
-- A round-trip test pins the `Account` / `AccountWrapper` field sets and order, so a future regeneration that drops or reorders a field fails in this package instead of in a consumer's decoded output.
+- `Account` gains its trailing `referrer_receive_address: Option<address>` field, and the `referrerReceiveAddress` getter is now generated.
+- A round-trip test plus a byte-level assertion pin the `Account` / `AccountWrapper` field sets, order, and wire encoding, so a future regeneration that drops, reorders, or re-types a field fails in this package instead of in a consumer's decoded output.
 
-No API or behavior change to `AccountContract`: the builders, their argument slots, and `deriveAccountWrapperId` are unchanged, and `AccountConfig` still supplies the deployed ids, so consumers targeting either deployment keep working.
+**Breaking: this is a decode-layout change.** `AccountContract`'s API and behavior are unchanged — the builders, their argument slots, and `deriveAccountWrapperId` all emit byte-identical transactions, and `AccountConfig` still supplies the deployed ids. But the BCS structs now expect the 8-21 `Account`, so parsing an `Account` or `AccountWrapper` from the older 7-29 deployment will fail (`ULEB decode error: buffer overflow`) or, when the bytes are a view into a larger buffer as gRPC returns them, silently mis-decode `referrer_receive_address`. Consumers still reading 7-29 account objects should stay on `0.0.2`.

--- a/packages/deepbook-account/src/contracts/account/account.ts
+++ b/packages/deepbook-account/src/contracts/account/account.ts
@@ -38,6 +38,8 @@ export const Account = new MoveStruct({
 		settlements: bag.Bag,
 		/** Canonical account ID supplied at referral-based creation, if any. */
 		referrer_account_id: bcs.option(bcs.Address),
+		/** Referrer's wrapper address for accumulator delivery, if any. */
+		referrer_receive_address: bcs.option(bcs.Address),
 	},
 });
 export const AccountWrapper = new MoveStruct({
@@ -218,6 +220,33 @@ export function referrerAccountId(options: ReferrerAccountIdOptions) {
 			package: packageAddress,
 			module: 'account',
 			function: 'referrer_account_id',
+			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
+		});
+}
+export interface ReferrerReceiveAddressArguments {
+	self: TransactionArgument;
+}
+export interface ReferrerReceiveAddressOptions {
+	package?: string;
+	arguments: ReferrerReceiveAddressArguments | [self: TransactionArgument];
+	config?: {
+		accountPackageId?: string;
+	};
+}
+/**
+ * Returns the referrer's accumulator receive address for external Move
+ * composition.
+ */
+export function referrerReceiveAddress(options: ReferrerReceiveAddressOptions) {
+	const packageAddress =
+		options.package ?? options.config?.accountPackageId ?? '@local-pkg/account';
+	const argumentsTypes = [null] satisfies (string | null)[];
+	const parameterNames = ['self'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'account',
+			function: 'referrer_receive_address',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
 		});
 }

--- a/packages/deepbook-account/src/contracts/account/account_registry.ts
+++ b/packages/deepbook-account/src/contracts/account/account_registry.ts
@@ -231,7 +231,7 @@ export interface NewWithReferrerOptions {
 }
 /**
  * Creates the sender's canonical account and permanently records the supplied
- * wrapper's account as its referrer.
+ * wrapper's account identity and receive address as its referrer.
  */
 export function newWithReferrer(options: NewWithReferrerOptions) {
 	const packageAddress =

--- a/packages/deepbook-account/tests/account.test.ts
+++ b/packages/deepbook-account/tests/account.test.ts
@@ -5,6 +5,7 @@ import { normalizeSuiAddress } from '@mysten/sui/utils';
 import { describe, expect, test } from 'vitest';
 
 import { AccountContract } from '../src/account.js';
+import { Account, AccountWrapper } from '../src/index.js';
 
 const PKG = '0x' + '11'.repeat(32);
 const REGISTRY = '0x' + '22'.repeat(32);
@@ -135,5 +136,46 @@ describe('deriveAccountWrapperId', () => {
 			accountRegistry: '0x' + '33'.repeat(32),
 		});
 		expect(other.deriveAccountWrapperId(OWNER)).not.toBe(account.deriveAccountWrapperId(OWNER));
+	});
+});
+
+describe('generated layout', () => {
+	// BCS is positional: a field inserted or reordered mid-struct silently corrupts
+	// every field after it, and these structs are parsed straight off chain
+	// (`AccountWrapper` -> `account.account_id` drives Predict's position enumeration).
+	// Round-trip a fully specified value so a regeneration that drops, adds or reorders
+	// a field fails here rather than in a consumer's decoded output.
+	const ADDR = (b: string) => normalizeSuiAddress('0x' + b.repeat(32));
+	const account = {
+		account_id: ADDR('aa'),
+		owner: ADDR('bb'),
+		receive_address: ADDR('cc'),
+		balances: { id: ADDR('dd'), size: 1n },
+		settlements: { id: ADDR('ee'), size: 2n },
+		referrer_account_id: ADDR('ff'),
+		referrer_receive_address: ADDR('12'),
+	};
+
+	test('Account round-trips with the deployed field set, in order', () => {
+		const parsed = Account.parse(Account.serialize(account).toBytes());
+		expect(Object.keys(parsed)).toEqual([
+			'account_id',
+			'owner',
+			'receive_address',
+			'balances',
+			'settlements',
+			'referrer_account_id',
+			'referrer_receive_address',
+		]);
+		expect(parsed.account_id).toBe(account.account_id);
+		expect(parsed.referrer_receive_address).toBe(account.referrer_receive_address);
+	});
+
+	test('AccountWrapper wraps Account as its trailing field', () => {
+		const parsed = AccountWrapper.parse(
+			AccountWrapper.serialize({ id: ADDR('99'), account }).toBytes(),
+		);
+		expect(Object.keys(parsed)).toEqual(['id', 'account']);
+		expect(parsed.account.account_id).toBe(account.account_id);
 	});
 });

--- a/packages/deepbook-account/tests/account.test.ts
+++ b/packages/deepbook-account/tests/account.test.ts
@@ -146,7 +146,7 @@ describe('generated layout', () => {
 	// Round-trip a fully specified value so a regeneration that drops, adds or reorders
 	// a field fails here rather than in a consumer's decoded output.
 	const ADDR = (b: string) => normalizeSuiAddress('0x' + b.repeat(32));
-	const account = {
+	const accountValue = {
 		account_id: ADDR('aa'),
 		owner: ADDR('bb'),
 		receive_address: ADDR('cc'),
@@ -157,7 +157,7 @@ describe('generated layout', () => {
 	};
 
 	test('Account round-trips with the deployed field set, in order', () => {
-		const parsed = Account.parse(Account.serialize(account).toBytes());
+		const parsed = Account.parse(Account.serialize(accountValue).toBytes());
 		expect(Object.keys(parsed)).toEqual([
 			'account_id',
 			'owner',
@@ -167,15 +167,37 @@ describe('generated layout', () => {
 			'referrer_account_id',
 			'referrer_receive_address',
 		]);
-		expect(parsed.account_id).toBe(account.account_id);
-		expect(parsed.referrer_receive_address).toBe(account.referrer_receive_address);
+		expect(parsed.account_id).toBe(accountValue.account_id);
+		expect(parsed.referrer_receive_address).toBe(accountValue.referrer_receive_address);
+	});
+
+	// The key-order round trip above cannot see a TYPE change: narrowing `Bag.size`
+	// u64 -> u32, or widening `referrer_account_id` from Option<ID> to ID, round-trips
+	// happily through the same schema on both sides while shifting every following
+	// field on the wire. Pin the encoding itself.
+	test('Account encodes to the exact deployed wire layout', () => {
+		const bytes = Account.serialize(accountValue).toBytes();
+		expect(bytes.length).toBe(242);
+		expect(Buffer.from(bytes).toString('hex')).toBe(
+			'aa'.repeat(32) + // account_id
+				'bb'.repeat(32) + // owner
+				'cc'.repeat(32) + // receive_address
+				'dd'.repeat(32) +
+				'0100000000000000' + // balances: Bag { id, size: u64 }
+				'ee'.repeat(32) +
+				'0200000000000000' + // settlements: Bag { id, size: u64 }
+				'01' +
+				'ff'.repeat(32) + // referrer_account_id: Option<ID> = Some
+				'01' +
+				'12'.repeat(32), // referrer_receive_address: Option<address> = Some
+		);
 	});
 
 	test('AccountWrapper wraps Account as its trailing field', () => {
 		const parsed = AccountWrapper.parse(
-			AccountWrapper.serialize({ id: ADDR('99'), account }).toBytes(),
+			AccountWrapper.serialize({ id: ADDR('99'), account: accountValue }).toBytes(),
 		);
 		expect(Object.keys(parsed)).toEqual(['id', 'account']);
-		expect(parsed.account.account_id).toBe(account.account_id);
+		expect(parsed.account.account_id).toBe(accountValue.account_id);
 	});
 });


### PR DESCRIPTION
## Description

`@mysten/deepbook-account`'s generated Move bindings were pinned to the `predict-testnet-7-29` account sources (`a92ceb01`). The deployed `predict-testnet-8-21` account package (`1f79fe87`) added a trailing field the bindings did not have:

```move
public struct Account has store {
    account_id, owner, receive_address, balances, settlements, referrer_account_id,
    referrer_receive_address: Option<address>,   // ← new, absent from the bindings
}
```

This regenerates against `1f79fe87`, picking up that field and the `referrerReceiveAddress` getter.

**This closes a mismatch that exists on main right now.** #1220 moved `@mysten/deepbook-predict`'s config to the 8-21 account package (`0xa94ec89b…`) while these bindings still described the 7-29 `Account`. That direction is benign — a 6-field binding parses an 8-21 object and ignores the trailing byte — but it is a latent inconsistency, and this PR resolves it.

### Breaking: decode-layout change

`AccountContract`'s **API and behavior are unchanged** — every builder emits byte-identical transactions, argument slots are untouched, `deriveAccountWrapperId` is identical, and `AccountConfig` still supplies the deployed ids. The only export added is `accountMoveCalls.referrerReceiveAddress`.

But the BCS structs now expect the 8-21 `Account`, so **parsing a 7-29 `Account` / `AccountWrapper` breaks**:

- direct bytes → `ULEB decode error: buffer overflow`
- bytes that are a *view into a larger buffer* — exactly what the gRPC client returns — → silently reads past the view bound and fabricates a `referrer_receive_address` from adjacent memory

Consumers still reading 7-29 account objects should stay on `0.0.2`. The changeset says this plainly, and the bump is `minor` (the breaking level under changesets' 0.x convention) rather than `patch`.

## Test plan

- `@mysten/deepbook-account`: **11/11**, `tsc --noEmit` clean, build clean, oxlint + prettier clean.
- **Consumer, current main config (8-21):** `@mysten/deepbook-predict` **142/142** offline and **11/11 live-testnet e2e** against the deployment, with fresh builds.
- **Layout pinned two ways:** a round-trip asserting the field set and order, plus a byte-level assertion of the exact wire encoding (242 bytes, full hex). The round trip alone could not see a *type* change — narrowing `Bag.size` u64→u32 round-trips happily through the same schema on both sides while shifting every following field — so the encoding itself is now pinned.
- Generated `Account` field list verified against the deployed Move at `1f79fe87`: 7 fields, same order, `referrer_receive_address` genuinely last.
- Diff is limited to `packages/deepbook-account` plus its changeset.


---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
