### PR TITLE
feat(sui): expose transaction ledger metadata

### DIFF
--- a/.changeset/fresh-clocks-smile.md
+++ b/.changeset/fresh-clocks-smile.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add transaction checkpoint and timestamp metadata to the Core API, and support parsing V1 transaction effects.

--- a/packages/dapp-kit/packages/dapp-kit-core/src/utils/transaction-result.ts
+++ b/packages/dapp-kit/packages/dapp-kit-core/src/utils/transaction-result.ts
@@ -35,6 +35,8 @@ export function buildTransactionResult(
 		digest,
 		signatures: [signature],
 		epoch: null,
+		timestampMs: null,
+		checkpoint: null,
 		status,
 		effects: effects as SuiClientTypes.TransactionEffects,
 		transaction: parseTransactionBcs(transactionBytes),

--- a/packages/sui/src/client/types.ts
+++ b/packages/sui/src/client/types.ts
@@ -326,6 +326,16 @@ export namespace SuiClientTypes {
 		digest: string;
 		signatures: string[];
 		epoch: string | null;
+		/**
+		 * Timestamp of the checkpoint containing this transaction, in milliseconds since Unix epoch.
+		 * `null` for transactions that have not been checkpointed, including execution and simulation results.
+		 */
+		timestampMs: number | null;
+		/**
+		 * Sequence number of the checkpoint containing this transaction.
+		 * `null` for transactions that have not been checkpointed, including execution and simulation results.
+		 */
+		checkpoint: string | null;
 		status: ExecutionStatus;
 		balanceChanges: Include extends { balanceChanges: true } ? BalanceChange[] : undefined;
 		effects: Include extends { effects: true } ? TransactionEffects : undefined;

--- a/packages/sui/src/client/utils.ts
+++ b/packages/sui/src/client/utils.ts
@@ -505,8 +505,8 @@ function parseTransactionEffectsV1({
 			inputDigest: change.inputState === 'Exists' ? (sharedInput?.digest ?? null) : null,
 			inputOwner: null,
 			outputState: change.outputState,
-			outputVersion: reference.version,
-			outputDigest: reference.digest,
+			outputVersion: change.outputState === 'DoesNotExist' ? null : reference.version,
+			outputDigest: change.outputState === 'DoesNotExist' ? null : reference.digest,
 			outputOwner: change.outputOwner,
 			idOperation: change.idOperation,
 		};
@@ -529,13 +529,14 @@ function parseTransactionEffectsV1({
 	const removed = (
 		changes: typeof effects.deleted,
 		inputState: 'DoesNotExist' | 'Exists',
+		idOperation: 'Deleted' | 'None',
 	): SuiClientTypes.ChangedObject[] =>
 		changes.map((reference) =>
 			mapChangedObject(reference, {
 				inputState,
 				outputState: 'DoesNotExist',
 				outputOwner: null,
-				idOperation: 'Deleted',
+				idOperation,
 			}),
 		);
 
@@ -543,9 +544,9 @@ function parseTransactionEffectsV1({
 		...written(effects.created, 'DoesNotExist', 'Created'),
 		...written(effects.mutated, 'Exists', 'None'),
 		...written(effects.unwrapped, 'DoesNotExist', 'None'),
-		...removed(effects.deleted, 'Exists'),
-		...removed(effects.unwrappedThenDeleted, 'DoesNotExist'),
-		...removed(effects.wrapped, 'Exists'),
+		...removed(effects.deleted, 'Exists', 'Deleted'),
+		...removed(effects.unwrappedThenDeleted, 'DoesNotExist', 'Deleted'),
+		...removed(effects.wrapped, 'Exists', 'None'),
 	];
 	const gasObjectId = effects.gasObject[0].objectId;
 	const gasObject = changedObjects.find((object) => object.objectId === gasObjectId) ?? null;

--- a/packages/sui/src/client/utils.ts
+++ b/packages/sui/src/client/utils.ts
@@ -478,11 +478,107 @@ export function parseTransactionEffectsBcs(effects: Uint8Array): SuiClientTypes.
 	}
 }
 
-function parseTransactionEffectsV1(_: {
+function parseTransactionEffectsV1({
+	bytes,
+	effects,
+}: {
 	bytes: Uint8Array;
 	effects: NonNullable<(typeof bcs.TransactionEffects.$inferType)['V1']>;
 }): SuiClientTypes.TransactionEffects {
-	throw new Error('V1 effects are not supported yet');
+	const modifiedAtVersions = new Map(effects.modifiedAtVersions);
+	const sharedObjects = new Map(effects.sharedObjects.map((object) => [object.objectId, object]));
+	const mapChangedObject = (
+		reference: (typeof effects.deleted)[number],
+		change: Pick<
+			SuiClientTypes.ChangedObject,
+			'inputState' | 'outputState' | 'outputOwner' | 'idOperation'
+		>,
+	): SuiClientTypes.ChangedObject => {
+		const sharedInput = sharedObjects.get(reference.objectId);
+		return {
+			objectId: reference.objectId,
+			inputState: change.inputState,
+			inputVersion:
+				change.inputState === 'Exists'
+					? (sharedInput?.version ?? modifiedAtVersions.get(reference.objectId) ?? null)
+					: null,
+			inputDigest: change.inputState === 'Exists' ? (sharedInput?.digest ?? null) : null,
+			inputOwner: null,
+			outputState: change.outputState,
+			outputVersion: reference.version,
+			outputDigest: reference.digest,
+			outputOwner: change.outputOwner,
+			idOperation: change.idOperation,
+		};
+	};
+
+	const written = (
+		changes: typeof effects.created,
+		inputState: 'DoesNotExist' | 'Exists',
+		idOperation: 'Created' | 'None',
+	): SuiClientTypes.ChangedObject[] =>
+		changes.map(([reference, owner]) =>
+			mapChangedObject(reference, {
+				inputState,
+				outputState: 'ObjectWrite',
+				outputOwner: owner,
+				idOperation,
+			}),
+		);
+
+	const removed = (
+		changes: typeof effects.deleted,
+		inputState: 'DoesNotExist' | 'Exists',
+	): SuiClientTypes.ChangedObject[] =>
+		changes.map((reference) =>
+			mapChangedObject(reference, {
+				inputState,
+				outputState: 'DoesNotExist',
+				outputOwner: null,
+				idOperation: 'Deleted',
+			}),
+		);
+
+	const changedObjects = [
+		...written(effects.created, 'DoesNotExist', 'Created'),
+		...written(effects.mutated, 'Exists', 'None'),
+		...written(effects.unwrapped, 'DoesNotExist', 'None'),
+		...removed(effects.deleted, 'Exists'),
+		...removed(effects.unwrappedThenDeleted, 'DoesNotExist'),
+		...removed(effects.wrapped, 'Exists'),
+	];
+	const gasObjectId = effects.gasObject[0].objectId;
+	const gasObject = changedObjects.find((object) => object.objectId === gasObjectId) ?? null;
+	const changedObjectIds = new Set(changedObjects.map((object) => object.objectId));
+	const lamportVersion = effects.modifiedAtVersions.reduce(
+		(max, [, version]) => (BigInt(version) > max ? BigInt(version) : max),
+		0n,
+	);
+
+	return {
+		bcs: bytes,
+		version: 1,
+		status:
+			effects.status.$kind === 'Success'
+				? { success: true, error: null }
+				: { success: false, error: parseBcsExecutionError(effects.status.Failure) },
+		gasUsed: effects.gasUsed,
+		transactionDigest: effects.transactionDigest,
+		gasObject,
+		eventsDigest: effects.eventsDigest,
+		dependencies: effects.dependencies,
+		lamportVersion: (lamportVersion + 1n).toString(),
+		changedObjects,
+		unchangedConsensusObjects: effects.sharedObjects
+			.filter((object) => !changedObjectIds.has(object.objectId))
+			.map((object) => ({
+				kind: 'ReadOnlyRoot',
+				objectId: object.objectId,
+				version: object.version,
+				digest: object.digest,
+			})),
+		auxiliaryDataDigest: null,
+	};
 }
 
 function parseTransactionEffectsV2({

--- a/packages/sui/src/graphql/core.ts
+++ b/packages/sui/src/graphql/core.ts
@@ -1121,6 +1121,9 @@ function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}
 
 	const bcsBytes =
 		include?.bcs && transaction.transactionBcs ? fromBase64(transaction.transactionBcs) : undefined;
+	const timestampMs = transaction.effects?.timestamp
+		? Date.parse(transaction.effects.timestamp)
+		: null;
 
 	const result: SuiClientTypes.Transaction<Include> = {
 		digest: transaction.digest!,
@@ -1129,6 +1132,8 @@ function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}
 			? parseTransactionEffectsBcs(fromBase64(transaction.effects?.effectsBcs!))
 			: undefined) as SuiClientTypes.Transaction<Include>['effects'],
 		epoch: transaction.effects?.epoch?.epochId?.toString() ?? null,
+		timestampMs: timestampMs !== null && !Number.isNaN(timestampMs) ? timestampMs : null,
+		checkpoint: transaction.effects?.checkpoint?.sequenceNumber?.toString() ?? null,
 		objectTypes: (include?.objectTypes
 			? objectTypes
 			: undefined) as SuiClientTypes.Transaction<Include>['objectTypes'],

--- a/packages/sui/src/graphql/generated/queries.ts
+++ b/packages/sui/src/graphql/generated/queries.ts
@@ -380,7 +380,7 @@ export type SimulateTransactionQueryVariables = Exact<{
 }>;
 
 
-export type SimulateTransactionQuery = { simulateTransaction: { effects: { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null } | null, outputs?: Array<{ returnValues: Array<{ value: { bcs: string | null } | null }> | null, mutatedReferences: Array<{ value: { bcs: string | null } | null }> | null }> | null } };
+export type SimulateTransactionQuery = { simulateTransaction: { effects: { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, timestamp: string | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, checkpoint: { sequenceNumber: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null } | null, outputs?: Array<{ returnValues: Array<{ value: { bcs: string | null } | null }> | null, mutatedReferences: Array<{ value: { bcs: string | null } | null }> | null }> | null } };
 
 export type ExecuteTransactionMutationVariables = Exact<{
   transactionDataBcs: string;
@@ -394,7 +394,7 @@ export type ExecuteTransactionMutationVariables = Exact<{
 }>;
 
 
-export type ExecuteTransactionMutation = { executeTransaction: { effects: { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null } | null } };
+export type ExecuteTransactionMutation = { executeTransaction: { effects: { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, timestamp: string | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, checkpoint: { sequenceNumber: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null } | null } };
 
 export type GetTransactionBlockQueryVariables = Exact<{
   digest: string;
@@ -407,7 +407,7 @@ export type GetTransactionBlockQueryVariables = Exact<{
 }>;
 
 
-export type GetTransactionBlockQuery = { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null };
+export type GetTransactionBlockQuery = { transaction: { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, timestamp: string | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, checkpoint: { sequenceNumber: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null } | null };
 
 export type ListTransactionsQueryVariables = Exact<{
   filter?: TransactionFilter | null | undefined;
@@ -424,9 +424,9 @@ export type ListTransactionsQueryVariables = Exact<{
 }>;
 
 
-export type ListTransactionsQuery = { transactions: { pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, nodes: Array<{ digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null }> } | null };
+export type ListTransactionsQuery = { transactions: { pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, nodes: Array<{ digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, timestamp: string | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, checkpoint: { sequenceNumber: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null }> } | null };
 
-export type Transaction_FieldsFragment = { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null };
+export type Transaction_FieldsFragment = { digest: string, transactionJson?: unknown, transactionBcs?: string | null, signatures: Array<{ signatureBytes: string | null }>, effects: { status: ExecutionStatus | null, timestamp: string | null, effectsBcs?: string | null, effectsJson?: unknown, balanceChangesJson?: unknown, checkpoint: { sequenceNumber: number } | null, executionError: { message: string, abortCode: string | null, identifier: string | null, constant: string | null, sourceLineNumber: number | null, instructionOffset: number | null, module: { name: string, package: { address: string } | null } | null, function: { name: string } | null } | null, epoch: { epochId: number } | null, objectChanges?: { nodes: Array<{ address: string, outputState: { asMoveObject: { contents: { type: { repr: string } | null } | null } | null } | null }> } | null, events?: { pageInfo: { hasNextPage: boolean }, nodes: Array<{ transactionModule: { name: string, package: { address: string } | null } | null, sender: { address: string } | null, contents: { bcs: string | null, json: unknown, type: { repr: string } | null } | null }> } | null } | null };
 
 export type ResolveTransactionQueryVariables = Exact<{
   transaction: unknown;
@@ -596,6 +596,10 @@ export const Transaction_FieldsFragmentDoc = new TypedDocumentString(`
   }
   effects {
     status
+    timestamp
+    checkpoint {
+      sequenceNumber
+    }
     executionError {
       message
       abortCode
@@ -1068,6 +1072,10 @@ export const SimulateTransactionDocument = new TypedDocumentString(`
   }
   effects {
     status
+    timestamp
+    checkpoint {
+      sequenceNumber
+    }
     executionError {
       message
       abortCode
@@ -1152,6 +1160,10 @@ export const ExecuteTransactionDocument = new TypedDocumentString(`
   }
   effects {
     status
+    timestamp
+    checkpoint {
+      sequenceNumber
+    }
     executionError {
       message
       abortCode
@@ -1229,6 +1241,10 @@ export const GetTransactionBlockDocument = new TypedDocumentString(`
   }
   effects {
     status
+    timestamp
+    checkpoint {
+      sequenceNumber
+    }
     executionError {
       message
       abortCode
@@ -1320,6 +1336,10 @@ export const ListTransactionsDocument = new TypedDocumentString(`
   }
   effects {
     status
+    timestamp
+    checkpoint {
+      sequenceNumber
+    }
     executionError {
       message
       abortCode

--- a/packages/sui/src/graphql/queries/transactions.graphql
+++ b/packages/sui/src/graphql/queries/transactions.graphql
@@ -106,6 +106,10 @@ fragment TRANSACTION_FIELDS on Transaction {
 	}
 	effects {
 		status
+		timestamp
+		checkpoint {
+			sequenceNumber
+		}
 		executionError {
 			message
 			abortCode

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -1417,7 +1417,7 @@ export function parseTransactionEffects({
 	return {
 		bcs: effects.bcs?.value!,
 
-		version: 2,
+		version: effects.version ?? 2,
 		status: effects.status?.success
 			? {
 					success: true,

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -1008,7 +1008,14 @@ function transactionReadMaskPaths(
 	include: SuiClientTypes.TransactionInclude | undefined,
 	prefix = '',
 ): string[] {
-	const paths = ['digest', 'transaction.digest', 'signatures', 'effects.status'];
+	const paths = [
+		'digest',
+		'transaction.digest',
+		'signatures',
+		'effects.status',
+		'timestamp',
+		'checkpoint',
+	];
 
 	if (include?.transaction) {
 		paths.push(
@@ -1523,6 +1530,11 @@ export function parseGrpcTransactionResponse<
 	const result: SuiClientTypes.Transaction<Include> = {
 		digest: transaction.digest!,
 		epoch: transaction.effects?.epoch?.toString() ?? null,
+		timestampMs: transaction.timestamp
+			? Number(transaction.timestamp.seconds) * 1000 +
+				Math.floor(transaction.timestamp.nanos / 1_000_000)
+			: null,
+		checkpoint: transaction.checkpoint?.toString() ?? null,
 		status,
 		effects: effects as SuiClientTypes.Transaction<Include>['effects'],
 		objectTypes: (include?.objectTypes

--- a/packages/sui/src/jsonRpc/core.ts
+++ b/packages/sui/src/jsonRpc/core.ts
@@ -467,6 +467,8 @@ export class JSONRpcCoreClient extends CoreClient {
 		const transactionData: SuiClientTypes.Transaction<Include> = {
 			digest: TransactionDataBuilder.getDigestFromBytes(transactionBytes),
 			epoch: null,
+			timestampMs: null,
+			checkpoint: null,
 			status: effects.status,
 			effects: (options.include?.effects
 				? effects
@@ -1167,6 +1169,8 @@ function parseTransaction<Include extends SuiClientTypes.TransactionInclude = {}
 	const result: SuiClientTypes.Transaction<Include> = {
 		digest: transaction.digest,
 		epoch: transaction.effects?.executedEpoch ?? null,
+		timestampMs: transaction.timestampMs == null ? null : Number(transaction.timestampMs),
+		checkpoint: transaction.checkpoint ?? null,
 		status,
 		effects: (include?.effects && effectsBytes
 			? parseTransactionEffectsBcs(effectsBytes)

--- a/packages/sui/test/e2e/clients/core/transactions.test.ts
+++ b/packages/sui/test/e2e/clients/core/transactions.test.ts
@@ -67,6 +67,8 @@ describe('Core API - Transactions', () => {
 			});
 
 			expect(result.Transaction!.digest).toBe(executedTxDigest);
+			expect(result.Transaction!.timestampMs).not.toBeNull();
+			expect(result.Transaction!.checkpoint).not.toBeNull();
 			expect(result.Transaction!.effects).toBeDefined();
 			expect(result.Transaction!.effects?.status).toBeDefined();
 			if (result.Transaction!.effects && 'success' in result.Transaction!.effects.status) {
@@ -165,6 +167,8 @@ describe('Core API - Transactions', () => {
 			});
 
 			expect(result.Transaction!.digest).toBeDefined();
+			expect(result.Transaction!.timestampMs).toBeNull();
+			expect(result.Transaction!.checkpoint).toBeNull();
 			expect(result.Transaction!.effects).toBeDefined();
 			expect(result.Transaction!.effects?.status).toBeDefined();
 			if (result.Transaction!.effects && 'success' in result.Transaction!.effects.status) {
@@ -248,6 +252,8 @@ describe('Core API - Transactions', () => {
 			});
 
 			expect(result.Transaction!.effects).toBeDefined();
+			expect(result.Transaction!.timestampMs).toBeNull();
+			expect(result.Transaction!.checkpoint).toBeNull();
 			expect(result.Transaction!.effects?.status).toBeDefined();
 			if (result.Transaction!.effects && 'success' in result.Transaction!.effects.status) {
 				expect(result.Transaction!.effects.status.success).toBe(true);

--- a/packages/sui/test/unit/client/parse-transaction-effects-v1.test.ts
+++ b/packages/sui/test/unit/client/parse-transaction-effects-v1.test.ts
@@ -132,8 +132,18 @@ describe('parseTransactionEffectsBcs V1', () => {
 				objectId: expect.stringMatching(/07$/),
 				inputState: 'Exists',
 				outputState: 'DoesNotExist',
-				idOperation: 'Deleted',
+				idOperation: 'None',
 			},
+		]);
+		expect(
+			effects.changedObjects.slice(4).map(({ outputVersion, outputDigest }) => ({
+				outputVersion,
+				outputDigest,
+			})),
+		).toEqual([
+			{ outputVersion: null, outputDigest: null },
+			{ outputVersion: null, outputDigest: null },
+			{ outputVersion: null, outputDigest: null },
 		]);
 		expect(effects.gasObject).toBe(effects.changedObjects[1]);
 		expect(effects.lamportVersion).toBe('71');

--- a/packages/sui/test/unit/client/parse-transaction-effects-v1.test.ts
+++ b/packages/sui/test/unit/client/parse-transaction-effects-v1.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toBase58 } from '@mysten/bcs';
+import { fromBase64 } from '@mysten/utils';
+import { describe, expect, it } from 'vitest';
+
+import { bcs } from '../../../src/bcs/index.js';
+import { parseTransactionEffectsBcs } from '../../../src/client/utils.js';
+
+// Mainnet transaction DyNVCcweVUBz7g3vxiKHF6SuoxynYbr6d8AJyDL1dhMm,
+// checkpoint 15,000,000 (2023-10-08T03:09:07.028Z).
+const V1_EFFECTS_BCS =
+	'AACyAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwOHkAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbA4eQAAAAAACAzESdhjrydlnr6/HuHKVoVUiokk25nYiG2UIpTZCZ7wSDAvRAeUc/6vfqjK6wbMI/2hjmY7fIkOWIIKPCFW8tY1AABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbB4eQAAAAAACAGkHp5VdlBHbr+Gc1pyExoRdzMTN0eme/sgjO4SzTXiQIBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEgLrfJME6gm+umzwBd6ob02mtQTKyProvihogPS0KMhbE=';
+
+describe('parseTransactionEffectsBcs V1', () => {
+	it('maps a historical mainnet transaction to core effects', () => {
+		const effects = parseTransactionEffectsBcs(fromBase64(V1_EFFECTS_BCS));
+
+		expect(effects).toMatchObject({
+			version: 1,
+			status: { success: true, error: null },
+			transactionDigest: 'DyNVCcweVUBz7g3vxiKHF6SuoxynYbr6d8AJyDL1dhMm',
+			gasObject: null,
+			lamportVersion: '15000001',
+			changedObjects: [
+				{
+					objectId: '0x0000000000000000000000000000000000000000000000000000000000000006',
+					inputState: 'Exists',
+					inputVersion: '15000000',
+					inputDigest: '4SLxtHjFAXozbeuAABaT2t7U8VuJw2HxVSzdBWyF4VrY',
+					inputOwner: null,
+					outputState: 'ObjectWrite',
+					outputVersion: '15000001',
+					outputDigest: 'SdDyHZMJ9ZxQf2XyBjsqCmJThgSGCZNghRZnDvisBr8',
+					outputOwner: { $kind: 'Shared', Shared: { initialSharedVersion: '1' } },
+					idOperation: 'None',
+				},
+			],
+			unchangedConsensusObjects: [],
+			auxiliaryDataDigest: null,
+		});
+	});
+
+	it('maps every V1 object-change category and the gas object', () => {
+		const digest = (byte: number) => toBase58(new Uint8Array(32).fill(byte));
+		const reference = (objectId: string, version: number, digestByte: number) => ({
+			objectId,
+			version: version.toString(),
+			digest: digest(digestByte),
+		});
+		const effects = parseTransactionEffectsBcs(
+			bcs.TransactionEffects.serialize({
+				V1: {
+					status: { Success: true },
+					executedEpoch: 1,
+					gasUsed: {
+						computationCost: 1,
+						storageCost: 2,
+						storageRebate: 3,
+						nonRefundableStorageFee: 4,
+					},
+					modifiedAtVersions: [
+						['0x2', 20],
+						['0x3', 30],
+						['0x5', 50],
+						['0x7', 70],
+					],
+					sharedObjects: [reference('0x3', 30, 13), reference('0x8', 80, 18)],
+					transactionDigest: digest(1),
+					created: [[reference('0x1', 11, 11), { AddressOwner: '0xa' }]],
+					mutated: [
+						[reference('0x2', 21, 12), { AddressOwner: '0xa' }],
+						[reference('0x3', 31, 13), { Shared: { initialSharedVersion: 1 } }],
+					],
+					unwrapped: [[reference('0x4', 41, 14), { ObjectOwner: '0xb' }]],
+					deleted: [reference('0x5', 51, 15)],
+					unwrappedThenDeleted: [reference('0x6', 61, 16)],
+					wrapped: [reference('0x7', 71, 17)],
+					gasObject: [reference('0x2', 21, 12), { AddressOwner: '0xa' }],
+					eventsDigest: null,
+					dependencies: [],
+				},
+			}).toBytes(),
+		);
+
+		expect(
+			effects.changedObjects.map(({ objectId, inputState, outputState, idOperation }) => ({
+				objectId,
+				inputState,
+				outputState,
+				idOperation,
+			})),
+		).toEqual([
+			{
+				objectId: expect.stringMatching(/01$/),
+				inputState: 'DoesNotExist',
+				outputState: 'ObjectWrite',
+				idOperation: 'Created',
+			},
+			{
+				objectId: expect.stringMatching(/02$/),
+				inputState: 'Exists',
+				outputState: 'ObjectWrite',
+				idOperation: 'None',
+			},
+			{
+				objectId: expect.stringMatching(/03$/),
+				inputState: 'Exists',
+				outputState: 'ObjectWrite',
+				idOperation: 'None',
+			},
+			{
+				objectId: expect.stringMatching(/04$/),
+				inputState: 'DoesNotExist',
+				outputState: 'ObjectWrite',
+				idOperation: 'None',
+			},
+			{
+				objectId: expect.stringMatching(/05$/),
+				inputState: 'Exists',
+				outputState: 'DoesNotExist',
+				idOperation: 'Deleted',
+			},
+			{
+				objectId: expect.stringMatching(/06$/),
+				inputState: 'DoesNotExist',
+				outputState: 'DoesNotExist',
+				idOperation: 'Deleted',
+			},
+			{
+				objectId: expect.stringMatching(/07$/),
+				inputState: 'Exists',
+				outputState: 'DoesNotExist',
+				idOperation: 'Deleted',
+			},
+		]);
+		expect(effects.gasObject).toBe(effects.changedObjects[1]);
+		expect(effects.lamportVersion).toBe('71');
+		expect(effects.unchangedConsensusObjects).toEqual([
+			{
+				kind: 'ReadOnlyRoot',
+				objectId: expect.stringMatching(/08$/),
+				version: '80',
+				digest: digest(18),
+			},
+		]);
+	});
+});

--- a/packages/sui/test/unit/client/transaction-metadata.test.ts
+++ b/packages/sui/test/unit/client/transaction-metadata.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+
+import { SuiGraphQLClient } from '../../../src/graphql/index.js';
+import type {
+	JsonRpcTransport,
+	JsonRpcTransportRequestOptions,
+} from '../../../src/jsonRpc/index.js';
+import { SuiJsonRpcClient } from '../../../src/jsonRpc/index.js';
+
+const DIGEST = 'DyNVCcweVUBz7g3vxiKHF6SuoxynYbr6d8AJyDL1dhMm';
+const CHECKPOINT = '15000000';
+const TIMESTAMP_MS = 1_696_734_547_028;
+
+describe('core transaction metadata', () => {
+	it('maps checkpoint and timestamp from GraphQL ledger reads', async () => {
+		const client = new SuiGraphQLClient({
+			url: 'http://localhost/graphql',
+			network: 'mainnet',
+			fetch: async () =>
+				Response.json({
+					data: {
+						transaction: {
+							digest: DIGEST,
+							signatures: [],
+							effects: {
+								status: 'SUCCESS',
+								executionError: null,
+								epoch: { epochId: 178 },
+								timestamp: '2023-10-08T03:09:07.028Z',
+								checkpoint: { sequenceNumber: 15_000_000 },
+							},
+						},
+					},
+				}),
+		});
+
+		const result = await client.core.getTransaction({ digest: DIGEST });
+
+		expect(result.Transaction).toMatchObject({
+			timestampMs: TIMESTAMP_MS,
+			checkpoint: CHECKPOINT,
+		});
+	});
+
+	it('returns null checkpoint and timestamp from GraphQL execution', async () => {
+		const client = new SuiGraphQLClient({
+			url: 'http://localhost/graphql',
+			network: 'mainnet',
+			fetch: async () =>
+				Response.json({
+					data: {
+						executeTransaction: {
+							effects: {
+								transaction: {
+									digest: DIGEST,
+									signatures: [],
+									effects: {
+										status: 'SUCCESS',
+										executionError: null,
+										epoch: { epochId: 178 },
+										timestamp: null,
+										checkpoint: null,
+									},
+								},
+							},
+						},
+					},
+				}),
+		});
+
+		const result = await client.core.executeTransaction({
+			transaction: new Uint8Array(),
+			signatures: [],
+		});
+
+		expect(result.Transaction).toMatchObject({ timestampMs: null, checkpoint: null });
+	});
+
+	it('maps checkpoint and timestamp from JSON-RPC ledger reads', async () => {
+		const transport: JsonRpcTransport = {
+			async request<T>(input: JsonRpcTransportRequestOptions) {
+				expect(input.method).toBe('sui_getTransactionBlock');
+				return {
+					digest: DIGEST,
+					effects: {
+						status: { status: 'success' },
+						executedEpoch: '178',
+					},
+					timestampMs: TIMESTAMP_MS.toString(),
+					checkpoint: CHECKPOINT,
+					errors: [],
+				} as T;
+			},
+		};
+		const client = new SuiJsonRpcClient({ network: 'mainnet', transport });
+
+		const result = await client.core.getTransaction({ digest: DIGEST });
+
+		expect(result.Transaction).toMatchObject({
+			timestampMs: TIMESTAMP_MS,
+			checkpoint: CHECKPOINT,
+		});
+	});
+
+	it('returns null checkpoint and timestamp from JSON-RPC execution', async () => {
+		const transport: JsonRpcTransport = {
+			async request<T>(input: JsonRpcTransportRequestOptions) {
+				expect(input.method).toBe('sui_executeTransactionBlock');
+				return {
+					digest: DIGEST,
+					effects: {
+						status: { status: 'success' },
+						executedEpoch: '178',
+					},
+					errors: [],
+				} as T;
+			},
+		};
+		const client = new SuiJsonRpcClient({ network: 'mainnet', transport });
+
+		const result = await client.core.executeTransaction({
+			transaction: new Uint8Array(),
+			signatures: [],
+		});
+
+		expect(result.Transaction).toMatchObject({ timestampMs: null, checkpoint: null });
+	});
+});

--- a/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
+++ b/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
@@ -191,6 +191,21 @@ describe('gRPC transaction response parsers', () => {
 		expect(uncheckpointed.Transaction).toMatchObject({ timestampMs: null, checkpoint: null });
 	});
 
+	it('maps the transaction effects wire version', () => {
+		const result = parseGrpcTransactionResponse(
+			GrpcTypes.ExecutedTransaction.create({
+				digest: 'v1-transaction',
+				effects: { version: 1, status: { success: true } },
+			}),
+			{ include: { effects: true } },
+		);
+
+		if (result.$kind !== 'Transaction') {
+			throw new Error('Expected Transaction result');
+		}
+		expect(result.Transaction.effects.version).toBe(1);
+	});
+
 	it('includes protobuf JSON from top-level gRPC transaction methods', async () => {
 		const transaction = GrpcTypes.ExecutedTransaction.create({
 			digest: 'top-level-transaction-digest',

--- a/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
+++ b/packages/sui/test/unit/grpc/parse-transaction-response.test.ts
@@ -164,6 +164,33 @@ describe('gRPC transaction response parsers', () => {
 		});
 	});
 
+	it('maps checkpoint and timestamp from executed transactions', () => {
+		const transaction = GrpcTypes.ExecutedTransaction.create({
+			digest: 'transaction-digest',
+			checkpoint: 15_000_000n,
+			timestamp: {
+				seconds: 1_696_734_547n,
+				nanos: 28_000_000,
+			},
+			effects: { status: { success: true } },
+		});
+
+		const result = parseGrpcTransactionResponse(transaction);
+
+		expect(result.Transaction).toMatchObject({
+			checkpoint: '15000000',
+			timestampMs: 1_696_734_547_028,
+		});
+
+		const uncheckpointed = parseGrpcTransactionResponse(
+			GrpcTypes.ExecutedTransaction.create({
+				digest: 'uncheckpointed-transaction',
+				effects: { status: { success: true } },
+			}),
+		);
+		expect(uncheckpointed.Transaction).toMatchObject({ timestampMs: null, checkpoint: null });
+	});
+
 	it('includes protobuf JSON from top-level gRPC transaction methods', async () => {
 		const transaction = GrpcTypes.ExecutedTransaction.create({
 			digest: 'top-level-transaction-digest',
@@ -182,11 +209,15 @@ describe('gRPC transaction response parsers', () => {
 			network: 'testnet',
 		});
 
-		client.ledgerService.getTransaction = (async () => ({
-			response: {
-				transaction,
-			},
-		})) as never;
+		let getTransactionRequest: { readMask?: { paths: string[] } } | undefined;
+		client.ledgerService.getTransaction = (async (request: GrpcTypes.GetTransactionRequest) => {
+			getTransactionRequest = request;
+			return {
+				response: {
+					transaction,
+				},
+			};
+		}) as never;
 		client.transactionExecutionService.executeTransaction = (async () => ({
 			response: {
 				transaction,
@@ -207,6 +238,9 @@ describe('gRPC transaction response parsers', () => {
 		>();
 		expect(GrpcTypes.ExecutedTransaction.fromJson(getResult.protoJson).digest).toBe(
 			'top-level-transaction-digest',
+		);
+		expect(getTransactionRequest?.readMask?.paths).toEqual(
+			expect.arrayContaining(['timestamp', 'checkpoint']),
 		);
 
 		const defaultResult = await client.getTransaction({


### PR DESCRIPTION
## Description

- expose checkpoint and numeric timestamp metadata on Core API transactions across gRPC, GraphQL, and JSON-RPC
- implement legacy V1 transaction effects conversion for the unified Core API
- add unit, fixture, and cross-transport parity coverage

## Test plan

- `pnpm --filter @mysten/sui test`
- `pnpm --filter @mysten/sui lint`
- `pnpm --filter @mysten/sui build`
- `pnpm --filter @mysten/sui vitest run --config test/e2e/vitest.config.mts test/e2e/clients/core/transactions.test.ts`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.