### PR TITLE
feat(sui): support validity transaction expirations

### DIFF
--- a/.changeset/calm-proposers-validate.md
+++ b/.changeset/calm-proposers-validate.md
@@ -1,5 +1,6 @@
 ---
 '@mysten/sui': minor
+'@mysten-incubation/sponsor': patch
 ---
 
 Add BCS, transaction schema, and gRPC support for `Validity` transaction expirations and allowed proposers. Also synchronize recently added transaction and execution error variants.

--- a/.changeset/calm-proposers-validate.md
+++ b/.changeset/calm-proposers-validate.md
@@ -1,0 +1,5 @@
+---
+'@mysten/sui': minor
+---
+
+Add BCS, transaction schema, and gRPC support for `Validity` transaction expirations and allowed proposers. Also synchronize recently added transaction and execution error variants.

--- a/.changeset/calm-proposers-validate.md
+++ b/.changeset/calm-proposers-validate.md
@@ -4,3 +4,10 @@
 ---
 
 Add BCS, transaction schema, and gRPC support for `Validity` transaction expirations and allowed proposers. Also synchronize recently added transaction and execution error variants.
+
+The deprecated v1 JSON transaction format now represents `ValidDuring` and `Validity` expirations
+instead of collapsing them to `{ None: true }`. Previously a `Transaction.serialize()` ->
+`Transaction.from()` round trip silently discarded the expiration — and, for `Validity`, the set of
+validators allowed to propose the transaction — so the rebuilt transaction signed materially
+broader bytes. An expiration the v1 reader does not recognize is now an error rather than a silent
+downgrade.

--- a/packages/sponsor/src/validators.ts
+++ b/packages/sponsor/src/validators.ts
@@ -421,7 +421,10 @@ export function simulationSucceeds(): Validator {
 function expirationMaxEpoch(expiration: TransactionData['expiration']): bigint | null {
 	if (!expiration || expiration.$kind === 'None') return null;
 	if (expiration.$kind === 'Epoch') return BigInt(expiration.Epoch);
-	const max = expiration.ValidDuring.maxEpoch;
+	const max =
+		expiration.$kind === 'Validity'
+			? expiration.Validity.maxEpoch
+			: expiration.ValidDuring.maxEpoch;
 	return max == null ? null : BigInt(max);
 }
 

--- a/packages/sui/src/bcs/bcs.ts
+++ b/packages/sui/src/bcs/bcs.ts
@@ -257,11 +257,13 @@ const AllowedProposerIndices = bcs.vector(bcs.u32()).transform({
 	output: validateAllowedProposerIndices,
 });
 
+// Rust: crates/sui-types/src/transaction.rs
 export const AllowedProposers = bcs.struct('AllowedProposers', {
 	epoch: bcs.u64(),
 	proposers: AllowedProposerIndices,
 });
 
+// Rust: crates/sui-types/src/transaction.rs
 export const Validity = bcs.struct('Validity', {
 	minEpoch: bcs.option(bcs.u64()),
 	maxEpoch: bcs.option(bcs.u64()),

--- a/packages/sui/src/bcs/bcs.ts
+++ b/packages/sui/src/bcs/bcs.ts
@@ -238,10 +238,20 @@ export const ValidDuring = bcs.struct('ValidDuring', {
 	nonce: bcs.u32(),
 });
 
-function validateAllowedProposerIndices(proposers: number[]) {
+/**
+ * Upstream rejects an empty proposer set while deserializing, because the field is `NonEmpty`.
+ * Reject it everywhere we decode, so all transports agree on what is readable.
+ */
+export function assertAllowedProposersNotEmpty(proposers: number[]) {
 	if (proposers.length === 0) {
 		throw new Error('Allowed proposers must not be empty');
 	}
+
+	return proposers;
+}
+
+function assertAllowedProposersStrictlyIncreasing(proposers: number[]) {
+	assertAllowedProposersNotEmpty(proposers);
 
 	for (let i = 1; i < proposers.length; i++) {
 		if (proposers[i] <= proposers[i - 1]) {
@@ -252,9 +262,12 @@ function validateAllowedProposerIndices(proposers: number[]) {
 	return proposers;
 }
 
+// Sortedness is only checked when encoding. Upstream enforces it in `validity_check`, on
+// submission, and `is_allowed_proposer` documents reading an unsorted set as a deterministic
+// miss -- so decoding one must succeed, or we fail to read transactions the network accepted.
 const AllowedProposerIndices = bcs.vector(bcs.u32()).transform({
-	input: validateAllowedProposerIndices,
-	output: validateAllowedProposerIndices,
+	input: assertAllowedProposersStrictlyIncreasing,
+	output: assertAllowedProposersNotEmpty,
 });
 
 // Rust: crates/sui-types/src/transaction.rs

--- a/packages/sui/src/bcs/bcs.ts
+++ b/packages/sui/src/bcs/bcs.ts
@@ -238,10 +238,6 @@ export const ValidDuring = bcs.struct('ValidDuring', {
 	nonce: bcs.u32(),
 });
 
-/**
- * Upstream rejects an empty proposer set while deserializing, because the field is `NonEmpty`.
- * Reject it everywhere we decode, so all transports agree on what is readable.
- */
 export function assertAllowedProposersNotEmpty(proposers: number[]) {
 	if (proposers.length === 0) {
 		throw new Error('Allowed proposers must not be empty');
@@ -250,7 +246,7 @@ export function assertAllowedProposersNotEmpty(proposers: number[]) {
 	return proposers;
 }
 
-function assertAllowedProposersStrictlyIncreasing(proposers: number[]) {
+export function assertAllowedProposersStrictlyIncreasing(proposers: number[]) {
 	assertAllowedProposersNotEmpty(proposers);
 
 	for (let i = 1; i < proposers.length; i++) {
@@ -262,9 +258,8 @@ function assertAllowedProposersStrictlyIncreasing(proposers: number[]) {
 	return proposers;
 }
 
-// Sortedness is only checked when encoding. Upstream enforces it in `validity_check`, on
-// submission, and `is_allowed_proposer` documents reading an unsorted set as a deterministic
-// miss -- so decoding one must succeed, or we fail to read transactions the network accepted.
+// Upstream only checks sortedness in `validity_check`, on submission, so decoding an unsorted
+// set must succeed. Empty is a deserialization error there, and here.
 const AllowedProposerIndices = bcs.vector(bcs.u32()).transform({
 	input: assertAllowedProposersStrictlyIncreasing,
 	output: assertAllowedProposersNotEmpty,

--- a/packages/sui/src/bcs/bcs.ts
+++ b/packages/sui/src/bcs/bcs.ts
@@ -238,10 +238,45 @@ export const ValidDuring = bcs.struct('ValidDuring', {
 	nonce: bcs.u32(),
 });
 
+function validateAllowedProposerIndices(proposers: number[]) {
+	if (proposers.length === 0) {
+		throw new Error('Allowed proposers must not be empty');
+	}
+
+	for (let i = 1; i < proposers.length; i++) {
+		if (proposers[i] <= proposers[i - 1]) {
+			throw new Error('Allowed proposers must be strictly increasing');
+		}
+	}
+
+	return proposers;
+}
+
+const AllowedProposerIndices = bcs.vector(bcs.u32()).transform({
+	input: validateAllowedProposerIndices,
+	output: validateAllowedProposerIndices,
+});
+
+export const AllowedProposers = bcs.struct('AllowedProposers', {
+	epoch: bcs.u64(),
+	proposers: AllowedProposerIndices,
+});
+
+export const Validity = bcs.struct('Validity', {
+	minEpoch: bcs.option(bcs.u64()),
+	maxEpoch: bcs.option(bcs.u64()),
+	minTimestamp: bcs.option(bcs.u64()),
+	maxTimestamp: bcs.option(bcs.u64()),
+	chain: ObjectDigest,
+	nonce: bcs.u32(),
+	allowedProposers: bcs.option(AllowedProposers),
+});
+
 export const TransactionExpiration = bcs.enum('TransactionExpiration', {
 	None: null,
 	Epoch: unsafe_u64(),
 	ValidDuring: ValidDuring,
+	Validity,
 });
 
 export const StructTag = bcs.struct('StructTag', {

--- a/packages/sui/src/bcs/effects.ts
+++ b/packages/sui/src/bcs/effects.ts
@@ -55,6 +55,7 @@ const CommandArgumentError = bcs.enum('CommandArgumentError', {
 	CannotMoveBorrowedValue: null,
 	CannotWriteToExtendedReference: null,
 	InvalidReferenceArgument: null,
+	InvalidTxContext: null,
 });
 
 // Rust: crates/sui-types/src/execution_status.rs
@@ -139,7 +140,7 @@ const ExecutionFailureStatus = bcs.enum('ExecutionFailureStatus', {
 		maxScaledSize: bcs.u64(),
 	}),
 	InvalidLinkage: null,
-	InsufficientBalanceForWithdraw: null,
+	InsufficientFundsForWithdraw: null,
 	NonExclusiveWriteInputObjectModified: bcs.struct('NonExclusiveWriteInputObjectModified', {
 		id: Address,
 	}),

--- a/packages/sui/src/bcs/effects.ts
+++ b/packages/sui/src/bcs/effects.ts
@@ -140,7 +140,10 @@ const ExecutionFailureStatus = bcs.enum('ExecutionFailureStatus', {
 		maxScaledSize: bcs.u64(),
 	}),
 	InvalidLinkage: null,
-	InsufficientFundsForWithdraw: null,
+	// Upstream renamed this variant to `InsufficientFundsForWithdraw`. Keep the existing SDK name
+	// because changing the parsed BCS `$kind` would be a breaking API change. The BCS enum index and
+	// wire representation are unchanged.
+	InsufficientBalanceForWithdraw: null,
 	NonExclusiveWriteInputObjectModified: bcs.struct('NonExclusiveWriteInputObjectModified', {
 		id: Address,
 	}),

--- a/packages/sui/src/bcs/effects.ts
+++ b/packages/sui/src/bcs/effects.ts
@@ -140,9 +140,8 @@ const ExecutionFailureStatus = bcs.enum('ExecutionFailureStatus', {
 		maxScaledSize: bcs.u64(),
 	}),
 	InvalidLinkage: null,
-	// Upstream renamed this variant to `InsufficientFundsForWithdraw`. Keep the existing SDK name
-	// because changing the parsed BCS `$kind` would be a breaking API change. The BCS enum index and
-	// wire representation are unchanged.
+	// Upstream renamed this to `InsufficientFundsForWithdraw`; renaming the parsed `$kind` would
+	// break the public API, and the wire representation is unchanged either way.
 	InsufficientBalanceForWithdraw: null,
 	NonExclusiveWriteInputObjectModified: bcs.struct('NonExclusiveWriteInputObjectModified', {
 		id: Address,

--- a/packages/sui/src/bcs/transactions.ts
+++ b/packages/sui/src/bcs/transactions.ts
@@ -188,6 +188,7 @@ export const EndOfEpochTransactionKind = bcs.enum('EndOfEpochTransactionKind', {
 	DisplayRegistryCreate: null,
 	AddressAliasStateCreate: null,
 	WriteAccumulatorStorageCost: WriteAccumulatorStorageCost,
+	ForwardingAddressRegistryCreate: null,
 });
 
 // Rust: crates/sui-types/src/transaction.rs

--- a/packages/sui/src/bcs/types.ts
+++ b/packages/sui/src/bcs/types.ts
@@ -126,10 +126,19 @@ type ValidDuring = {
 	nonce: number;
 };
 
+type AllowedProposers = {
+	epoch: number | string;
+	proposers: number[];
+};
+
+type Validity = ValidDuring & {
+	allowedProposers: { None: null } | { Some: AllowedProposers };
+};
+
 /**
  * TransactionExpiration
  *
  * Indications the expiration time for a transaction.
  */
 export type TransactionExpiration =
-	{ None: null } | { Epoch: number } | { ValidDuring: ValidDuring };
+	{ None: null } | { Epoch: number } | { ValidDuring: ValidDuring } | { Validity: Validity };

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -603,6 +603,9 @@ export function grpcTransactionToTransactionData(grpcTx: GrpcTransaction): Trans
 					},
 				};
 				break;
+			default:
+				// Leaving `expiration` null here would drop a restriction the server did send.
+				throw new Error(`Unknown transaction expiration kind: ${grpcTx.expiration.kind}`);
 		}
 	}
 

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -23,6 +23,18 @@ import type { Argument } from '../grpc/proto/sui/rpc/v2/argument.js';
 import { Argument_ArgumentKind } from '../grpc/proto/sui/rpc/v2/argument.js';
 import { Transaction } from '../transactions/Transaction.js';
 
+function millisecondsToGrpcTimestamp(value: string | number) {
+	const milliseconds = BigInt(value);
+	return {
+		seconds: milliseconds / 1000n,
+		nanos: Number(milliseconds % 1000n) * 1_000_000,
+	};
+}
+
+function grpcTimestampToMilliseconds(timestamp: { seconds: bigint; nanos: number }) {
+	return (timestamp.seconds * 1000n + BigInt(Math.floor(timestamp.nanos / 1_000_000))).toString();
+}
+
 /**
  * Converts CallArg (TypeScript internal format) to gRPC Input format
  */
@@ -263,14 +275,36 @@ export function transactionDataToGrpcTransaction(data: TransactionData): GrpcTra
 				kind: TransactionExpiration_TransactionExpirationKind.EPOCH,
 				epoch: BigInt(data.expiration.Epoch),
 			};
-		} else if (data.expiration.$kind === 'ValidDuring') {
-			const validDuring = data.expiration.ValidDuring;
+		} else if (data.expiration.$kind === 'ValidDuring' || data.expiration.$kind === 'Validity') {
+			const validity =
+				data.expiration.$kind === 'ValidDuring'
+					? data.expiration.ValidDuring
+					: data.expiration.Validity;
+			const allowedProposers =
+				data.expiration.$kind === 'Validity' ? data.expiration.Validity.allowedProposers : null;
 			transaction.expiration = {
-				kind: TransactionExpiration_TransactionExpirationKind.VALID_DURING,
-				minEpoch: validDuring.minEpoch != null ? BigInt(validDuring.minEpoch) : undefined,
-				epoch: validDuring.maxEpoch != null ? BigInt(validDuring.maxEpoch) : undefined,
-				chain: validDuring.chain,
-				nonce: validDuring.nonce,
+				kind:
+					data.expiration.$kind === 'ValidDuring'
+						? TransactionExpiration_TransactionExpirationKind.VALID_DURING
+						: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+				minEpoch: validity.minEpoch != null ? BigInt(validity.minEpoch) : undefined,
+				epoch: validity.maxEpoch != null ? BigInt(validity.maxEpoch) : undefined,
+				minTimestamp:
+					validity.minTimestamp != null
+						? millisecondsToGrpcTimestamp(validity.minTimestamp)
+						: undefined,
+				maxTimestamp:
+					validity.maxTimestamp != null
+						? millisecondsToGrpcTimestamp(validity.maxTimestamp)
+						: undefined,
+				chain: validity.chain,
+				nonce: validity.nonce,
+				allowedProposers: allowedProposers
+					? {
+							epoch: BigInt(allowedProposers.epoch),
+							proposers: allowedProposers.proposers,
+						}
+					: undefined,
 			};
 		}
 	}
@@ -529,10 +563,37 @@ export function grpcTransactionToTransactionData(grpcTx: GrpcTransaction): Trans
 					ValidDuring: {
 						minEpoch: grpcTx.expiration.minEpoch?.toString() ?? null,
 						maxEpoch: grpcTx.expiration.epoch?.toString() ?? null,
-						minTimestamp: null,
-						maxTimestamp: null,
+						minTimestamp: grpcTx.expiration.minTimestamp
+							? grpcTimestampToMilliseconds(grpcTx.expiration.minTimestamp)
+							: null,
+						maxTimestamp: grpcTx.expiration.maxTimestamp
+							? grpcTimestampToMilliseconds(grpcTx.expiration.maxTimestamp)
+							: null,
 						chain: grpcTx.expiration.chain ?? '',
 						nonce: grpcTx.expiration.nonce ?? 0,
+					},
+				};
+				break;
+			case TransactionExpiration_TransactionExpirationKind.VALIDITY:
+				expiration = {
+					$kind: 'Validity',
+					Validity: {
+						minEpoch: grpcTx.expiration.minEpoch?.toString() ?? null,
+						maxEpoch: grpcTx.expiration.epoch?.toString() ?? null,
+						minTimestamp: grpcTx.expiration.minTimestamp
+							? grpcTimestampToMilliseconds(grpcTx.expiration.minTimestamp)
+							: null,
+						maxTimestamp: grpcTx.expiration.maxTimestamp
+							? grpcTimestampToMilliseconds(grpcTx.expiration.maxTimestamp)
+							: null,
+						chain: grpcTx.expiration.chain ?? '',
+						nonce: grpcTx.expiration.nonce ?? 0,
+						allowedProposers: grpcTx.expiration.allowedProposers
+							? {
+									epoch: grpcTx.expiration.allowedProposers.epoch?.toString() ?? '0',
+									proposers: grpcTx.expiration.allowedProposers.proposers,
+								}
+							: null,
 					},
 				};
 				break;

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -4,6 +4,7 @@
 import { fromBase64, toBase64 } from '@mysten/bcs';
 
 import type { bcs } from '../bcs/index.js';
+import { assertAllowedProposersNotEmpty } from '../bcs/bcs.js';
 import { TransactionDataBuilder } from '../transactions/TransactionData.js';
 import type {
 	CallArg,
@@ -591,7 +592,9 @@ export function grpcTransactionToTransactionData(grpcTx: GrpcTransaction): Trans
 						allowedProposers: grpcTx.expiration.allowedProposers
 							? {
 									epoch: grpcTx.expiration.allowedProposers.epoch?.toString() ?? '0',
-									proposers: grpcTx.expiration.allowedProposers.proposers,
+									proposers: assertAllowedProposersNotEmpty(
+										grpcTx.expiration.allowedProposers.proposers,
+									),
 								}
 							: null,
 					},

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -4,7 +4,10 @@
 import { fromBase64, toBase64 } from '@mysten/bcs';
 
 import type { bcs } from '../bcs/index.js';
-import { assertAllowedProposersNotEmpty } from '../bcs/bcs.js';
+import {
+	assertAllowedProposersNotEmpty,
+	assertAllowedProposersStrictlyIncreasing,
+} from '../bcs/bcs.js';
 import { TransactionDataBuilder } from '../transactions/TransactionData.js';
 import type {
 	CallArg,
@@ -303,7 +306,7 @@ export function transactionDataToGrpcTransaction(data: TransactionData): GrpcTra
 				allowedProposers: allowedProposers
 					? {
 							epoch: BigInt(allowedProposers.epoch),
-							proposers: allowedProposers.proposers,
+							proposers: assertAllowedProposersStrictlyIncreasing(allowedProposers.proposers),
 						}
 					: undefined,
 			};

--- a/packages/sui/src/client/utils.ts
+++ b/packages/sui/src/client/utils.ts
@@ -371,7 +371,7 @@ function parseBcsExecutionError(failure: {
 		case 'SharedObjectOperationNotAllowed':
 		case 'ExecutionCancelledDueToRandomnessUnavailable':
 		case 'InvalidLinkage':
-		case 'InsufficientFundsForWithdraw':
+		case 'InsufficientBalanceForWithdraw':
 			return {
 				$kind: 'Unknown',
 				message: error.$kind,

--- a/packages/sui/src/client/utils.ts
+++ b/packages/sui/src/client/utils.ts
@@ -371,7 +371,7 @@ function parseBcsExecutionError(failure: {
 		case 'SharedObjectOperationNotAllowed':
 		case 'ExecutionCancelledDueToRandomnessUnavailable':
 		case 'InvalidLinkage':
-		case 'InsufficientBalanceForWithdraw':
+		case 'InsufficientFundsForWithdraw':
 			return {
 				$kind: 'Unknown',
 				message: error.$kind,

--- a/packages/sui/src/grpc/proto/sui/rpc/v2/execution_status.ts
+++ b/packages/sui/src/grpc/proto/sui/rpc/v2/execution_status.ts
@@ -727,6 +727,14 @@ export enum CommandArgumentError_CommandArgumentErrorKind {
 	 * @generated from protobuf enum value: INVALID_REFERENCE_ARGUMENT = 19;
 	 */
 	INVALID_REFERENCE_ARGUMENT = 19,
+	/**
+	 * Invalid usage of TxContext in the function signature. TxContext can only be used by
+	 * reference, `&TxContext` or `&mut TxContext`. If used mutably, it must be the only
+	 * TxContext parameter, and TxContext can never be returned from a Move call.
+	 *
+	 * @generated from protobuf enum value: INVALID_TX_CONTEXT = 20;
+	 */
+	INVALID_TX_CONTEXT = 20,
 }
 /**
  * An error with upgrading a package.

--- a/packages/sui/src/grpc/proto/sui/rpc/v2/transaction.ts
+++ b/packages/sui/src/grpc/proto/sui/rpc/v2/transaction.ts
@@ -145,6 +145,13 @@ export interface TransactionExpiration {
 	 * @generated from protobuf field: optional uint32 nonce = 7;
 	 */
 	nonce?: number;
+	/**
+	 * The validators allowed to propose this transaction in consensus. Only set when `kind`
+	 * is `VALIDITY`. Leave unset to let any validator propose the transaction.
+	 *
+	 * @generated from protobuf field: optional sui.rpc.v2.AllowedProposers allowed_proposers = 8;
+	 */
+	allowedProposers?: AllowedProposers;
 }
 /**
  * @generated from protobuf enum sui.rpc.v2.TransactionExpiration.TransactionExpirationKind
@@ -181,6 +188,40 @@ export enum TransactionExpiration_TransactionExpirationKind {
 	 * @generated from protobuf enum value: VALID_DURING = 3;
 	 */
 	VALID_DURING = 3,
+	/**
+	 * Everything in VALID_DURING, plus a restriction on which validators may
+	 * propose the transaction in consensus.
+	 *
+	 * @generated from protobuf enum value: VALIDITY = 4;
+	 */
+	VALIDITY = 4,
+}
+/**
+ * The validators allowed to propose a transaction in consensus.
+ *
+ * Proposal by any other validator is byzantine behavior and invalidates the whole block.
+ *
+ * @generated from protobuf message sui.rpc.v2.AllowedProposers
+ */
+export interface AllowedProposers {
+	/**
+	 * The epoch whose committee `proposers` indexes into.
+	 *
+	 * Committee indices are only meaningful against one committee, so a set recorded for any
+	 * other epoch is ignored and the transaction is treated as naming no proposers.
+	 *
+	 * @generated from protobuf field: optional uint64 epoch = 1;
+	 */
+	epoch?: bigint;
+	/**
+	 * Committee indices of the allowed proposers, strictly increasing and non-empty.
+	 *
+	 * An empty list names no validator and is rejected; omit `allowed_proposers` entirely to
+	 * let any validator propose the transaction.
+	 *
+	 * @generated from protobuf field: repeated uint32 proposers = 2;
+	 */
+	proposers: number[];
 }
 /**
  * Transaction type.
@@ -1314,6 +1355,7 @@ class TransactionExpiration$Type extends MessageType<TransactionExpiration> {
 			{ no: 5, name: 'max_timestamp', kind: 'message', T: () => Timestamp },
 			{ no: 6, name: 'chain', kind: 'scalar', opt: true, T: 9 /*ScalarType.STRING*/ },
 			{ no: 7, name: 'nonce', kind: 'scalar', opt: true, T: 13 /*ScalarType.UINT32*/ },
+			{ no: 8, name: 'allowed_proposers', kind: 'message', T: () => AllowedProposers },
 		]);
 	}
 }
@@ -1321,6 +1363,32 @@ class TransactionExpiration$Type extends MessageType<TransactionExpiration> {
  * @generated MessageType for protobuf message sui.rpc.v2.TransactionExpiration
  */
 export const TransactionExpiration = new TransactionExpiration$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AllowedProposers$Type extends MessageType<AllowedProposers> {
+	constructor() {
+		super('sui.rpc.v2.AllowedProposers', [
+			{
+				no: 1,
+				name: 'epoch',
+				kind: 'scalar',
+				opt: true,
+				T: 4 /*ScalarType.UINT64*/,
+				L: 0 /*LongType.BIGINT*/,
+			},
+			{
+				no: 2,
+				name: 'proposers',
+				kind: 'scalar',
+				repeat: 1 /*RepeatType.PACKED*/,
+				T: 13 /*ScalarType.UINT32*/,
+			},
+		]);
+	}
+}
+/**
+ * @generated MessageType for protobuf message sui.rpc.v2.AllowedProposers
+ */
+export const AllowedProposers = new AllowedProposers$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class TransactionKind$Type extends MessageType<TransactionKind> {
 	constructor() {

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -346,9 +346,7 @@ export type ValidDuring = InferOutput<typeof ValidDuringSchema>;
 // Rust: crates/sui-types/src/transaction.rs
 export const AllowedProposersSchema = object({
 	epoch: JsonU64,
-	// This schema is shared by `setExpiration` and by `TransactionDataBuilder.restore`, so it can
-	// only carry the invariant that holds on both paths. Sortedness is enforced when encoding to
-	// BCS; see `assertAllowedProposersNotEmpty` in ../../bcs/bcs.ts.
+	// Shared by `setExpiration` and `restore`, so this can only carry the invariant true on both.
 	proposers: pipe(
 		array(U32),
 		check((proposers) => proposers.length > 0, 'Allowed proposers must not be empty'),

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -346,14 +346,12 @@ export type ValidDuring = InferOutput<typeof ValidDuringSchema>;
 // Rust: crates/sui-types/src/transaction.rs
 export const AllowedProposersSchema = object({
 	epoch: JsonU64,
+	// This schema is shared by `setExpiration` and by `TransactionDataBuilder.restore`, so it can
+	// only carry the invariant that holds on both paths. Sortedness is enforced when encoding to
+	// BCS; see `assertAllowedProposersNotEmpty` in ../../bcs/bcs.ts.
 	proposers: pipe(
 		array(U32),
-		check(
-			(proposers) =>
-				proposers.length > 0 &&
-				proposers.every((proposer, i) => i === 0 || proposer > proposers[i - 1]),
-			'Allowed proposers must be strictly increasing and non-empty',
-		),
+		check((proposers) => proposers.length > 0, 'Allowed proposers must not be empty'),
 	),
 });
 export type AllowedProposers = InferOutput<typeof AllowedProposersSchema>;

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -343,10 +343,31 @@ export const ValidDuringSchema = object({
 });
 export type ValidDuring = InferOutput<typeof ValidDuringSchema>;
 
+export const AllowedProposersSchema = object({
+	epoch: JsonU64,
+	proposers: pipe(
+		array(U32),
+		check(
+			(proposers) =>
+				proposers.length > 0 &&
+				proposers.every((proposer, i) => i === 0 || proposer > proposers[i - 1]),
+			'Allowed proposers must be strictly increasing and non-empty',
+		),
+	),
+});
+export type AllowedProposers = InferOutput<typeof AllowedProposersSchema>;
+
+export const ValiditySchema = object({
+	...ValidDuringSchema.entries,
+	allowedProposers: nullable(AllowedProposersSchema),
+});
+export type Validity = InferOutput<typeof ValiditySchema>;
+
 export const TransactionExpiration = safeEnum({
 	None: literal(true),
 	Epoch: JsonU64,
 	ValidDuring: ValidDuringSchema,
+	Validity: ValiditySchema,
 });
 
 export type TransactionExpiration = InferOutput<typeof TransactionExpiration>;

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -343,6 +343,7 @@ export const ValidDuringSchema = object({
 });
 export type ValidDuring = InferOutput<typeof ValidDuringSchema>;
 
+// Rust: crates/sui-types/src/transaction.rs
 export const AllowedProposersSchema = object({
 	epoch: JsonU64,
 	proposers: pipe(
@@ -357,6 +358,7 @@ export const AllowedProposersSchema = object({
 });
 export type AllowedProposers = InferOutput<typeof AllowedProposersSchema>;
 
+// Rust: crates/sui-types/src/transaction.rs
 export const ValiditySchema = object({
 	...ValidDuringSchema.entries,
 	allowedProposers: nullable(AllowedProposersSchema),

--- a/packages/sui/src/transactions/data/v1.ts
+++ b/packages/sui/src/transactions/data/v1.ts
@@ -72,11 +72,8 @@ const TransactionInput = union([
 	}),
 ]);
 
-// `ValidDuring` and `Validity` were added after v1 was otherwise frozen. Representing them here
-// rather than collapsing them to `{ None: true }` keeps a `serialize()` -> `from()` round trip
-// lossless: the old behaviour dropped the expiration -- and, for `Validity`, the set of validators
-// allowed to propose the transaction -- so the rebuilt transaction signed materially broader bytes.
-// An older SDK reading these throws on a union mismatch instead, which is the safe failure.
+// Carried here rather than collapsed to `{ None: true }`, which silently dropped the expiration
+// (and its allowed proposers) from a `serialize()` -> `from()` round trip before signing.
 const TransactionExpiration = union([
 	object({ Epoch: pipe(number(), integer()) }),
 	object({ None: nullable(literal(true)) }),
@@ -98,14 +95,11 @@ function expirationToV1(
 			return { Validity: expiration.Validity };
 		case 'None':
 			return { None: true };
+		default:
+			// Representing a new variant here is not optional: this fails to compile without it.
+			expiration satisfies never;
+			throw new Error(`Unknown transaction expiration: ${JSON.stringify(expiration)}`);
 	}
-
-	// Adding a variant to `TransactionExpiration` without representing it here is a compile error:
-	// the switch above narrows `expiration` to `never`, so this assignment stops typechecking.
-	// Without it a new variant would serialize as no expiration at all, which is the silent
-	// downgrade this function exists to avoid.
-	const unhandled: never = expiration;
-	throw new Error(`Unknown transaction expiration: ${(unhandled as { $kind: string }).$kind}`);
 }
 
 function expirationFromV1(
@@ -117,10 +111,8 @@ function expirationFromV1(
 	if ('Validity' in expiration) return { Validity: expiration.Validity };
 	if ('None' in expiration) return { None: true };
 
-	// `restore` hands v1 payloads straight here without validating them against
-	// `SerializedTransactionDataV1`, so this is the only place an unrecognised expiration can be
-	// caught. Falling through to `{ None: true }` -- as this did before -- silently discards an
-	// expiration we failed to understand and rebuilds a transaction that signs broader bytes.
+	// `restore` does not validate v1 payloads against the schema, so this is the only place an
+	// unrecognised expiration can be caught rather than silently becoming `{ None: true }`.
 	throw new Error(
 		`Unknown transaction expiration in v1 transaction data: ${Object.keys(expiration).join(', ')}`,
 	);

--- a/packages/sui/src/transactions/data/v1.ts
+++ b/packages/sui/src/transactions/data/v1.ts
@@ -87,7 +87,9 @@ const TransactionExpiration = union([
 function expirationToV1(
 	expiration: TransactionData['expiration'],
 ): InferOutput<typeof TransactionExpiration> | null {
-	switch (expiration?.$kind) {
+	if (!expiration) return null;
+
+	switch (expiration.$kind) {
 		case 'Epoch':
 			return { Epoch: Number(expiration.Epoch) };
 		case 'ValidDuring':
@@ -96,9 +98,14 @@ function expirationToV1(
 			return { Validity: expiration.Validity };
 		case 'None':
 			return { None: true };
-		default:
-			return null;
 	}
+
+	// Adding a variant to `TransactionExpiration` without representing it here is a compile error:
+	// the switch above narrows `expiration` to `never`, so this assignment stops typechecking.
+	// Without it a new variant would serialize as no expiration at all, which is the silent
+	// downgrade this function exists to avoid.
+	const unhandled: never = expiration;
+	throw new Error(`Unknown transaction expiration: ${(unhandled as { $kind: string }).$kind}`);
 }
 
 function expirationFromV1(

--- a/packages/sui/src/transactions/data/v1.ts
+++ b/packages/sui/src/transactions/data/v1.ts
@@ -201,6 +201,15 @@ export type SerializedTransactionDataV1 = InferOutput<typeof SerializedTransacti
 export function serializeV1TransactionData(
 	transactionData: TransactionData,
 ): SerializedTransactionDataV1 {
+	if (
+		transactionData.expiration?.$kind === 'ValidDuring' ||
+		transactionData.expiration?.$kind === 'Validity'
+	) {
+		throw new Error(
+			`${transactionData.expiration.$kind} expiration cannot be represented by the deprecated V1 transaction JSON format. Use Transaction.toJSON() instead.`,
+		);
+	}
+
 	const inputs: InferOutput<typeof TransactionInput>[] = transactionData.inputs.map(
 		(input, index) => {
 			if (input.Object) {

--- a/packages/sui/src/transactions/data/v1.ts
+++ b/packages/sui/src/transactions/data/v1.ts
@@ -26,7 +26,14 @@ import {
 
 import { TypeTagSerializer } from '../../bcs/index.js';
 import type { StructTag as StructTagType, TypeTag as TypeTagType } from '../../bcs/types.js';
-import { JsonU64, ObjectID, safeEnum, TransactionDataSchema } from './internal.js';
+import {
+	JsonU64,
+	ObjectID,
+	safeEnum,
+	TransactionDataSchema,
+	ValidDuringSchema,
+	ValiditySchema,
+} from './internal.js';
 import type { Argument, ArgumentSchema, TransactionData } from './internal.js';
 
 export const ObjectRef = object({
@@ -65,10 +72,52 @@ const TransactionInput = union([
 	}),
 ]);
 
+// `ValidDuring` and `Validity` were added after v1 was otherwise frozen. Representing them here
+// rather than collapsing them to `{ None: true }` keeps a `serialize()` -> `from()` round trip
+// lossless: the old behaviour dropped the expiration -- and, for `Validity`, the set of validators
+// allowed to propose the transaction -- so the rebuilt transaction signed materially broader bytes.
+// An older SDK reading these throws on a union mismatch instead, which is the safe failure.
 const TransactionExpiration = union([
 	object({ Epoch: pipe(number(), integer()) }),
 	object({ None: nullable(literal(true)) }),
+	object({ ValidDuring: ValidDuringSchema }),
+	object({ Validity: ValiditySchema }),
 ]);
+
+function expirationToV1(
+	expiration: TransactionData['expiration'],
+): InferOutput<typeof TransactionExpiration> | null {
+	switch (expiration?.$kind) {
+		case 'Epoch':
+			return { Epoch: Number(expiration.Epoch) };
+		case 'ValidDuring':
+			return { ValidDuring: expiration.ValidDuring };
+		case 'Validity':
+			return { Validity: expiration.Validity };
+		case 'None':
+			return { None: true };
+		default:
+			return null;
+	}
+}
+
+function expirationFromV1(
+	expiration: SerializedTransactionDataV1['expiration'],
+): InferInput<typeof TransactionDataSchema>['expiration'] {
+	if (!expiration) return null;
+	if ('Epoch' in expiration) return { Epoch: expiration.Epoch };
+	if ('ValidDuring' in expiration) return { ValidDuring: expiration.ValidDuring };
+	if ('Validity' in expiration) return { Validity: expiration.Validity };
+	if ('None' in expiration) return { None: true };
+
+	// `restore` hands v1 payloads straight here without validating them against
+	// `SerializedTransactionDataV1`, so this is the only place an unrecognised expiration can be
+	// caught. Falling through to `{ None: true }` -- as this did before -- silently discards an
+	// expiration we failed to understand and rebuilds a transaction that signs broader bytes.
+	throw new Error(
+		`Unknown transaction expiration in v1 transaction data: ${Object.keys(expiration).join(', ')}`,
+	);
+}
 
 const StringEncodedBigint = pipe(
 	union([number(), string(), bigint()]),
@@ -267,12 +316,7 @@ export function serializeV1TransactionData(
 	return {
 		version: 1,
 		sender: transactionData.sender ?? undefined,
-		expiration:
-			transactionData.expiration?.$kind === 'Epoch'
-				? { Epoch: Number(transactionData.expiration.Epoch) }
-				: transactionData.expiration
-					? { None: true }
-					: null,
+		expiration: expirationToV1(transactionData.expiration),
 		gasConfig: {
 			owner: transactionData.gasData.owner ?? undefined,
 			budget: transactionData.gasData.budget ?? undefined,
@@ -373,11 +417,7 @@ export function transactionDataFromV1(data: SerializedTransactionDataV1): Transa
 	return parse(TransactionDataSchema, {
 		version: 2,
 		sender: data.sender ?? null,
-		expiration: data.expiration
-			? 'Epoch' in data.expiration
-				? { Epoch: data.expiration.Epoch }
-				: { None: true }
-			: null,
+		expiration: expirationFromV1(data.expiration),
 		gasData: {
 			owner: data.gasConfig.owner ?? null,
 			budget: data.gasConfig.budget?.toString() ?? null,

--- a/packages/sui/src/transactions/data/v1.ts
+++ b/packages/sui/src/transactions/data/v1.ts
@@ -201,15 +201,6 @@ export type SerializedTransactionDataV1 = InferOutput<typeof SerializedTransacti
 export function serializeV1TransactionData(
 	transactionData: TransactionData,
 ): SerializedTransactionDataV1 {
-	if (
-		transactionData.expiration?.$kind === 'ValidDuring' ||
-		transactionData.expiration?.$kind === 'Validity'
-	) {
-		throw new Error(
-			`${transactionData.expiration.$kind} expiration cannot be represented by the deprecated V1 transaction JSON format. Use Transaction.toJSON() instead.`,
-		);
-	}
-
 	const inputs: InferOutput<typeof TransactionInput>[] = transactionData.inputs.map(
 		(input, index) => {
 			if (input.Object) {

--- a/packages/sui/src/transactions/data/v2.ts
+++ b/packages/sui/src/transactions/data/v2.ts
@@ -29,6 +29,7 @@ import {
 	ObjectRefSchema,
 	SuiAddress,
 	ValidDuringSchema,
+	ValiditySchema,
 } from './internal.js';
 import type { Simplify } from '@mysten/utils';
 
@@ -143,6 +144,7 @@ const TransactionExpiration = enumUnion({
 	None: literal(true),
 	Epoch: JsonU64,
 	ValidDuring: ValidDuringSchema,
+	Validity: ValiditySchema,
 });
 
 export const SerializedTransactionDataV2Schema = object({

--- a/packages/sui/test/unit/client/extract-status.test.ts
+++ b/packages/sui/test/unit/client/extract-status.test.ts
@@ -172,6 +172,39 @@ describe('extractStatusFromEffectsBcs', () => {
 		}).toBytes();
 	}
 
+	function createInvalidTxContextEffectsV2(): Uint8Array {
+		return bcs.TransactionEffects.serialize({
+			V2: {
+				status: {
+					Failure: {
+						error: {
+							CommandArgumentError: {
+								argIdx: 1,
+								kind: { InvalidTxContext: true },
+							},
+						},
+						command: 2,
+					},
+				},
+				executedEpoch: 1n,
+				gasUsed: {
+					computationCost: 1000n,
+					storageCost: 500n,
+					storageRebate: 100n,
+					nonRefundableStorageFee: 0n,
+				},
+				transactionDigest: ZERO_DIGEST,
+				gasObjectIndex: null,
+				eventsDigest: null,
+				dependencies: [],
+				lamportVersion: 1n,
+				changedObjects: [],
+				unchangedConsensusObjects: [],
+				auxDataDigest: null,
+			},
+		}).toBytes();
+	}
+
 	describe('V2 effects', () => {
 		it('should extract success status from V2 effects', () => {
 			const effectsBytes = createSuccessEffectsV2();
@@ -208,6 +241,21 @@ describe('extractStatusFromEffectsBcs', () => {
 					name: 'ObjectTooBig',
 					size: 1000000,
 					maxSize: 500000,
+				},
+			});
+		});
+
+		it('should extract InvalidTxContext command argument errors', () => {
+			const status = extractStatusFromEffectsBcs(createInvalidTxContextEffectsV2());
+
+			expect(status.error).toEqual({
+				$kind: 'CommandArgumentError',
+				message:
+					'CommandArgumentError({"argIdx":1,"kind":{"InvalidTxContext":true,"$kind":"InvalidTxContext"}})',
+				command: 2,
+				CommandArgumentError: {
+					argument: 1,
+					name: 'InvalidTxContext',
 				},
 			});
 		});

--- a/packages/sui/test/unit/client/transaction-resolver.test.ts
+++ b/packages/sui/test/unit/client/transaction-resolver.test.ts
@@ -562,6 +562,22 @@ describe('Transaction Resolver - TypeScript to gRPC Conversion', () => {
 			);
 		});
 
+		it.each([0, 99])('rejects the unsupported grpc expiration kind %i', (kind) => {
+			const grpcTx = {
+				kind: {
+					data: {
+						oneofKind: 'programmableTransaction',
+						programmableTransaction: { inputs: [], commands: [] },
+					},
+				},
+				expiration: { kind, epoch: 43n },
+			} as unknown as GrpcTransaction;
+
+			expect(() => grpcTransactionToTransactionData(grpcTx)).toThrow(
+				/Unknown transaction expiration kind/,
+			);
+		});
+
 		it('rejects an empty allowed proposer set when decoding a grpc transaction', () => {
 			const grpcTx = {
 				kind: {

--- a/packages/sui/test/unit/client/transaction-resolver.test.ts
+++ b/packages/sui/test/unit/client/transaction-resolver.test.ts
@@ -11,6 +11,7 @@ import {
 import { Input_InputKind } from '../../../src/grpc/proto/sui/rpc/v2/input.js';
 import { Argument_ArgumentKind } from '../../../src/grpc/proto/sui/rpc/v2/argument.js';
 import type { Transaction as GrpcTransaction } from '../../../src/grpc/proto/sui/rpc/v2/transaction.js';
+import { TransactionExpiration_TransactionExpirationKind } from '../../../src/grpc/proto/sui/rpc/v2/transaction.js';
 
 // Helper to get programmable transaction from gRPC transaction
 function getProgrammableTx(grpcTx: GrpcTransaction) {
@@ -540,5 +541,28 @@ describe('Transaction Resolver - TypeScript to gRPC Conversion', () => {
 				);
 			},
 		);
+
+		it('rejects an empty allowed proposer set when decoding a grpc transaction', () => {
+			const grpcTx = {
+				kind: {
+					data: {
+						oneofKind: 'programmableTransaction',
+						programmableTransaction: { inputs: [], commands: [] },
+					},
+				},
+				expiration: {
+					kind: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+					minEpoch: 42n,
+					epoch: 43n,
+					chain: toBase58(new Uint8Array(32).fill(7)),
+					nonce: 0,
+					allowedProposers: { epoch: 42n, proposers: [] },
+				},
+			} as unknown as GrpcTransaction;
+
+			expect(() => grpcTransactionToTransactionData(grpcTx)).toThrow(
+				/Allowed proposers must not be empty/,
+			);
+		});
 	});
 });

--- a/packages/sui/test/unit/client/transaction-resolver.test.ts
+++ b/packages/sui/test/unit/client/transaction-resolver.test.ts
@@ -542,6 +542,26 @@ describe('Transaction Resolver - TypeScript to gRPC Conversion', () => {
 			},
 		);
 
+		it('rejects unsorted allowed proposers when encoding a grpc transaction', () => {
+			const tx = new Transaction();
+			tx.setExpiration({
+				Validity: {
+					minEpoch: '42',
+					maxEpoch: '43',
+					minTimestamp: null,
+					maxTimestamp: null,
+					chain: toBase58(new Uint8Array(32).fill(7)),
+					nonce: 0,
+					allowedProposers: { epoch: '42', proposers: [5, 2] },
+				},
+			});
+			tx.moveCall({ target: '0x2::foo::bar' });
+
+			expect(() => transactionDataToGrpcTransaction(tx.getData())).toThrow(
+				/Allowed proposers must be strictly increasing/,
+			);
+		});
+
 		it('rejects an empty allowed proposer set when decoding a grpc transaction', () => {
 			const grpcTx = {
 				kind: {

--- a/packages/sui/test/unit/client/transaction-resolver.test.ts
+++ b/packages/sui/test/unit/client/transaction-resolver.test.ts
@@ -4,7 +4,10 @@
 import { describe, it, expect } from 'vitest';
 import { toBase58 } from '@mysten/bcs';
 import { Transaction } from '../../../src/transactions/Transaction.js';
-import { transactionDataToGrpcTransaction } from '../../../src/client/transaction-resolver.js';
+import {
+	grpcTransactionToTransactionData,
+	transactionDataToGrpcTransaction,
+} from '../../../src/client/transaction-resolver.js';
 import { Input_InputKind } from '../../../src/grpc/proto/sui/rpc/v2/input.js';
 import { Argument_ArgumentKind } from '../../../src/grpc/proto/sui/rpc/v2/argument.js';
 import type { Transaction as GrpcTransaction } from '../../../src/grpc/proto/sui/rpc/v2/transaction.js';
@@ -480,5 +483,62 @@ describe('Transaction Resolver - TypeScript to gRPC Conversion', () => {
 			const grpcTx = transactionDataToGrpcTransaction(tx.getData());
 			expect(grpcTx.expiration?.kind).toBe(1); // NONE = 1
 		});
+
+		it('should round-trip ValidDuring timestamps through gRPC', () => {
+			const tx = new Transaction();
+			tx.setExpiration({
+				ValidDuring: {
+					minEpoch: '42',
+					maxEpoch: '43',
+					minTimestamp: '1700000000123',
+					maxTimestamp: '1700000999456',
+					chain: toBase58(new Uint8Array(32).fill(7)),
+					nonce: 0xc0ffee,
+				},
+			});
+			tx.moveCall({ target: '0x2::foo::bar' });
+
+			const grpcTx = transactionDataToGrpcTransaction(tx.getData());
+
+			expect(grpcTx.expiration?.minTimestamp).toEqual({
+				seconds: 1_700_000_000n,
+				nanos: 123_000_000,
+			});
+			expect(grpcTransactionToTransactionData(grpcTx).expiration).toEqual(tx.getData().expiration);
+		});
+
+		it.each([{ epoch: '42', proposers: [0, 2, 5] }, null])(
+			'should round-trip Validity through gRPC with allowed proposers %j',
+			(allowedProposers) => {
+				const tx = new Transaction();
+				tx.setExpiration({
+					Validity: {
+						minEpoch: '42',
+						maxEpoch: '43',
+						minTimestamp: '1700000000123',
+						maxTimestamp: '1700000999456',
+						chain: toBase58(new Uint8Array(32).fill(7)),
+						nonce: 0xc0ffee,
+						allowedProposers,
+					},
+				});
+				tx.moveCall({ target: '0x2::foo::bar' });
+
+				const grpcTx = transactionDataToGrpcTransaction(tx.getData());
+
+				expect(grpcTx.expiration?.kind).toBe(4); // VALIDITY = 4
+				expect(grpcTx.expiration?.allowedProposers).toEqual(
+					allowedProposers
+						? {
+								epoch: 42n,
+								proposers: [0, 2, 5],
+							}
+						: undefined,
+				);
+				expect(grpcTransactionToTransactionData(grpcTx).expiration).toEqual(
+					tx.getData().expiration,
+				);
+			},
+		);
 	});
 });

--- a/packages/sui/test/unit/transactions/bcs.test.ts
+++ b/packages/sui/test/unit/transactions/bcs.test.ts
@@ -102,8 +102,6 @@ it.each([[[]], [[2, 2]], [[2, 1]]])(
 	},
 );
 
-// Sortedness is a submission-time rule upstream, not a deserialization one, so bytes carrying an
-// unsorted set must still decode -- they can represent a transaction the network accepted.
 it('decodes an unsorted allowed proposer set', () => {
 	const bytes = validityBytes([2, 5]);
 	// Swap the two trailing u32s so the encoded set reads [5, 2].

--- a/packages/sui/test/unit/transactions/bcs.test.ts
+++ b/packages/sui/test/unit/transactions/bcs.test.ts
@@ -81,8 +81,8 @@ it.each([{ epoch: '42', proposers: [0, 2, 5] }, null])(
 	},
 );
 
-it.each([[[]], [[2, 2]], [[2, 1]]])('rejects invalid allowed proposer indices %j', (proposers) => {
-	const expiration = {
+function validityBytes(proposers: number[]) {
+	return bcs.TransactionExpiration.serialize({
 		Validity: {
 			minEpoch: null,
 			maxEpoch: null,
@@ -92,9 +92,35 @@ it.each([[[]], [[2, 2]], [[2, 1]]])('rejects invalid allowed proposer indices %j
 			nonce: 0,
 			allowedProposers: { epoch: '42', proposers },
 		},
-	} satisfies typeof bcs.TransactionExpiration.$inferInput;
+	}).toBytes();
+}
 
-	expect(() => bcs.TransactionExpiration.serialize(expiration)).toThrow(/Allowed proposers/);
+it.each([[[]], [[2, 2]], [[2, 1]]])(
+	'rejects invalid allowed proposer indices when encoding %j',
+	(proposers) => {
+		expect(() => validityBytes(proposers)).toThrow(/Allowed proposers/);
+	},
+);
+
+// Sortedness is a submission-time rule upstream, not a deserialization one, so bytes carrying an
+// unsorted set must still decode -- they can represent a transaction the network accepted.
+it('decodes an unsorted allowed proposer set', () => {
+	const bytes = validityBytes([2, 5]);
+	// Swap the two trailing u32s so the encoded set reads [5, 2].
+	bytes.set([...bytes.slice(-4), ...bytes.slice(-8, -4)], bytes.length - 8);
+
+	expect(bcs.TransactionExpiration.parse(bytes).Validity?.allowedProposers?.proposers).toEqual([
+		5, 2,
+	]);
+});
+
+it('rejects an empty allowed proposer set when decoding', () => {
+	// Drop the trailing u32 and rewrite the vector length as 0.
+	const bytes = new Uint8Array([...validityBytes([2]).slice(0, -5), 0]);
+
+	expect(() => bcs.TransactionExpiration.parse(bytes)).toThrow(
+		/Allowed proposers must not be empty/,
+	);
 });
 
 it('serializes ForwardingAddressRegistryCreate with its upstream enum index', () => {

--- a/packages/sui/test/unit/transactions/bcs.test.ts
+++ b/packages/sui/test/unit/transactions/bcs.test.ts
@@ -5,6 +5,7 @@ import { toBase58 } from '@mysten/bcs';
 import { expect, it } from 'vitest';
 
 import { bcs } from '../../../src/bcs/index.js';
+import { EndOfEpochTransactionKind } from '../../../src/bcs/transactions.js';
 import { normalizeStructTag, normalizeSuiAddress } from '../../../src/utils/sui-types.js';
 
 // Oooh-weeee we nailed it!
@@ -59,6 +60,48 @@ function ref(): { objectId: string; version: string; digest: string } {
 		),
 	};
 }
+
+it.each([{ epoch: '42', proposers: [0, 2, 5] }, null])(
+	'round-trips a Validity expiration with allowed proposers %j',
+	(allowedProposers) => {
+		const expiration = {
+			Validity: {
+				minEpoch: '42',
+				maxEpoch: '43',
+				minTimestamp: '1700000000123',
+				maxTimestamp: '1700000999456',
+				chain: toBase58(new Uint8Array(32).fill(7)),
+				nonce: 0xc0ffee,
+				allowedProposers,
+			},
+		} satisfies typeof bcs.TransactionExpiration.$inferInput;
+
+		const bytes = bcs.TransactionExpiration.serialize(expiration).toBytes();
+		expect(bcs.TransactionExpiration.parse(bytes)).toEqual({ $kind: 'Validity', ...expiration });
+	},
+);
+
+it.each([[[]], [[2, 2]], [[2, 1]]])('rejects invalid allowed proposer indices %j', (proposers) => {
+	const expiration = {
+		Validity: {
+			minEpoch: null,
+			maxEpoch: null,
+			minTimestamp: null,
+			maxTimestamp: null,
+			chain: toBase58(new Uint8Array(32).fill(7)),
+			nonce: 0,
+			allowedProposers: { epoch: '42', proposers },
+		},
+	} satisfies typeof bcs.TransactionExpiration.$inferInput;
+
+	expect(() => bcs.TransactionExpiration.serialize(expiration)).toThrow(/Allowed proposers/);
+});
+
+it('serializes ForwardingAddressRegistryCreate with its upstream enum index', () => {
+	expect(
+		EndOfEpochTransactionKind.serialize({ ForwardingAddressRegistryCreate: true }).toBytes(),
+	).toEqual(new Uint8Array([13]));
+});
 
 it('can serialize transaction data with a programmable transaction', () => {
 	const sui = normalizeSuiAddress('0x2');

--- a/packages/sui/test/unit/transactions/v1-json.test.ts
+++ b/packages/sui/test/unit/transactions/v1-json.test.ts
@@ -7,6 +7,26 @@ import { describe, expect, it } from 'vitest';
 import { Inputs, Transaction } from '../../../src/transactions/index.js';
 
 describe('V1 JSON serialization', () => {
+	it('does not silently remove Validity expiration', async () => {
+		const tx = new Transaction();
+		tx.setExpiration({
+			Validity: {
+				minEpoch: '42',
+				maxEpoch: '43',
+				minTimestamp: null,
+				maxTimestamp: null,
+				chain: toBase58(new Uint8Array(32).fill(7)),
+				nonce: 0xc0ffee,
+				allowedProposers: { epoch: '42', proposers: [0, 2, 5] },
+			},
+		});
+
+		expect(() => tx.serialize()).toThrow(/cannot be represented/);
+
+		const restored = Transaction.from(await tx.toJSON());
+		expect(restored.getData().expiration).toEqual(tx.getData().expiration);
+	});
+
 	it('can serialize and deserialize transactions', async () => {
 		const tx = new Transaction();
 

--- a/packages/sui/test/unit/transactions/v1-json.test.ts
+++ b/packages/sui/test/unit/transactions/v1-json.test.ts
@@ -7,25 +7,54 @@ import { describe, expect, it } from 'vitest';
 import { Inputs, Transaction } from '../../../src/transactions/index.js';
 
 describe('V1 JSON serialization', () => {
-	it('preserves Validity in v2 JSON while maintaining the legacy v1 representation', async () => {
-		const tx = new Transaction();
-		tx.setExpiration({
-			Validity: {
-				minEpoch: '42',
-				maxEpoch: '43',
-				minTimestamp: null,
-				maxTimestamp: null,
-				chain: toBase58(new Uint8Array(32).fill(7)),
-				nonce: 0xc0ffee,
-				allowedProposers: { epoch: '42', proposers: [0, 2, 5] },
-			},
-		});
+	const validity = {
+		minEpoch: '42',
+		maxEpoch: '43',
+		minTimestamp: null,
+		maxTimestamp: null,
+		chain: toBase58(new Uint8Array(32).fill(7)),
+		nonce: 0xc0ffee,
+		allowedProposers: { epoch: '42', proposers: [0, 2, 5] },
+	};
 
-		expect(JSON.parse(tx.serialize()).expiration).toEqual({ None: true });
+	it('preserves Validity through both v1 and v2 JSON', async () => {
+		const tx = new Transaction();
+		tx.setExpiration({ Validity: validity });
+
+		// v1 used to collapse this to `{ None: true }`, silently dropping the expiration and the
+		// allowed proposers, so a `serialize()` -> `from()` round trip signed broader bytes.
+		expect(JSON.parse(tx.serialize()).expiration).toEqual({ Validity: validity });
+		expect(Transaction.from(tx.serialize()).getData().expiration).toEqual(tx.getData().expiration);
 
 		const restored = Transaction.from(await tx.toJSON());
 		expect(restored.getData().expiration).toEqual(tx.getData().expiration);
 	});
+
+	it('preserves ValidDuring through v1 JSON', () => {
+		const tx = new Transaction();
+		const { allowedProposers, ...validDuring } = validity;
+		tx.setExpiration({ ValidDuring: validDuring });
+
+		expect(JSON.parse(tx.serialize()).expiration).toEqual({ ValidDuring: validDuring });
+		expect(Transaction.from(tx.serialize()).getData().expiration).toEqual(tx.getData().expiration);
+	});
+
+	it('refuses to silently drop an expiration it does not understand', () => {
+		const json = JSON.parse(new Transaction().serialize());
+		json.expiration = { SomeFutureVariant: { maxEpoch: '43' } };
+
+		expect(() => Transaction.from(JSON.stringify(json))).toThrow(/Unknown transaction expiration/);
+	});
+
+	it.each([{ Epoch: 42 }, { None: true }, null])(
+		'round-trips the legacy v1 expiration %j unchanged',
+		(expiration) => {
+			const tx = new Transaction();
+			if (expiration) tx.setExpiration(expiration as never);
+
+			expect(JSON.parse(tx.serialize()).expiration).toEqual(expiration ?? null);
+		},
+	);
 
 	it('can serialize and deserialize transactions', async () => {
 		const tx = new Transaction();

--- a/packages/sui/test/unit/transactions/v1-json.test.ts
+++ b/packages/sui/test/unit/transactions/v1-json.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest';
 import { Inputs, Transaction } from '../../../src/transactions/index.js';
 
 describe('V1 JSON serialization', () => {
-	it('does not silently remove Validity expiration', async () => {
+	it('preserves Validity in v2 JSON while maintaining the legacy v1 representation', async () => {
 		const tx = new Transaction();
 		tx.setExpiration({
 			Validity: {
@@ -21,7 +21,7 @@ describe('V1 JSON serialization', () => {
 			},
 		});
 
-		expect(() => tx.serialize()).toThrow(/cannot be represented/);
+		expect(JSON.parse(tx.serialize()).expiration).toEqual({ None: true });
 
 		const restored = Transaction.from(await tx.toJSON());
 		expect(restored.getData().expiration).toEqual(tx.getData().expiration);

--- a/packages/sui/test/unit/transactions/v1-json.test.ts
+++ b/packages/sui/test/unit/transactions/v1-json.test.ts
@@ -21,8 +21,6 @@ describe('V1 JSON serialization', () => {
 		const tx = new Transaction();
 		tx.setExpiration({ Validity: validity });
 
-		// v1 used to collapse this to `{ None: true }`, silently dropping the expiration and the
-		// allowed proposers, so a `serialize()` -> `from()` round trip signed broader bytes.
 		expect(JSON.parse(tx.serialize()).expiration).toEqual({ Validity: validity });
 		expect(Transaction.from(tx.serialize()).getData().expiration).toEqual(tx.getData().expiration);
 


### PR DESCRIPTION
## Description

Adds TypeScript SDK support for the `Validity` transaction expiration introduced by
[MystenLabs/sui#27598](https://github.com/MystenLabs/sui/pull/27598) — everything in `ValidDuring`
plus an optional `allowed_proposers` set restricting which validators may propose the transaction
in consensus. Sui fullnodes populate allowed proposers on transactions resolved through
`simulateTransaction`, so without this variant the SDK fails to parse those responses.

Covers the `AllowedProposers`/`Validity` BCS schemas, the v2 transaction schema, the generated gRPC
types, and conversion in both directions. GraphQL and JSON-RPC route through the shared BCS and
protobuf paths, so they need no query changes.

Upstream references: [MystenLabs/sui#27598](https://github.com/MystenLabs/sui/pull/27598),
[MystenLabs/sui-apis#31](https://github.com/MystenLabs/sui-apis/pull/31),
[MystenLabs/sui-rust-sdk#293](https://github.com/MystenLabs/sui-rust-sdk/pull/293).

This supersedes #1236, which implemented the same feature independently; its changes are included
here.

### Fixes to pre-existing behaviour

Two bugs surfaced while reviewing the above. Both predate this PR but are made worse by it, so
they are fixed here rather than left to bite the new variant.

**v1 JSON silently dropped windowed expirations.** `serializeV1TransactionData` collapsed every
non-`Epoch` expiration to `{ None: true }`, and `transactionDataFromV1` collapsed it again on the
way back. A `Transaction.serialize()` → `Transaction.from()` round trip — still common across
wallet and application boundaries — therefore discarded the expiration before signing, and the
rebuilt transaction signed materially broader bytes than the caller built. For `Validity` that also
drops `allowedProposers`, so the transaction becomes proposable by any validator rather than the
named set: an authorization constraint, not just an expiry.

v1's expiration union now carries `ValidDuring` and `Validity`. Note this does **not** help
already-published SDK versions — `TransactionDataBuilder.restore` hands v1 payloads to
`transactionDataFromV1` without validating them against `SerializedTransactionDataV1` first, so
their reader has the same catch-all and will still collapse these to `{ None: true }`. That is
unavoidable; what is fixed is the behaviour going forward. An unrecognised expiration now throws on
read, and an unhandled variant fails to compile on write, so the next variant added cannot
reintroduce the same silent downgrade.

**`ValidDuring` timestamps were dropped in gRPC conversion.** `minTimestamp`/`maxTimestamp` were
hardcoded to `null` in both directions. They now convert losslessly, using the same arithmetic as
upstream `ms_to_timestamp`/`timestamp_to_ms`.

### Other changes

- Allowed proposer indices are validated when encoding, but only checked non-empty when decoding.
  Upstream rejects an empty set while deserializing (the field is `NonEmpty`) but only requires
  strictly-increasing indices in `validity_check`, on submission — and `is_allowed_proposer`
  documents reading an unsorted set as a deterministic miss. Validating sortedness on decode would
  have made the GraphQL and JSON-RPC read paths reject transactions the network accepted, while
  gRPC accepted them. All three transports now agree on what is readable.
- Synchronizes `InvalidTxContext` and `ForwardingAddressRegistryCreate` with upstream BCS and
  protobuf definitions.
- Documents the upstream `InsufficientFundsForWithdraw` rename while preserving the existing SDK
  name — changing the parsed BCS `$kind` would be a breaking API change. The wire representation is
  unchanged.
- `@mysten-incubation/sponsor`: `expirationMaxEpoch` handles the new variant, which is required for
  the narrowing to compile.

## Test plan

- `pnpm turbo build --filter=@mysten/sui`
- `pnpm --filter @mysten/sui test` — typecheck + 522 unit tests
- `pnpm --filter @mysten-incubation/sponsor test` — 63 unit tests
- `pnpm lint`

Added coverage for BCS and gRPC round trips with and without proposer restrictions, millisecond
timestamps, invalid proposer sets when encoding, unsorted and empty sets when decoding, v1 and v2
JSON round trips for both `ValidDuring` and `Validity`, unchanged legacy v1 expirations,
unrecognised v1 expirations, `InvalidTxContext` effects, and the new end-of-epoch variant.

The two round-trip regression tests were confirmed non-vacuous by reverting the source fix and
observing them fail. The write-path exhaustiveness guard was confirmed by adding a fifth expiration
variant and observing `v1.ts` fail to typecheck.

The generated gRPC types were verified reproducible: regenerating from `sui-apis` at `201981c` with
protobuf-ts 2.9.6 produces no diff.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
