### PR TITLE
fix(slush-wallet): default personal message signing to mainnet

### DIFF
--- a/.changeset/tidy-slushes-sign.md
+++ b/.changeset/tidy-slushes-sign.md
@@ -1,0 +1,5 @@
+---
+'@mysten/slush-wallet': patch
+---
+
+Default personal message signing requests without a chain to Sui mainnet.

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -22,7 +22,12 @@ import type {
 	Wallet,
 	WalletIcon,
 } from '@mysten/wallet-standard';
-import { getWallets, ReadonlyWalletAccount, SUI_CHAINS } from '@mysten/wallet-standard';
+import {
+	getWallets,
+	ReadonlyWalletAccount,
+	SUI_CHAINS,
+	SUI_MAINNET_CHAIN,
+} from '@mysten/wallet-standard';
 import { mitt, type Emitter } from '@mysten/utils';
 import type { InferOutput } from 'valibot';
 import { boolean, object, parse, string } from 'valibot';
@@ -258,7 +263,7 @@ export class SlushWallet implements Wallet {
 			type: 'sign-personal-message',
 			message: toBase64(message),
 			address: account.address,
-			chain: chain ?? account.chains[0],
+			chain: chain ?? SUI_MAINNET_CHAIN,
 			session: getSessionFromStorage(),
 		});
 


### PR DESCRIPTION
## Description

- Default chainless Slush personal-message signing requests to Sui mainnet instead of the first advertised account chain, which is devnet.
- Preserve explicitly requested chains.
- Add a patch changeset.

This fixes the invalid zkLogin envelope reported in MystenLabs/sui#27853. The wallet-standard personal-message chain is optional, but the Slush adapter previously substituted account.chains[0]. Since SUI_CHAINS starts with sui:devnet, Slush created a devnet-bound zkLogin signature (observed maxEpoch 8) for a message that downstream consumers verified on mainnet.

Fixes MystenLabs/sui#27853

## Test plan

- [x] pnpm turbo build --filter=@mysten/slush-wallet
- [x] pnpm --filter @mysten/slush-wallet lint

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
