### PR TITLE
fix(zksend): source coins from address balances

### DIFF
--- a/.changeset/tidy-zebras-share.md
+++ b/.changeset/tidy-zebras-share.md
@@ -1,0 +1,5 @@
+---
+'@mysten/zksend': patch
+---
+
+Source claimable balances from address balances as well as coin objects.

--- a/packages/zksend/src/links/builder.ts
+++ b/packages/zksend/src/links/builder.ts
@@ -10,7 +10,7 @@ import { normalizeStructTag, normalizeSuiAddress, SUI_TYPE_ARG, toBase64 } from 
 
 import type { ZkBagContractOptions } from './zk-bag.js';
 import { getContractIds, ZkBag } from './zk-bag.js';
-import type { ClientWithCoreApi, SuiClientTypes } from '@mysten/sui/client';
+import type { ClientWithCoreApi } from '@mysten/sui/client';
 
 export interface ZkSendLinkBuilderOptions {
 	host?: string;
@@ -47,7 +47,6 @@ export class ZkSendLinkBuilder {
 	#path: string;
 	keypair: Keypair;
 	#client: ClientWithCoreApi;
-	#coinsByType = new Map<string, SuiClientTypes.Coin[]>();
 	#contract: ZkBag<ZkBagContractOptions>;
 
 	constructor({
@@ -178,42 +177,13 @@ export class ZkSendLinkBuilder {
 		);
 
 		for (const [coinType, amount] of this.balances) {
-			if (coinType === SUI_COIN_TYPE) {
-				const [sui] = tx.splitCoins(tx.gas, [amount]);
-				refsWithType.push({
-					ref: sui,
-					type: `0x2::coin::Coin<${coinType}>`,
-				} as never);
-			} else {
-				const coins = (await this.#getCoinsByType(coinType)).map((coin) => coin.objectId);
-
-				if (coins.length > 1) {
-					tx.mergeCoins(coins[0], coins.slice(1));
-				}
-				const [split] = tx.splitCoins(coins[0], [amount]);
-				refsWithType.push({
-					ref: split,
-					type: `0x2::coin::Coin<${coinType}>`,
-				});
-			}
+			refsWithType.push({
+				ref: tx.coin({ type: coinType, balance: amount }),
+				type: `0x2::coin::Coin<${coinType}>`,
+			});
 		}
 
 		return refsWithType;
-	}
-
-	async #getCoinsByType(coinType: string) {
-		if (this.#coinsByType.has(coinType)) {
-			return this.#coinsByType.get(coinType)!;
-		}
-
-		const coins = await this.#client.core.listCoins({
-			coinType,
-			owner: this.sender,
-		});
-
-		this.#coinsByType.set(coinType, coins.objects);
-
-		return coins.objects;
 	}
 
 	static async createLinks({
@@ -233,24 +203,9 @@ export class ZkSendLinkBuilder {
 		const contract = new ZkBag(resolvedContractIds.packageId, resolvedContractIds);
 		const store = transaction.object(contract.ids.bagStoreId);
 
-		const coinsByType = new Map<string, SuiClientTypes.Coin[]>();
 		const allIds = links.flatMap((link) => [...link.objectIds]);
 		const sender = links[0].sender;
 		transaction.setSenderIfNotSet(sender);
-
-		await Promise.all(
-			[...new Set(links.flatMap((link) => [...link.balances.keys()]))].map(async (coinType) => {
-				const coins = await client.core.listCoins({
-					coinType,
-					owner: sender,
-				});
-
-				coinsByType.set(
-					coinType,
-					coins.objects.filter((coin) => !allIds.includes(coin.objectId)),
-				);
-			}),
-		);
 
 		const objectRefs = new Map<
 			string,
@@ -286,28 +241,6 @@ export class ZkSendLinkBuilder {
 			}
 		}
 
-		const mergedCoins = new Map<string, TransactionObjectArgument>([
-			[SUI_COIN_TYPE, transaction.gas],
-		]);
-
-		for (const [coinType, coins] of coinsByType) {
-			if (coinType === SUI_COIN_TYPE) {
-				continue;
-			}
-
-			const [first, ...rest] = coins.map((coin) =>
-				transaction.objectRef({
-					objectId: coin.objectId,
-					version: coin.version,
-					digest: coin.digest,
-				}),
-			);
-			if (rest.length > 0) {
-				transaction.mergeCoins(first, rest);
-			}
-			mergedCoins.set(coinType, transaction.object(first));
-		}
-
 		for (const link of links) {
 			const receiver = link.keypair.toSuiAddress();
 			transaction.add(contract.new({ arguments: [store, receiver] }));
@@ -333,20 +266,11 @@ export class ZkSendLinkBuilder {
 					}),
 				);
 			});
-		}
 
-		for (const [coinType, merged] of mergedCoins) {
-			const linksWithCoin = links.filter((link) => link.balances.has(coinType));
-			if (linksWithCoin.length === 0) {
-				continue;
-			}
-
-			const balances = linksWithCoin.map((link) => link.balances.get(coinType)!);
-			const splits = transaction.splitCoins(merged, balances);
-			for (const [i, link] of linksWithCoin.entries()) {
+			for (const [coinType, balance] of link.balances) {
 				transaction.add(
 					contract.add({
-						arguments: [store, link.keypair.toSuiAddress(), splits[i]],
+						arguments: [store, receiver, transaction.coin({ type: coinType, balance })],
 						typeArguments: [`0x2::coin::Coin<${coinType}>`],
 					}),
 				);

--- a/packages/zksend/test/builder.test.ts
+++ b/packages/zksend/test/builder.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ClientWithCoreApi } from '@mysten/sui/client';
+import { normalizeStructTag } from '@mysten/sui/utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ZkSendLinkBuilder } from '../src/links/builder.js';
+
+const SENDER = `0x${'1'.repeat(64)}`;
+const COIN_TYPE = normalizeStructTag('0x2::usdsui::USDSUI');
+
+describe('ZkSendLinkBuilder', () => {
+	function setup() {
+		const listCoins = vi.fn().mockResolvedValue({
+			objects: [],
+			hasNextPage: false,
+			cursor: null,
+		});
+		const client = {
+			network: 'testnet',
+			core: { listCoins },
+		} as unknown as ClientWithCoreApi;
+		const link = new ZkSendLinkBuilder({ client, sender: SENDER });
+
+		link.addClaimableBalance(COIN_TYPE, 100n);
+		return { link, listCoins };
+	}
+
+	function expectCoinIntent(
+		transaction: Awaited<ReturnType<ZkSendLinkBuilder['createSendTransaction']>>,
+	) {
+		const coinIntents = transaction
+			.getData()
+			.commands.filter((command) => command.$Intent?.name === 'CoinWithBalance');
+
+		expect(coinIntents).toHaveLength(1);
+		expect(coinIntents[0].$Intent?.data).toMatchObject({
+			type: COIN_TYPE,
+			balance: 100n,
+			outputKind: 'coin',
+		});
+	}
+
+	it('sources link balances through a CoinWithBalance intent', async () => {
+		const { link, listCoins } = setup();
+
+		const transaction = await link.createSendTransaction();
+
+		expect(listCoins).not.toHaveBeenCalled();
+		expectCoinIntent(transaction);
+	});
+
+	it('sources address-transfer balances through a CoinWithBalance intent', async () => {
+		const { link, listCoins } = setup();
+
+		const transaction = await link.createSendToAddressTransaction({ address: SENDER });
+
+		expect(listCoins).not.toHaveBeenCalled();
+		expectCoinIntent(transaction);
+	});
+});


### PR DESCRIPTION
## Description

Use `Transaction.coin()` when building zkSend balance transfers. This delegates coin sourcing to the `CoinWithBalance` resolver, which supports address balances, coin objects, and mixed balances.

This applies to both claimable links and direct address-transfer transactions. It also removes the eager coin-object enumeration that failed when a balance existed only in the address balance store.

## Test plan

- `pnpm --filter @mysten/zksend exec vitest run test/builder.test.ts`
- `pnpm --filter @mysten/zksend test:typecheck`
- `pnpm --filter @mysten/zksend lint`
- `pnpm --filter @mysten/zksend build`

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.