### PR TITLE
Support the Validity transaction expiration with allowed proposers

### DIFF
--- a/.changeset/shiny-months-repeat.md
+++ b/.changeset/shiny-months-repeat.md
@@ -1,0 +1,6 @@
+---
+'@mysten/sui': minor
+'@mysten-incubation/sponsor': patch
+---
+
+Add support for the `Validity` transaction expiration, which carries everything in `ValidDuring` plus an optional `allowed_proposers` set restricting which validators may propose the transaction in consensus. The BCS schema, transaction data model, and gRPC conversions understand the new variant, so transactions resolved or simulated by a server that populates allowed proposers round-trip correctly.

--- a/packages/sponsor/src/validators.ts
+++ b/packages/sponsor/src/validators.ts
@@ -421,7 +421,10 @@ export function simulationSucceeds(): Validator {
 function expirationMaxEpoch(expiration: TransactionData['expiration']): bigint | null {
 	if (!expiration || expiration.$kind === 'None') return null;
 	if (expiration.$kind === 'Epoch') return BigInt(expiration.Epoch);
-	const max = expiration.ValidDuring.maxEpoch;
+	const max =
+		expiration.$kind === 'Validity'
+			? expiration.Validity.maxEpoch
+			: expiration.ValidDuring.maxEpoch;
 	return max == null ? null : BigInt(max);
 }
 

--- a/packages/sui/src/bcs/bcs.ts
+++ b/packages/sui/src/bcs/bcs.ts
@@ -238,10 +238,28 @@ export const ValidDuring = bcs.struct('ValidDuring', {
 	nonce: bcs.u32(),
 });
 
+// Rust: crates/sui-types/src/transaction.rs
+export const AllowedProposers = bcs.struct('AllowedProposers', {
+	epoch: bcs.u64(),
+	proposers: bcs.vector(bcs.u32()),
+});
+
+// Rust: crates/sui-types/src/transaction.rs
+export const Validity = bcs.struct('Validity', {
+	minEpoch: bcs.option(bcs.u64()),
+	maxEpoch: bcs.option(bcs.u64()),
+	minTimestamp: bcs.option(bcs.u64()),
+	maxTimestamp: bcs.option(bcs.u64()),
+	chain: ObjectDigest,
+	nonce: bcs.u32(),
+	allowedProposers: bcs.option(AllowedProposers),
+});
+
 export const TransactionExpiration = bcs.enum('TransactionExpiration', {
 	None: null,
 	Epoch: unsafe_u64(),
 	ValidDuring: ValidDuring,
+	Validity: Validity,
 });
 
 export const StructTag = bcs.struct('StructTag', {

--- a/packages/sui/src/bcs/types.ts
+++ b/packages/sui/src/bcs/types.ts
@@ -126,10 +126,19 @@ type ValidDuring = {
 	nonce: number;
 };
 
+type AllowedProposers = {
+	epoch: number | string;
+	proposers: number[];
+};
+
+type Validity = ValidDuring & {
+	allowedProposers: { None: null } | { Some: AllowedProposers };
+};
+
 /**
  * TransactionExpiration
  *
  * Indications the expiration time for a transaction.
  */
 export type TransactionExpiration =
-	{ None: null } | { Epoch: number } | { ValidDuring: ValidDuring };
+	{ None: null } | { Epoch: number } | { ValidDuring: ValidDuring } | { Validity: Validity };

--- a/packages/sui/src/client/transaction-resolver.ts
+++ b/packages/sui/src/client/transaction-resolver.ts
@@ -272,6 +272,21 @@ export function transactionDataToGrpcTransaction(data: TransactionData): GrpcTra
 				chain: validDuring.chain,
 				nonce: validDuring.nonce,
 			};
+		} else if (data.expiration.$kind === 'Validity') {
+			const validity = data.expiration.Validity;
+			transaction.expiration = {
+				kind: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+				minEpoch: validity.minEpoch != null ? BigInt(validity.minEpoch) : undefined,
+				epoch: validity.maxEpoch != null ? BigInt(validity.maxEpoch) : undefined,
+				chain: validity.chain,
+				nonce: validity.nonce,
+				allowedProposers: validity.allowedProposers
+					? {
+							epoch: BigInt(validity.allowedProposers.epoch),
+							proposers: validity.allowedProposers.proposers,
+						}
+					: undefined,
+			};
 		}
 	}
 
@@ -533,6 +548,25 @@ export function grpcTransactionToTransactionData(grpcTx: GrpcTransaction): Trans
 						maxTimestamp: null,
 						chain: grpcTx.expiration.chain ?? '',
 						nonce: grpcTx.expiration.nonce ?? 0,
+					},
+				};
+				break;
+			case TransactionExpiration_TransactionExpirationKind.VALIDITY:
+				expiration = {
+					$kind: 'Validity',
+					Validity: {
+						minEpoch: grpcTx.expiration.minEpoch?.toString() ?? null,
+						maxEpoch: grpcTx.expiration.epoch?.toString() ?? null,
+						minTimestamp: null,
+						maxTimestamp: null,
+						chain: grpcTx.expiration.chain ?? '',
+						nonce: grpcTx.expiration.nonce ?? 0,
+						allowedProposers: grpcTx.expiration.allowedProposers
+							? {
+									epoch: grpcTx.expiration.allowedProposers.epoch?.toString() ?? '0',
+									proposers: grpcTx.expiration.allowedProposers.proposers ?? [],
+								}
+							: null,
 					},
 				};
 				break;

--- a/packages/sui/src/grpc/proto/sui/rpc/v2/execution_status.ts
+++ b/packages/sui/src/grpc/proto/sui/rpc/v2/execution_status.ts
@@ -727,6 +727,14 @@ export enum CommandArgumentError_CommandArgumentErrorKind {
 	 * @generated from protobuf enum value: INVALID_REFERENCE_ARGUMENT = 19;
 	 */
 	INVALID_REFERENCE_ARGUMENT = 19,
+	/**
+	 * Invalid usage of TxContext in the function signature. TxContext can only be used by
+	 * reference, `&TxContext` or `&mut TxContext`. If used mutably, it must be the only
+	 * TxContext parameter, and TxContext can never be returned from a Move call.
+	 *
+	 * @generated from protobuf enum value: INVALID_TX_CONTEXT = 20;
+	 */
+	INVALID_TX_CONTEXT = 20,
 }
 /**
  * An error with upgrading a package.

--- a/packages/sui/src/grpc/proto/sui/rpc/v2/transaction.ts
+++ b/packages/sui/src/grpc/proto/sui/rpc/v2/transaction.ts
@@ -145,6 +145,13 @@ export interface TransactionExpiration {
 	 * @generated from protobuf field: optional uint32 nonce = 7;
 	 */
 	nonce?: number;
+	/**
+	 * The validators allowed to propose this transaction in consensus. Only set when `kind`
+	 * is `VALIDITY`. Leave unset to let any validator propose the transaction.
+	 *
+	 * @generated from protobuf field: optional sui.rpc.v2.AllowedProposers allowed_proposers = 8;
+	 */
+	allowedProposers?: AllowedProposers;
 }
 /**
  * @generated from protobuf enum sui.rpc.v2.TransactionExpiration.TransactionExpirationKind
@@ -181,6 +188,40 @@ export enum TransactionExpiration_TransactionExpirationKind {
 	 * @generated from protobuf enum value: VALID_DURING = 3;
 	 */
 	VALID_DURING = 3,
+	/**
+	 * Everything in VALID_DURING, plus a restriction on which validators may
+	 * propose the transaction in consensus.
+	 *
+	 * @generated from protobuf enum value: VALIDITY = 4;
+	 */
+	VALIDITY = 4,
+}
+/**
+ * The validators allowed to propose a transaction in consensus.
+ *
+ * Proposal by any other validator is byzantine behavior and invalidates the whole block.
+ *
+ * @generated from protobuf message sui.rpc.v2.AllowedProposers
+ */
+export interface AllowedProposers {
+	/**
+	 * The epoch whose committee `proposers` indexes into.
+	 *
+	 * Committee indices are only meaningful against one committee, so a set recorded for any
+	 * other epoch is ignored and the transaction is treated as naming no proposers.
+	 *
+	 * @generated from protobuf field: optional uint64 epoch = 1;
+	 */
+	epoch?: bigint;
+	/**
+	 * Committee indices of the allowed proposers, strictly increasing and non-empty.
+	 *
+	 * An empty list names no validator and is rejected; omit `allowed_proposers` entirely to
+	 * let any validator propose the transaction.
+	 *
+	 * @generated from protobuf field: repeated uint32 proposers = 2;
+	 */
+	proposers: number[];
 }
 /**
  * Transaction type.
@@ -1314,6 +1355,7 @@ class TransactionExpiration$Type extends MessageType<TransactionExpiration> {
 			{ no: 5, name: 'max_timestamp', kind: 'message', T: () => Timestamp },
 			{ no: 6, name: 'chain', kind: 'scalar', opt: true, T: 9 /*ScalarType.STRING*/ },
 			{ no: 7, name: 'nonce', kind: 'scalar', opt: true, T: 13 /*ScalarType.UINT32*/ },
+			{ no: 8, name: 'allowed_proposers', kind: 'message', T: () => AllowedProposers },
 		]);
 	}
 }
@@ -1321,6 +1363,32 @@ class TransactionExpiration$Type extends MessageType<TransactionExpiration> {
  * @generated MessageType for protobuf message sui.rpc.v2.TransactionExpiration
  */
 export const TransactionExpiration = new TransactionExpiration$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class AllowedProposers$Type extends MessageType<AllowedProposers> {
+	constructor() {
+		super('sui.rpc.v2.AllowedProposers', [
+			{
+				no: 1,
+				name: 'epoch',
+				kind: 'scalar',
+				opt: true,
+				T: 4 /*ScalarType.UINT64*/,
+				L: 0 /*LongType.BIGINT*/,
+			},
+			{
+				no: 2,
+				name: 'proposers',
+				kind: 'scalar',
+				repeat: 1 /*RepeatType.PACKED*/,
+				T: 13 /*ScalarType.UINT32*/,
+			},
+		]);
+	}
+}
+/**
+ * @generated MessageType for protobuf message sui.rpc.v2.AllowedProposers
+ */
+export const AllowedProposers = new AllowedProposers$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class TransactionKind$Type extends MessageType<TransactionKind> {
 	constructor() {

--- a/packages/sui/src/transactions/data/internal.ts
+++ b/packages/sui/src/transactions/data/internal.ts
@@ -343,10 +343,30 @@ export const ValidDuringSchema = object({
 });
 export type ValidDuring = InferOutput<typeof ValidDuringSchema>;
 
+// Rust: crates/sui-types/src/transaction.rs
+export const AllowedProposersSchema = object({
+	epoch: JsonU64,
+	proposers: array(U32),
+});
+export type AllowedProposers = InferOutput<typeof AllowedProposersSchema>;
+
+// Rust: crates/sui-types/src/transaction.rs
+export const ValiditySchema = object({
+	minEpoch: nullable(JsonU64),
+	maxEpoch: nullable(JsonU64),
+	minTimestamp: nullable(JsonU64),
+	maxTimestamp: nullable(JsonU64),
+	chain: string(),
+	nonce: U32,
+	allowedProposers: nullable(AllowedProposersSchema),
+});
+export type Validity = InferOutput<typeof ValiditySchema>;
+
 export const TransactionExpiration = safeEnum({
 	None: literal(true),
 	Epoch: JsonU64,
 	ValidDuring: ValidDuringSchema,
+	Validity: ValiditySchema,
 });
 
 export type TransactionExpiration = InferOutput<typeof TransactionExpiration>;

--- a/packages/sui/src/transactions/data/v2.ts
+++ b/packages/sui/src/transactions/data/v2.ts
@@ -29,6 +29,7 @@ import {
 	ObjectRefSchema,
 	SuiAddress,
 	ValidDuringSchema,
+	ValiditySchema,
 } from './internal.js';
 import type { Simplify } from '@mysten/utils';
 
@@ -143,6 +144,7 @@ const TransactionExpiration = enumUnion({
 	None: literal(true),
 	Epoch: JsonU64,
 	ValidDuring: ValidDuringSchema,
+	Validity: ValiditySchema,
 });
 
 export const SerializedTransactionDataV2Schema = object({

--- a/packages/sui/test/unit/transactions/validity-expiration.test.ts
+++ b/packages/sui/test/unit/transactions/validity-expiration.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { toBase58 } from '@mysten/bcs';
+import { describe, expect, it } from 'vitest';
+
+import { bcs } from '../../../src/bcs/index.js';
+import {
+	grpcTransactionToTransactionData,
+	transactionDataToGrpcTransaction,
+} from '../../../src/client/transaction-resolver.js';
+import type { Transaction as GrpcTransaction } from '../../../src/grpc/proto/sui/rpc/v2/transaction.js';
+import { TransactionExpiration_TransactionExpirationKind } from '../../../src/grpc/proto/sui/rpc/v2/transaction.js';
+import { Transaction } from '../../../src/transactions/Transaction.js';
+
+const CHAIN = toBase58(new Uint8Array(32).fill(7));
+
+const VALIDITY = {
+	minEpoch: '11',
+	maxEpoch: '12',
+	minTimestamp: null,
+	maxTimestamp: null,
+	chain: CHAIN,
+	nonce: 42,
+	allowedProposers: {
+		epoch: '11',
+		proposers: [0, 2, 5],
+	},
+};
+
+describe('Validity transaction expiration', () => {
+	it('round-trips through bcs', () => {
+		const bytes = bcs.TransactionExpiration.serialize({ Validity: VALIDITY }).toBytes();
+		const parsed = bcs.TransactionExpiration.parse(bytes);
+
+		expect(parsed).toEqual({ $kind: 'Validity', Validity: VALIDITY });
+	});
+
+	it('round-trips through bcs without a proposer set', () => {
+		const validity = { ...VALIDITY, allowedProposers: null };
+		const bytes = bcs.TransactionExpiration.serialize({ Validity: validity }).toBytes();
+		const parsed = bcs.TransactionExpiration.parse(bytes);
+
+		expect(parsed).toEqual({ $kind: 'Validity', Validity: validity });
+	});
+
+	it('converts to a grpc transaction', () => {
+		const tx = new Transaction();
+		tx.setExpiration({ Validity: VALIDITY });
+
+		const grpcTx = transactionDataToGrpcTransaction(tx.getData());
+
+		expect(grpcTx.expiration).toEqual({
+			kind: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+			minEpoch: 11n,
+			epoch: 12n,
+			chain: CHAIN,
+			nonce: 42,
+			allowedProposers: {
+				epoch: 11n,
+				proposers: [0, 2, 5],
+			},
+		});
+	});
+
+	it('parses from a grpc transaction', () => {
+		const grpcTx = {
+			kind: {
+				data: {
+					oneofKind: 'programmableTransaction',
+					programmableTransaction: { inputs: [], commands: [] },
+				},
+			},
+			expiration: {
+				kind: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+				minEpoch: 11n,
+				epoch: 12n,
+				chain: CHAIN,
+				nonce: 42,
+				allowedProposers: {
+					epoch: 11n,
+					proposers: [0, 2, 5],
+				},
+			},
+		} as unknown as GrpcTransaction;
+
+		const data = grpcTransactionToTransactionData(grpcTx);
+
+		expect(data.expiration).toEqual({ $kind: 'Validity', Validity: VALIDITY });
+	});
+
+	it('parses a grpc transaction without a proposer set', () => {
+		const grpcTx = {
+			kind: {
+				data: {
+					oneofKind: 'programmableTransaction',
+					programmableTransaction: { inputs: [], commands: [] },
+				},
+			},
+			expiration: {
+				kind: TransactionExpiration_TransactionExpirationKind.VALIDITY,
+				minEpoch: 11n,
+				epoch: 12n,
+				chain: CHAIN,
+				nonce: 42,
+			},
+		} as unknown as GrpcTransaction;
+
+		const data = grpcTransactionToTransactionData(grpcTx);
+
+		expect(data.expiration).toEqual({
+			$kind: 'Validity',
+			Validity: { ...VALIDITY, allowedProposers: null },
+		});
+	});
+});


### PR DESCRIPTION
## Description

Adds support for the new `Validity` transaction expiration variant ([sui-apis#31](https://github.com/MystenLabs/sui-apis/pull/31), [sui#27454](https://github.com/MystenLabs/sui/pull/27454)): everything in `ValidDuring` plus an optional `allowed_proposers` set restricting which validators may propose the transaction in consensus.

Sui fullnodes now populate allowed proposers on transactions resolved through `simulateTransaction`, so without this variant the SDK fails to parse those transactions when rebuilding them from the gRPC response.

- `bcs`: `Validity` and `AllowedProposers` schemas, wired into `TransactionExpiration`.
- Transaction data model (internal + serialized v2 schemas): the new variant; `setExpiration` accepts it.
- gRPC conversions (`transaction-resolver`): both directions, including the proposer set.
- Regenerated gRPC protos from latest sui-apis (first commit; also picks up the `InvalidTxContext` command argument error added upstream).
- `@mysten-incubation/sponsor`: `expirationMaxEpoch` handles the new variant (previously it would have thrown on it).

The v1 JSON transaction format continues to collapse windowed expirations to `None`, matching its existing `ValidDuring` behavior.

## Test plan

- New unit tests: BCS round-trip of `Validity` (with and without a proposer set) and gRPC conversion in both directions.
- `pnpm --filter @mysten/sui test` (typecheck + 508 unit tests) and sponsor package tests pass.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.