### PR TITLE
fix(sui): decode grpc-web status messages and code aborted calls from their reason

### DIFF
--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -7,13 +7,14 @@ same name from `@protobuf-ts/grpcweb-transport`, fixing three defects in it. Sta
 decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A timeout is coded
 `DEADLINE_EXCEEDED` and a custom abort reason `CANCELLED`, where upstream reports both as `INTERNAL`
 and only recognises a standard `AbortError`; an abort reason that already carries a gRPC status
-keeps it. `timeout` is enforced
-as a deadline instead of only being sent as the `grpc-timeout` header, so a stalled connection fails
-instead of hanging.
+keeps it. `timeout` is enforced as a deadline instead of only being sent as the `grpc-timeout`
+header, so a stalled connection fails instead of hanging, and that header goes out in a unit the
+server accepts rather than in milliseconds that overflow its eight-digit limit.
 
 `@mysten/sui/grpc` also exports the `RpcError` class and the `GrpcStatusCode` enum, so the errors
 gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.
 
 `SuiGrpcClient` builds one of these by default and now forwards the rest of `GrpcWebOptions`
-(`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to it, which
-were previously accepted and ignored. A transport passed in by the caller is used as given.
+(`fetch`, `format`, `meta`, `timeout`, `abort`, `interceptors`, `jsonOptions`, `binaryOptions`) to
+it, which were previously accepted and ignored. A transport passed in by the caller is used as
+given.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -2,14 +2,14 @@
 '@mysten/sui': minor
 ---
 
-Add `SuiGrpcWebTransport`, a `GrpcWebFetchTransport` with the two error defects of
-`@protobuf-ts/grpcweb-transport` 2.11.1 repaired, and build one by default in `SuiGrpcClient`.
-Percent-encoded `grpc-message` status text is decoded at the wire boundary, so `client.core`, the
-generated service clients and any interceptors all see readable messages instead of
-`Object%20not%20found%3A%200x1`; and a call cut short by its own signal is coded `DEADLINE_EXCEEDED`
-for an `AbortSignal.timeout` or `CANCELLED` for any other abort reason, rather than `INTERNAL`.
-Construct it directly (and pass it as `transport`) when you need transport options the client does
-not take. A transport supplied by the caller is used exactly as given.
+`GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the
+`@protobuf-ts/grpcweb-transport` class of the same name, with the two error defects that transport
+has as of 2.11.1 repaired, and `SuiGrpcClient` builds one by default. Percent-encoded `grpc-message`
+status text is decoded at the wire boundary, so `client.core`, the generated service clients and any
+interceptors all see readable messages instead of `Object%20not%20found%3A%200x1`; and a call cut
+short by its own signal is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or `CANCELLED` for
+any other abort reason, rather than `INTERNAL`. A transport supplied by the caller is used exactly
+as given, so build custom grpc-web transports from this class.
 
 `SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
 `interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -1,14 +1,16 @@
 ---
-'@mysten/sui': patch
+'@mysten/sui': minor
 ---
 
-Normalize gRPC transport errors in `SuiGrpcClient`: percent-encoded `grpc-message` status text is
-now decoded once at the wire boundary, so `client.core`, the generated service clients and any
-caller-supplied interceptors all see readable messages instead of `Object%20not%20found%3A%200x1`.
-Decoding applies to grpc-web transports, which pass the header through in its wire form; a
-transport that decodes for itself is left alone. A call that ends because its own signal aborted is
-now coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` and `CANCELLED` for any other abort
-reason, rather than `INTERNAL`. `SuiGrpcClient` also forwards the remaining `GrpcWebOptions`
-(`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to the
-transport it builds; previously only `baseUrl` and `fetchInit` were passed through and the rest were
-silently ignored.
+Add `SuiGrpcWebTransport`, a `GrpcWebFetchTransport` with the two error defects of
+`@protobuf-ts/grpcweb-transport` 2.11.1 repaired, and build one by default in `SuiGrpcClient`.
+Percent-encoded `grpc-message` status text is decoded at the wire boundary, so `client.core`, the
+generated service clients and any interceptors all see readable messages instead of
+`Object%20not%20found%3A%200x1`; and a call cut short by its own signal is coded `DEADLINE_EXCEEDED`
+for an `AbortSignal.timeout` or `CANCELLED` for any other abort reason, rather than `INTERNAL`.
+Construct it directly (and pass it as `transport`) when you need transport options the client does
+not take. A transport supplied by the caller is used exactly as given.
+
+`SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
+`interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only
+`baseUrl` and `fetchInit` were passed through and the rest were silently ignored.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -3,13 +3,11 @@
 ---
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
-same name from `@protobuf-ts/grpcweb-transport`, fixing three defects in it. Status messages are
-decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A timeout is coded
-`DEADLINE_EXCEEDED` and a custom abort reason `CANCELLED`, where upstream reports both as `INTERNAL`
-and only recognises a standard `AbortError`; an abort reason that already carries a gRPC status
-keeps it. `timeout` is enforced as a deadline instead of only being sent as the `grpc-timeout`
-header, so a stalled connection fails instead of hanging, and that header goes out in a unit the
-server accepts rather than in milliseconds that overflow its eight-digit limit.
+same name from `@protobuf-ts/grpcweb-transport`, fixing two defects in it. Status messages are
+decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by an
+abort takes its status from the reason: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the status
+an `RpcError` reason carries, and `CANCELLED` for anything else, where upstream reports all but a
+standard `AbortError` as `INTERNAL`.
 
 `@mysten/sui/grpc` also exports the `RpcError` class and the `GrpcStatusCode` enum, so the errors
 gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -4,9 +4,10 @@
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
 same name from `@protobuf-ts/grpcweb-transport`, fixing three defects in it. Status messages are
-decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by its
-own signal is coded `DEADLINE_EXCEEDED` for a deadline and `CANCELLED` for other aborts, instead of
-`INTERNAL`; an abort reason that already carries a gRPC status keeps it. `timeout` is enforced
+decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A timeout is coded
+`DEADLINE_EXCEEDED` and a custom abort reason `CANCELLED`, where upstream reports both as `INTERNAL`
+and only recognises a standard `AbortError`; an abort reason that already carries a gRPC status
+keeps it. `timeout` is enforced
 as a deadline instead of only being sent as the `grpc-timeout` header, so a stalled connection fails
 instead of hanging.
 

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -4,11 +4,10 @@
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
 same name from `@protobuf-ts/grpcweb-transport`, fixing two defects in it. Status messages are
-decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A request ended by
-an abort takes its status from the reason: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the
-status a reason carrying one gives, and `CANCELLED` for anything else, where upstream reports all
-but a standard `AbortError` as `INTERNAL`. An abort once the response has started arriving keeps
-upstream's status.
+decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by an
+abort takes its status from the reason: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the status
+a reason carrying one gives, and `CANCELLED` for anything else, where upstream reports all but a
+standard `AbortError` as `INTERNAL`.
 
 `@mysten/sui/grpc` also exports the `RpcError` class and the `GrpcStatusCode` enum, so the errors
 gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -14,6 +14,6 @@ upstream's status.
 gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.
 
 `SuiGrpcClient` builds one of these by default and now forwards the rest of `GrpcWebOptions`
-(`fetch`, `format`, `meta`, `timeout`, `abort`, `interceptors`, `jsonOptions`, `binaryOptions`) to
+(`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to
 it, which were previously accepted and ignored. A transport passed in by the caller is used as
 given.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -3,13 +3,20 @@
 ---
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the
-`@protobuf-ts/grpcweb-transport` class of the same name, with the two error defects that transport
-has as of 2.11.1 repaired, and `SuiGrpcClient` builds one by default. Percent-encoded `grpc-message`
-status text is decoded at the wire boundary, so `client.core`, the generated service clients and any
-interceptors all see readable messages instead of `Object%20not%20found%3A%200x1`; and a call cut
-short by its own signal is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or `CANCELLED` for
-any other abort reason, rather than `INTERNAL`. A transport supplied by the caller is used exactly
-as given, so build custom grpc-web transports from this class.
+`@protobuf-ts/grpcweb-transport` class of the same name, repairing three defects that transport has
+as of 2.11.1, and `SuiGrpcClient` builds one by default:
+
+- Percent-encoded `grpc-message` status text is decoded at the wire boundary, so `client.core`, the
+  generated service clients and any interceptors all see readable messages rather than
+  `Object%20not%20found:%200x1`.
+- A call cut short by its own signal is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or
+  `CANCELLED` for any other abort reason, rather than `INTERNAL`.
+- `timeout` is enforced as a client-side deadline instead of only being advertised in the
+  `grpc-timeout` header, so a stalled connection fails as `DEADLINE_EXCEEDED` rather than hanging.
+  No deadline is applied unless one is asked for.
+
+A transport supplied by the caller is used exactly as given, so build custom grpc-web transports
+from this class.
 
 `SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
 `interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -1,0 +1,11 @@
+---
+'@mysten/sui': patch
+---
+
+Normalize gRPC transport errors in `SuiGrpcClient`: percent-encoded `grpc-message` status text is
+now decoded once at the wire boundary, so `client.core`, the generated service clients and any
+caller-supplied interceptors all see readable messages instead of `Object%20not%20found%3A%200x1`.
+A call aborted by an `AbortSignal.timeout` is now coded `DEADLINE_EXCEEDED` rather than `INTERNAL`.
+`SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
+`interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only
+`baseUrl` and `fetchInit` were passed through and the rest were silently ignored.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -2,23 +2,13 @@
 '@mysten/sui': patch
 ---
 
-`GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the
-`@protobuf-ts/grpcweb-transport` class of the same name, repairing three defects that transport has
-as of 2.11.1, and `SuiGrpcClient` builds one by default:
+`GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
+same name from `@protobuf-ts/grpcweb-transport`, fixing three defects in it. Status messages are
+decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by its
+own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` instead of `INTERNAL`. `timeout` is enforced
+as a deadline instead of only being sent as the `grpc-timeout` header, so a stalled connection fails
+instead of hanging.
 
-- Percent-encoded `grpc-message` status text is decoded at the wire boundary, so `client.core`, the
-  generated service clients and any interceptors all see readable messages rather than
-  `Object%20not%20found:%200x1`.
-- A call cut short by its own signal is coded `DEADLINE_EXCEEDED` for a deadline or `CANCELLED` for
-  any other abort reason, rather than `INTERNAL`. A failure that merely raced an abort keeps the
-  status the server gave it.
-- `timeout` is enforced as a client-side deadline instead of only being advertised in the
-  `grpc-timeout` header, so a stalled connection fails as `DEADLINE_EXCEEDED` rather than hanging.
-  No deadline is applied unless one is asked for.
-
-A transport supplied by the caller is used exactly as given, so build custom grpc-web transports
-from this class.
-
-`SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
-`interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only
-`baseUrl` and `fetchInit` were passed through and the rest were silently ignored.
+`SuiGrpcClient` builds one of these by default and now forwards the rest of `GrpcWebOptions`
+(`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to it, which
+were previously accepted and ignored. A transport passed in by the caller is used as given.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/sui': minor
+'@mysten/sui': patch
 ---
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the
@@ -9,8 +9,9 @@ as of 2.11.1, and `SuiGrpcClient` builds one by default:
 - Percent-encoded `grpc-message` status text is decoded at the wire boundary, so `client.core`, the
   generated service clients and any interceptors all see readable messages rather than
   `Object%20not%20found:%200x1`.
-- A call cut short by its own signal is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or
-  `CANCELLED` for any other abort reason, rather than `INTERNAL`.
+- A call cut short by its own signal is coded `DEADLINE_EXCEEDED` for a deadline or `CANCELLED` for
+  any other abort reason, rather than `INTERNAL`. A failure that merely raced an abort keeps the
+  status the server gave it.
 - `timeout` is enforced as a client-side deadline instead of only being advertised in the
   `grpc-timeout` header, so a stalled connection fails as `DEADLINE_EXCEEDED` rather than hanging.
   No deadline is applied unless one is asked for.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/sui': patch
+'@mysten/sui': minor
 ---
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
@@ -10,6 +10,9 @@ and only recognises a standard `AbortError`; an abort reason that already carrie
 keeps it. `timeout` is enforced
 as a deadline instead of only being sent as the `grpc-timeout` header, so a stalled connection fails
 instead of hanging.
+
+`@mysten/sui/grpc` also exports the `RpcError` class and the `GrpcStatusCode` enum, so the errors
+gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.
 
 `SuiGrpcClient` builds one of these by default and now forwards the rest of `GrpcWebOptions`
 (`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to it, which

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -5,7 +5,8 @@
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
 same name from `@protobuf-ts/grpcweb-transport`, fixing three defects in it. Status messages are
 decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by its
-own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` instead of `INTERNAL`. `timeout` is enforced
+own signal is coded `DEADLINE_EXCEEDED` for a deadline and `CANCELLED` for other aborts, instead of
+`INTERNAL`; an abort reason that already carries a gRPC status keeps it. `timeout` is enforced
 as a deadline instead of only being sent as the `grpc-timeout` header, so a stalled connection fails
 instead of hanging.
 

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -5,7 +5,10 @@
 Normalize gRPC transport errors in `SuiGrpcClient`: percent-encoded `grpc-message` status text is
 now decoded once at the wire boundary, so `client.core`, the generated service clients and any
 caller-supplied interceptors all see readable messages instead of `Object%20not%20found%3A%200x1`.
-A call aborted by an `AbortSignal.timeout` is now coded `DEADLINE_EXCEEDED` rather than `INTERNAL`.
-`SuiGrpcClient` also forwards the remaining `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`,
-`interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds; previously only
-`baseUrl` and `fetchInit` were passed through and the rest were silently ignored.
+Decoding applies to grpc-web transports, which pass the header through in its wire form; a
+transport that decodes for itself is left alone. A call that ends because its own signal aborted is
+now coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` and `CANCELLED` for any other abort
+reason, rather than `INTERNAL`. `SuiGrpcClient` also forwards the remaining `GrpcWebOptions`
+(`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to the
+transport it builds; previously only `baseUrl` and `fetchInit` were passed through and the rest were
+silently ignored.

--- a/.changeset/tidy-hounds-smile.md
+++ b/.changeset/tidy-hounds-smile.md
@@ -4,10 +4,11 @@
 
 `GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of the transport of the
 same name from `@protobuf-ts/grpcweb-transport`, fixing two defects in it. Status messages are
-decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A call ended by an
-abort takes its status from the reason: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the status
-an `RpcError` reason carries, and `CANCELLED` for anything else, where upstream reports all but a
-standard `AbortError` as `INTERNAL`.
+decoded instead of arriving percent-encoded as `Object%20not%20found:%200x1`. A request ended by
+an abort takes its status from the reason: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the
+status a reason carrying one gives, and `CANCELLED` for anything else, where upstream reports all
+but a standard `AbortError` as `INTERNAL`. An abort once the response has started arriving keeps
+upstream's status.
 
 `@mysten/sui/grpc` also exports the `RpcError` class and the `GrpcStatusCode` enum, so the errors
 gRPC calls produce can be narrowed and coded without a direct `@protobuf-ts/*` dependency.

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -100,8 +100,9 @@ That class extends the transport of the same name from
 [protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes three defects in it:
 
 - It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
-- It codes a timeout as `DEADLINE_EXCEEDED` and a custom abort reason as `CANCELLED`. Upstream
-  reports both as `INTERNAL`, recognising only a standard `AbortError` cancellation.
+- It codes a timeout as `DEADLINE_EXCEEDED` and a custom abort reason as `CANCELLED`, except that a
+  reason which is already an `RpcError` keeps the status it carries. Upstream reports the first two
+  as `INTERNAL`, recognising only a standard `AbortError` cancellation.
 - It enforces `timeout` as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
   stalled connection hangs for as long as the underlying `fetch` does.
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -98,14 +98,12 @@ you can configure a transport and handle its errors without adding `@protobuf-ts
 dependency.
 
 That class extends the transport of the same name from
-[protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes three defects in it:
+[protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes two defects in it:
 
 - It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
-- It codes a timeout as `DEADLINE_EXCEEDED` and a custom abort reason as `CANCELLED`, except that a
-  reason which is already an `RpcError` keeps the status it carries. Upstream reports the first two
-  as `INTERNAL`, recognising only a standard `AbortError` cancellation.
-- It enforces `timeout` as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
-  stalled connection hangs for as long as the underlying `fetch` does.
+- It codes a call that an abort ended from the reason the abort carried: `DEADLINE_EXCEEDED` for an
+  `AbortSignal.timeout`, the status on an `RpcError` reason, and `CANCELLED` otherwise. Upstream
+  reports all but a standard `AbortError` cancellation as `INTERNAL`.
 
 Build custom transports from this class. `SuiGrpcClient` uses a transport you pass it as given.
 
@@ -120,7 +118,6 @@ import { SuiGrpcClient, GrpcWebFetchTransport } from '@mysten/sui/grpc';
 const transport = new GrpcWebFetchTransport({
 	baseUrl: 'https://your-custom-grpc-endpoint.com',
 	format: 'binary', // default is 'text' (base64-encoded)
-	timeout: 15_000, // deadline per call, in milliseconds
 	// Additional transport options like fetchInit
 });
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -109,8 +109,21 @@ Build custom transports from this class. `SuiGrpcClient` uses a transport you pa
 
 ### gRPC-web transport (default)
 
-The default transport uses the gRPC-web protocol over HTTP/1.1 or HTTP/2. Pass
-`GrpcWebFetchTransport` options to customize it:
+The default transport uses the gRPC-web protocol over HTTP/1.1 or HTTP/2. `SuiGrpcClient` passes any
+`GrpcWebOptions` it is given to the transport it builds, so most configuration needs no transport of
+your own:
+
+```typescript
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const client = new SuiGrpcClient({
+	network: 'testnet',
+	baseUrl: 'https://your-custom-grpc-endpoint.com',
+	format: 'binary', // default is 'text' (base64-encoded)
+});
+```
+
+Build the transport yourself to share one between clients, or to subclass it:
 
 ```typescript
 import { SuiGrpcClient, GrpcWebFetchTransport } from '@mysten/sui/grpc';

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -91,11 +91,19 @@ console.log(transaction.digest, result.protoJson);
 
 ## Transport options
 
-By default, `SuiGrpcClient` uses `GrpcWebFetchTransport` from
-[protobuf-ts](https://github.com/timostamm/protobuf-ts), which works in browsers and Node.js through
-the Fetch API. The `GrpcWebFetchTransport` class, `GrpcWebOptions` type, and `RpcTransport` type are
-re-exported from `@mysten/sui/grpc`, so you can configure a transport without adding
-`@protobuf-ts/*` as a direct dependency.
+By default, `SuiGrpcClient` uses `GrpcWebFetchTransport`, which works in browsers and Node.js
+through the Fetch API. `@mysten/sui/grpc` exports it alongside the `GrpcWebOptions` and
+`RpcTransport` types, so you can configure a transport without adding `@protobuf-ts/*` as a direct
+dependency.
+
+That class extends the transport of the same name from
+[protobuf-ts](https://github.com/timostamm/protobuf-ts) and repairs two defects in how it reports
+errors: gRPC status messages arrive decoded rather than percent-encoded (`Object not found: 0x1`,
+not `Object%20not%20found%3A%200x1`), and a call cut short by its own `signal` is coded
+`DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or `CANCELLED` for any other abort, rather than
+`INTERNAL`. Build custom transports from this class rather than importing one from
+`@protobuf-ts/grpcweb-transport` directly — a transport passed to `SuiGrpcClient` is used exactly as
+given.
 
 ### gRPC-web transport (default)
 
@@ -145,6 +153,12 @@ const client = new SuiGrpcClient({
 
 For local development without TLS, use `ChannelCredentials.createInsecure()` and a plain
 `host: '127.0.0.1:9000'`.
+
+This transport reports errors the way `@grpc/grpc-js` does, which differs from the gRPC-web
+transport above in one way worth knowing: grpc-js decodes a status message with `decodeURI`, which
+leaves escapes for reserved characters in place, so a message reaches you as
+`Object not found%3A 0x1`. Status codes are unaffected — grpc-js handles deadlines and cancellation
+natively.
 
 ## Read masks
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -101,10 +101,9 @@ That class extends the transport of the same name from
 [protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes two defects in it:
 
 - It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
-- It codes a request that an abort ended from the reason the abort carried: `DEADLINE_EXCEEDED` for
-  an `AbortSignal.timeout`, the status on a reason carrying one, and `CANCELLED` otherwise. Upstream
-  reports all but a standard `AbortError` cancellation as `INTERNAL`. An abort once the response has
-  started arriving, such as one cancelling a stream mid-read, keeps upstream's status.
+- It codes a call that an abort ended from the reason the abort carried: `DEADLINE_EXCEEDED` for an
+  `AbortSignal.timeout`, the status on a reason carrying one, and `CANCELLED` otherwise. Upstream
+  reports all but a standard `AbortError` cancellation as `INTERNAL`.
 
 Build custom transports from this class. `SuiGrpcClient` uses a transport you pass it as given.
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -97,19 +97,15 @@ through the Fetch API. `@mysten/sui/grpc` exports it alongside the `GrpcWebOptio
 dependency.
 
 That class extends the transport of the same name from
-[protobuf-ts](https://github.com/timostamm/protobuf-ts) and repairs three of its defects:
+[protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes three defects in it:
 
-- gRPC status messages arrive decoded rather than percent-encoded — `Object not found: 0x1`, not
-  `Object%20not%20found:%200x1`.
-- A call cut short by its own `signal` is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or
-  `CANCELLED` for any other abort, rather than `INTERNAL`.
-- `timeout` is a deadline the client enforces, not just one it advertises to the server in the
-  `grpc-timeout` header. Upstream sends the header and nothing else, so a stalled connection hangs
-  however long the underlying `fetch` does.
+- Status messages are decoded, rather than arriving as `Object%20not%20found:%200x1`.
+- A call ended by its own `signal` is coded `DEADLINE_EXCEEDED` for a timeout and `CANCELLED` for
+  any other abort, rather than `INTERNAL`.
+- `timeout` is enforced as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
+  stalled connection hangs for as long as the underlying `fetch` does.
 
-Build custom transports from this class rather than importing one from
-`@protobuf-ts/grpcweb-transport` directly — a transport passed to `SuiGrpcClient` is used exactly as
-given.
+Build custom transports from this class. A transport passed to `SuiGrpcClient` is used as given.
 
 ### gRPC-web transport (default)
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -93,7 +93,8 @@ console.log(transaction.digest, result.protoJson);
 
 By default, `SuiGrpcClient` uses `GrpcWebFetchTransport`, which works in browsers and Node.js
 through the Fetch API. `@mysten/sui/grpc` exports it alongside the `GrpcWebOptions` and
-`RpcTransport` types, so you can configure a transport without adding `@protobuf-ts/*` as a direct
+`RpcTransport` types, and the `RpcError` class and `GrpcStatusCode` enum that gRPC failures use, so
+you can configure a transport and handle its errors without adding `@protobuf-ts/*` as a direct
 dependency.
 
 That class extends the transport of the same name from
@@ -282,6 +283,7 @@ const result = parseGrpcTransactionResponse(response.transaction!, {
 | `parseGrpcTransactionResponse`                            | Raw `ExecutedTransaction` to the unified result shape |
 | `parseGrpcSimulateTransactionResponse`                    | Raw simulation response to the unified result shape   |
 | `GrpcWebFetchTransport`, `GrpcWebOptions`, `RpcTransport` | Configuring a [transport](#transport-options)         |
+| `RpcError`, `GrpcStatusCode`                              | Narrowing and coding gRPC failures                    |
 | `SuiGrpcClientOptions`, `GrpcTransactionInclude`, …       | Typing your own wrappers around the client            |
 | `isSuiGrpcClient`                                         | Type guard for narrowing an unknown client            |
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -161,13 +161,9 @@ const client = new SuiGrpcClient({
 For local development without TLS, use `ChannelCredentials.createInsecure()` and a plain
 `host: '127.0.0.1:9000'`.
 
-This transport reports errors the way `@grpc/grpc-js` does, which differs from the gRPC-web
-transport above in two small ways. grpc-js decodes status messages with `decodeURI`, which leaves
-escapes for reserved characters in place: of the characters a Sui node escapes, `#` and `?` reach
-you as `%23` and `%3F`, while spaces, non-ASCII text and a literal `%` decode correctly. And an
-aborted call is `CANCELLED` whatever the abort reason, so an `AbortSignal.timeout` reads `CANCELLED`
-rather than `DEADLINE_EXCEEDED`. Set `timeout` to express a deadline: both transports enforce it and
-report `DEADLINE_EXCEEDED`, so it is the spelling that behaves the same either way.
+Errors on this transport come from `@grpc/grpc-js`, so status text and codes can differ slightly
+from the gRPC-web transport above. Set deadlines with `timeout`, which both transports enforce and
+report as `DEADLINE_EXCEEDED`.
 
 ## Read masks
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -97,11 +97,17 @@ through the Fetch API. `@mysten/sui/grpc` exports it alongside the `GrpcWebOptio
 dependency.
 
 That class extends the transport of the same name from
-[protobuf-ts](https://github.com/timostamm/protobuf-ts) and repairs two defects in how it reports
-errors: gRPC status messages arrive decoded rather than percent-encoded (`Object not found: 0x1`,
-not `Object%20not%20found%3A%200x1`), and a call cut short by its own `signal` is coded
-`DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or `CANCELLED` for any other abort, rather than
-`INTERNAL`. Build custom transports from this class rather than importing one from
+[protobuf-ts](https://github.com/timostamm/protobuf-ts) and repairs three of its defects:
+
+- gRPC status messages arrive decoded rather than percent-encoded — `Object not found: 0x1`, not
+  `Object%20not%20found:%200x1`.
+- A call cut short by its own `signal` is coded `DEADLINE_EXCEEDED` for an `AbortSignal.timeout` or
+  `CANCELLED` for any other abort, rather than `INTERNAL`.
+- `timeout` is a deadline the client enforces, not just one it advertises to the server in the
+  `grpc-timeout` header. Upstream sends the header and nothing else, so a stalled connection hangs
+  however long the underlying `fetch` does.
+
+Build custom transports from this class rather than importing one from
 `@protobuf-ts/grpcweb-transport` directly — a transport passed to `SuiGrpcClient` is used exactly as
 given.
 
@@ -116,6 +122,7 @@ import { SuiGrpcClient, GrpcWebFetchTransport } from '@mysten/sui/grpc';
 const transport = new GrpcWebFetchTransport({
 	baseUrl: 'https://your-custom-grpc-endpoint.com',
 	format: 'binary', // default is 'text' (base64-encoded)
+	timeout: 15_000, // deadline per call, in milliseconds
 	// Additional transport options like fetchInit
 });
 
@@ -159,8 +166,8 @@ transport above in two small ways. grpc-js decodes status messages with `decodeU
 escapes for reserved characters in place: of the characters a Sui node escapes, `#` and `?` reach
 you as `%23` and `%3F`, while spaces, non-ASCII text and a literal `%` decode correctly. And an
 aborted call is `CANCELLED` whatever the abort reason, so an `AbortSignal.timeout` reads `CANCELLED`
-rather than `DEADLINE_EXCEEDED`; set `timeout` on the call options instead, which grpc-js enforces
-as a deadline.
+rather than `DEADLINE_EXCEEDED`. Set `timeout` to express a deadline: both transports enforce it and
+report `DEADLINE_EXCEEDED`, so it is the spelling that behaves the same either way.
 
 ## Read masks
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -100,8 +100,8 @@ That class extends the transport of the same name from
 [protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes three defects in it:
 
 - It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
-- It codes a call that its own `signal` ended as `DEADLINE_EXCEEDED` for a timeout and `CANCELLED`
-  for any other abort, rather than `INTERNAL`.
+- It codes a timeout as `DEADLINE_EXCEEDED` and a custom abort reason as `CANCELLED`. Upstream
+  reports both as `INTERNAL`, recognising only a standard `AbortError` cancellation.
 - It enforces `timeout` as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
   stalled connection hangs for as long as the underlying `fetch` does.
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -161,10 +161,6 @@ const client = new SuiGrpcClient({
 For local development without TLS, use `ChannelCredentials.createInsecure()` and a plain
 `host: '127.0.0.1:9000'`.
 
-Errors on this transport come from `@grpc/grpc-js`, so status text and codes can differ slightly
-from the gRPC-web transport above. Set deadlines with `timeout`, which both transports enforce and
-report as `DEADLINE_EXCEEDED`.
-
 ## Read masks
 
 gRPC responses are opt-in. A request names the fields it wants in a `readMask`, and the server

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -155,10 +155,12 @@ For local development without TLS, use `ChannelCredentials.createInsecure()` and
 `host: '127.0.0.1:9000'`.
 
 This transport reports errors the way `@grpc/grpc-js` does, which differs from the gRPC-web
-transport above in one way worth knowing: grpc-js decodes a status message with `decodeURI`, which
-leaves escapes for reserved characters in place, so a message reaches you as
-`Object not found%3A 0x1`. Status codes are unaffected — grpc-js handles deadlines and cancellation
-natively.
+transport above in two small ways. grpc-js decodes status messages with `decodeURI`, which leaves
+escapes for reserved characters in place: of the characters a Sui node escapes, `#` and `?` reach
+you as `%23` and `%3F`, while spaces, non-ASCII text and a literal `%` decode correctly. And an
+aborted call is `CANCELLED` whatever the abort reason, so an `AbortSignal.timeout` reads `CANCELLED`
+rather than `DEADLINE_EXCEEDED`; set `timeout` on the call options instead, which grpc-js enforces
+as a deadline.
 
 ## Read masks
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -101,9 +101,10 @@ That class extends the transport of the same name from
 [protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes two defects in it:
 
 - It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
-- It codes a call that an abort ended from the reason the abort carried: `DEADLINE_EXCEEDED` for an
-  `AbortSignal.timeout`, the status on an `RpcError` reason, and `CANCELLED` otherwise. Upstream
-  reports all but a standard `AbortError` cancellation as `INTERNAL`.
+- It codes a request that an abort ended from the reason the abort carried: `DEADLINE_EXCEEDED` for
+  an `AbortSignal.timeout`, the status on a reason carrying one, and `CANCELLED` otherwise. Upstream
+  reports all but a standard `AbortError` cancellation as `INTERNAL`. An abort once the response has
+  started arriving, such as one cancelling a stream mid-read, keeps upstream's status.
 
 Build custom transports from this class. `SuiGrpcClient` uses a transport you pass it as given.
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -99,13 +99,13 @@ dependency.
 That class extends the transport of the same name from
 [protobuf-ts](https://github.com/timostamm/protobuf-ts) and fixes three defects in it:
 
-- Status messages are decoded, rather than arriving as `Object%20not%20found:%200x1`.
-- A call ended by its own `signal` is coded `DEADLINE_EXCEEDED` for a timeout and `CANCELLED` for
-  any other abort, rather than `INTERNAL`.
-- `timeout` is enforced as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
+- It decodes status messages, rather than delivering them as `Object%20not%20found:%200x1`.
+- It codes a call that its own `signal` ended as `DEADLINE_EXCEEDED` for a timeout and `CANCELLED`
+  for any other abort, rather than `INTERNAL`.
+- It enforces `timeout` as a deadline. Upstream only sends it as the `grpc-timeout` header, so a
   stalled connection hangs for as long as the underlying `fetch` does.
 
-Build custom transports from this class. A transport passed to `SuiGrpcClient` is used as given.
+Build custom transports from this class. `SuiGrpcClient` uses a transport you pass it as given.
 
 ### gRPC-web transport (default)
 

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -111,8 +111,8 @@ Build custom transports from this class. `SuiGrpcClient` uses a transport you pa
 
 The default transport uses the gRPC-web protocol over HTTP/1.1 or HTTP/2. `SuiGrpcClient` passes the
 `GrpcWebOptions` it is given to the transport it builds, so most configuration needs no transport of
-your own. The one exception is `abort`: every call carries its own signal, so a client-wide one is
-not forwarded.
+your own. The one exception is `abort`: Core API calls each carry their own signal, so a client-wide
+one is not forwarded.
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';

--- a/packages/docs/content/sui/clients/grpc.mdx
+++ b/packages/docs/content/sui/clients/grpc.mdx
@@ -109,9 +109,10 @@ Build custom transports from this class. `SuiGrpcClient` uses a transport you pa
 
 ### gRPC-web transport (default)
 
-The default transport uses the gRPC-web protocol over HTTP/1.1 or HTTP/2. `SuiGrpcClient` passes any
+The default transport uses the gRPC-web protocol over HTTP/1.1 or HTTP/2. `SuiGrpcClient` passes the
 `GrpcWebOptions` it is given to the transport it builds, so most configuration needs no transport of
-your own:
+your own. The one exception is `abort`: every call carries its own signal, so a client-wide one is
+not forwarded.
 
 ```typescript
 import { SuiGrpcClient } from '@mysten/sui/grpc';

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -160,6 +160,9 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 		const {
 			network: _network,
 			mvr: _mvr,
+			// Every Core API call passes its own `signal`, which would overwrite a client-level default
+			// with `undefined`, so a transport-wide one is not forwarded.
+			abort: _abort,
 			transport: providedTransport,
 			...transportOptions
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
-import { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 import { TransactionExecutionServiceClient } from './proto/sui/rpc/v2/transaction_execution_service.client.js';
 import { LedgerServiceClient } from './proto/sui/rpc/v2/ledger_service.client.js';
 import { MovePackageServiceClient } from './proto/sui/rpc/v2/move_package_service.client.js';
@@ -19,7 +18,7 @@ import { fromBase64, toBase64 } from '@mysten/utils';
 import { NameServiceClient } from './proto/sui/rpc/v2/name_service.client.js';
 import { ForkingServiceClient } from './proto/sui/forking/v1alpha/forking_service.client.js';
 import type { TransactionPlugin } from '../transactions/index.js';
-import { withNormalizedErrors } from './transport.js';
+import { SuiGrpcWebTransport } from './transport.js';
 
 interface SuiGrpcTransportOptions extends GrpcWebOptions {
 	transport?: never;
@@ -165,15 +164,10 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 			...transportOptions
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
 
-		const baseTransport = providedTransport ?? new GrpcWebFetchTransport(transportOptions);
-
-		// Wrapped whether the transport is ours or the caller's, so status codes read the same
-		// everywhere. Only grpc-web leaves `grpc-message` in its percent-encoded wire form, though:
-		// other transports (`@protobuf-ts/grpc-transport`, say) decode it themselves, and decoding
-		// again would rewrite a status that really does contain `%20`. See `./transport.ts`.
-		const transport = withNormalizedErrors(baseTransport, {
-			decodeMessages: baseTransport instanceof GrpcWebFetchTransport,
-		});
+		// A transport the caller supplied is used exactly as given: whatever it does with errors is
+		// that transport's contract, not ours to reach into. The default fixes the two error defects
+		// `GrpcWebFetchTransport` has — see `SuiGrpcWebTransport`.
+		const transport = providedTransport ?? new SuiGrpcWebTransport(transportOptions);
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);
 		this.stateService = new StateServiceClient(transport);

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -164,9 +164,8 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 			...transportOptions
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
 
-		// A transport the caller supplied is used exactly as given: whatever it does with errors is
-		// that transport's contract, not ours to reach into. The default is our `GrpcWebFetchTransport`,
-		// which repairs upstream's two error defects — see `./transport.ts`.
+		// A caller-supplied transport is used as given. The default is our `GrpcWebFetchTransport`,
+		// which fixes upstream's error handling. See `./transport.ts`.
 		const transport = providedTransport ?? new GrpcWebFetchTransport(transportOptions);
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -160,15 +160,13 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 		const {
 			network: _network,
 			mvr: _mvr,
-			// Every Core API call passes its own `signal`, which would overwrite a client-level default
-			// with `undefined`, so a transport-wide one is not forwarded.
+			// Not forwarded: every Core API call passes its own `signal`, which would overwrite it.
 			abort: _abort,
 			transport: providedTransport,
 			...transportOptions
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
 
-		// A caller-supplied transport is used as given. The default is our `GrpcWebFetchTransport`,
-		// which fixes upstream's error handling. See `./transport.ts`.
+		// A caller-supplied transport is used as given. See ./transport.ts for the default.
 		const transport = providedTransport ?? new GrpcWebFetchTransport(transportOptions);
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -165,11 +165,15 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 			...transportOptions
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
 
-		// Wrapped whether the transport is ours or the caller's, so status text and status codes read
-		// the same everywhere. See `./transport.ts`.
-		const transport = withNormalizedErrors(
-			providedTransport ?? new GrpcWebFetchTransport(transportOptions),
-		);
+		const baseTransport = providedTransport ?? new GrpcWebFetchTransport(transportOptions);
+
+		// Wrapped whether the transport is ours or the caller's, so status codes read the same
+		// everywhere. Only grpc-web leaves `grpc-message` in its percent-encoded wire form, though:
+		// other transports (`@protobuf-ts/grpc-transport`, say) decode it themselves, and decoding
+		// again would rewrite a status that really does contain `%20`. See `./transport.ts`.
+		const transport = withNormalizedErrors(baseTransport, {
+			decodeMessages: baseTransport instanceof GrpcWebFetchTransport,
+		});
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);
 		this.stateService = new StateServiceClient(transport);

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -19,6 +19,7 @@ import { fromBase64, toBase64 } from '@mysten/utils';
 import { NameServiceClient } from './proto/sui/rpc/v2/name_service.client.js';
 import { ForkingServiceClient } from './proto/sui/forking/v1alpha/forking_service.client.js';
 import type { TransactionPlugin } from '../transactions/index.js';
+import { withNormalizedErrors } from './transport.js';
 
 interface SuiGrpcTransportOptions extends GrpcWebOptions {
 	transport?: never;
@@ -157,9 +158,18 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 
 	constructor(options: SuiGrpcClientOptions) {
 		super({ network: options.network });
-		const transport =
-			options.transport ??
-			new GrpcWebFetchTransport({ baseUrl: options.baseUrl, fetchInit: options.fetchInit });
+		const {
+			network: _network,
+			mvr: _mvr,
+			transport: providedTransport,
+			...transportOptions
+		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
+
+		// Wrapped whether the transport is ours or the caller's, so status text and status codes read
+		// the same everywhere. See `./transport.ts`.
+		const transport = withNormalizedErrors(
+			providedTransport ?? new GrpcWebFetchTransport(transportOptions),
+		);
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);
 		this.stateService = new StateServiceClient(transport);

--- a/packages/sui/src/grpc/client.ts
+++ b/packages/sui/src/grpc/client.ts
@@ -18,7 +18,7 @@ import { fromBase64, toBase64 } from '@mysten/utils';
 import { NameServiceClient } from './proto/sui/rpc/v2/name_service.client.js';
 import { ForkingServiceClient } from './proto/sui/forking/v1alpha/forking_service.client.js';
 import type { TransactionPlugin } from '../transactions/index.js';
-import { SuiGrpcWebTransport } from './transport.js';
+import { GrpcWebFetchTransport } from './transport.js';
 
 interface SuiGrpcTransportOptions extends GrpcWebOptions {
 	transport?: never;
@@ -165,9 +165,9 @@ export class SuiGrpcClient extends BaseClient implements SuiClientTypes.Transpor
 		} = options as SuiGrpcClientOptions & SuiGrpcTransportOptions & { transport?: RpcTransport };
 
 		// A transport the caller supplied is used exactly as given: whatever it does with errors is
-		// that transport's contract, not ours to reach into. The default fixes the two error defects
-		// `GrpcWebFetchTransport` has — see `SuiGrpcWebTransport`.
-		const transport = providedTransport ?? new SuiGrpcWebTransport(transportOptions);
+		// that transport's contract, not ours to reach into. The default is our `GrpcWebFetchTransport`,
+		// which repairs upstream's two error defects — see `./transport.ts`.
+		const transport = providedTransport ?? new GrpcWebFetchTransport(transportOptions);
 		this.transactionExecutionService = new TransactionExecutionServiceClient(transport);
 		this.ledgerService = new LedgerServiceClient(transport);
 		this.stateService = new StateServiceClient(transport);

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -69,7 +69,7 @@ import {
 	validateTransactionQuery,
 } from '../client/query-filters.js';
 import { toGrpcEventFilter, toGrpcTransactionFilter } from './filters.js';
-import { grpcStatusMessage } from './transport.js';
+import { hasDecodedStatusMessage } from './transport.js';
 
 export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
@@ -81,9 +81,14 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
 	// The service reports an expired name as RESOURCE_EXHAUSTED with no structured reason, so match
-	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone. A caller-supplied
-	// transport leaves `grpc-message` percent-encoded, hence the decode.
-	return grpcStatusMessage(error) === 'name has expired';
+	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone.
+	if (error.message === 'name has expired') return true;
+
+	// A transport this package did not build may leave `grpc-message` in its wire form, so match that
+	// too. Decoding the message instead would be a guess about what the transport already did, and
+	// would rewrite text that decodes to something else entirely. Our own transport has decoded by
+	// this point, so the wire form is only ever accepted from a transport that has not.
+	return !hasDecodedStatusMessage(error) && error.message === 'name%20has%20expired';
 }
 
 export class GrpcCoreClient extends CoreClient {
@@ -984,11 +989,9 @@ export class GrpcCoreClient extends CoreClient {
 				});
 				response = result.response;
 			} catch (error) {
-				// Decoded here only if the transport has not already done it. See ./transport.ts.
-				if (error instanceof RpcError && error.message) {
-					throw new SimulationError(grpcStatusMessage(error), { cause: error });
-				}
-
+				// The transport owns the status text: ours decodes it, and one supplied by the caller
+				// reports it however that transport does. Decoding here would corrupt a message another
+				// transport had already decoded. See ./transport.ts.
 				if (error instanceof Error && error.message) {
 					throw new SimulationError(error.message, { cause: error });
 				}

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -76,19 +76,25 @@ export interface GrpcCoreClientOptions extends CoreClientOptions {
 }
 
 function isNameServiceResolutionMiss(error: unknown): boolean {
-	if (!(error instanceof RpcError)) return false;
-	if (error.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) return true;
-	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
+	// Read by shape rather than `instanceof`, so an error from another installed copy of
+	// `@protobuf-ts/runtime-rpc` is still recognised.
+	if (typeof error !== 'object' || error === null) return false;
+
+	const { code, message } = error as { code?: unknown; message?: unknown };
+	if (typeof code !== 'string' || typeof message !== 'string') return false;
+
+	if (code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) return true;
+	if (code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
 	// The service reports an expired name as RESOURCE_EXHAUSTED with no structured reason, so match
 	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone.
-	if (error.message === 'name has expired') return true;
+	if (message === 'name has expired') return true;
 
 	// A transport this package did not build may leave `grpc-message` in its wire form, so match that
 	// too. Decoding the message instead would be a guess about what the transport already did, and
 	// would rewrite text that decodes to something else entirely. Our own transport has decoded by
 	// this point, so the wire form is only ever accepted from a transport that has not.
-	return !hasDecodedStatusMessage(error) && error.message === 'name%20has%20expired';
+	return !hasDecodedStatusMessage(error) && message === 'name%20has%20expired';
 }
 
 export class GrpcCoreClient extends CoreClient {

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -69,6 +69,7 @@ import {
 	validateTransactionQuery,
 } from '../client/query-filters.js';
 import { toGrpcEventFilter, toGrpcTransactionFilter } from './filters.js';
+import { decodeGrpcStatusMessage } from './transport.js';
 
 export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
@@ -81,8 +82,11 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 
 	// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a structured
 	// reason, so match on the status text while preserving unrelated RESOURCE_EXHAUSTED failures
-	// such as capacity limits. The transport wrapper has already decoded it (see ./transport.ts).
-	return error.message === 'name has expired';
+	// such as capacity limits. Decoded for the comparison only: a transport this package did not
+	// build leaves `grpc-message` percent-encoded, and whether a name resolved must not depend on
+	// which transport the client was given. Decoding text already decoded is a no-op here, because
+	// what it is compared against holds no escapes.
+	return decodeGrpcStatusMessage(error.message) === 'name has expired';
 }
 
 export class GrpcCoreClient extends CoreClient {

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -79,14 +79,10 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (error.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) return true;
 	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
-	try {
-		// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a
-		// structured reason. grpc-web URI-encodes status messages, so decode before matching while
-		// preserving unrelated RESOURCE_EXHAUSTED failures such as capacity limits.
-		return decodeURIComponent(error.message) === 'name has expired';
-	} catch {
-		return false;
-	}
+	// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a structured
+	// reason, so match on the status text while preserving unrelated RESOURCE_EXHAUSTED failures
+	// such as capacity limits. The transport wrapper has already decoded it (see ./transport.ts).
+	return error.message === 'name has expired';
 }
 
 export class GrpcCoreClient extends CoreClient {
@@ -987,9 +983,9 @@ export class GrpcCoreClient extends CoreClient {
 				});
 				response = result.response;
 			} catch (error) {
-				// https://github.com/timostamm/protobuf-ts/pull/739
+				// Status text arrives already decoded — see `withNormalizedErrors` in ./transport.ts.
 				if (error instanceof Error && error.message) {
-					throw new SimulationError(decodeURIComponent(error.message), { cause: error });
+					throw new SimulationError(error.message, { cause: error });
 				}
 				throw error;
 			}

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -80,12 +80,9 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (error.code === GrpcStatusCode[GrpcStatusCode.NOT_FOUND]) return true;
 	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
-	// The gRPC service currently reports expired names as RESOURCE_EXHAUSTED without a structured
-	// reason, so match on the status text while preserving unrelated RESOURCE_EXHAUSTED failures
-	// such as capacity limits. Decoded for the comparison only: a transport this package did not
-	// build leaves `grpc-message` percent-encoded, and whether a name resolved must not depend on
-	// which transport the client was given. Decoding text already decoded is a no-op here, because
-	// what it is compared against holds no escapes.
+	// The service reports an expired name as RESOURCE_EXHAUSTED with no structured reason, so match
+	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone. Decoded for the
+	// comparison only, since a caller-supplied transport leaves `grpc-message` percent-encoded.
 	return decodeGrpcStatusMessage(error.message) === 'name has expired';
 }
 
@@ -987,7 +984,7 @@ export class GrpcCoreClient extends CoreClient {
 				});
 				response = result.response;
 			} catch (error) {
-				// Status text arrives already decoded — see `withNormalizedErrors` in ./transport.ts.
+				// Status text is decoded by the transport. See ./transport.ts.
 				if (error instanceof Error && error.message) {
 					throw new SimulationError(error.message, { cause: error });
 				}

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -69,7 +69,7 @@ import {
 	validateTransactionQuery,
 } from '../client/query-filters.js';
 import { toGrpcEventFilter, toGrpcTransactionFilter } from './filters.js';
-import { decodeGrpcStatusMessage } from './transport.js';
+import { grpcStatusMessage } from './transport.js';
 
 export interface GrpcCoreClientOptions extends CoreClientOptions {
 	client: SuiGrpcClient;
@@ -81,9 +81,9 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (error.code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
 	// The service reports an expired name as RESOURCE_EXHAUSTED with no structured reason, so match
-	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone. Decoded for the
-	// comparison only, since a caller-supplied transport leaves `grpc-message` percent-encoded.
-	return decodeGrpcStatusMessage(error.message) === 'name has expired';
+	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone. A caller-supplied
+	// transport leaves `grpc-message` percent-encoded, hence the decode.
+	return grpcStatusMessage(error) === 'name has expired';
 }
 
 export class GrpcCoreClient extends CoreClient {
@@ -984,7 +984,11 @@ export class GrpcCoreClient extends CoreClient {
 				});
 				response = result.response;
 			} catch (error) {
-				// Status text is decoded by the transport. See ./transport.ts.
+				// Decoded here only if the transport has not already done it. See ./transport.ts.
+				if (error instanceof RpcError && error.message) {
+					throw new SimulationError(grpcStatusMessage(error), { cause: error });
+				}
+
 				if (error instanceof Error && error.message) {
 					throw new SimulationError(error.message, { cause: error });
 				}

--- a/packages/sui/src/grpc/core.ts
+++ b/packages/sui/src/grpc/core.ts
@@ -76,8 +76,7 @@ export interface GrpcCoreClientOptions extends CoreClientOptions {
 }
 
 function isNameServiceResolutionMiss(error: unknown): boolean {
-	// Read by shape rather than `instanceof`, so an error from another installed copy of
-	// `@protobuf-ts/runtime-rpc` is still recognised.
+	// Read by shape, so an error from another copy of runtime-rpc is still recognised.
 	if (typeof error !== 'object' || error === null) return false;
 
 	const { code, message } = error as { code?: unknown; message?: unknown };
@@ -87,13 +86,10 @@ function isNameServiceResolutionMiss(error: unknown): boolean {
 	if (code !== GrpcStatusCode[GrpcStatusCode.RESOURCE_EXHAUSTED]) return false;
 
 	// The service reports an expired name as RESOURCE_EXHAUSTED with no structured reason, so match
-	// the status text and leave unrelated RESOURCE_EXHAUSTED failures alone.
+	// the status text and leave other RESOURCE_EXHAUSTED failures alone. A transport this package did
+	// not build leaves `grpc-message` encoded, hence the second form.
 	if (message === 'name has expired') return true;
 
-	// A transport this package did not build may leave `grpc-message` in its wire form, so match that
-	// too. Decoding the message instead would be a guess about what the transport already did, and
-	// would rewrite text that decodes to something else entirely. Our own transport has decoded by
-	// this point, so the wire form is only ever accepted from a transport that has not.
 	return !hasDecodedStatusMessage(error) && message === 'name%20has%20expired';
 }
 
@@ -995,9 +991,7 @@ export class GrpcCoreClient extends CoreClient {
 				});
 				response = result.response;
 			} catch (error) {
-				// The transport owns the status text: ours decodes it, and one supplied by the caller
-				// reports it however that transport does. Decoding here would corrupt a message another
-				// transport had already decoded. See ./transport.ts.
+				// The transport owns the status text. See ./transport.ts.
 				if (error instanceof Error && error.message) {
 					throw new SimulationError(error.message, { cause: error });
 				}

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -23,13 +23,11 @@ export type {
 } from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 
-// The transport `SuiGrpcClient` builds by default, and the one to construct for a custom transport:
-// `@protobuf-ts/grpcweb-transport`'s, subclassed to repair its error defects. Exported here rather
-// than re-exported from that package so a caller following these types gets the fixes.
+// `@protobuf-ts/grpcweb-transport`'s transport, subclassed to fix its error handling. Exported
+// here instead of re-exporting that package's, so a custom transport gets the fixes too.
 export { GrpcWebFetchTransport } from './transport.js';
 
-// Re-export transport types so users can configure custom transports
-// without adding @protobuf-ts/* as direct dependencies.
+// Re-exported so users can configure a transport without adding @protobuf-ts/* as a dependency.
 export type { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
 export type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -23,15 +23,13 @@ export type {
 } from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 
-// The transport `SuiGrpcClient` builds by default: grpc-web, with the error defects of the
-// upstream transport repaired. Construct it directly to configure a transport the client does not
-// take options for, such as one carrying interceptors.
-export { SuiGrpcWebTransport } from './transport.js';
+// The transport `SuiGrpcClient` builds by default, and the one to construct for a custom transport:
+// `@protobuf-ts/grpcweb-transport`'s, subclassed to repair its error defects. Exported here rather
+// than re-exported from that package so a caller following these types gets the fixes.
+export { GrpcWebFetchTransport } from './transport.js';
 
-// Re-export transports and types so users can configure custom transports
-// without adding @protobuf-ts/* as direct dependencies. `GrpcWebFetchTransport` is upstream's,
-// unmodified; prefer `SuiGrpcWebTransport` above.
-export { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+// Re-export transport types so users can configure custom transports
+// without adding @protobuf-ts/* as direct dependencies.
 export type { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
 export type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -23,8 +23,7 @@ export type {
 } from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 
-// `@protobuf-ts/grpcweb-transport`'s transport, subclassed to fix its error handling. Exported
-// here instead of re-exporting that package's, so a custom transport gets the fixes too.
+// Subclasses `@protobuf-ts/grpcweb-transport`'s transport to fix its error handling.
 export { GrpcWebFetchTransport } from './transport.js';
 
 // Re-exported so users can configure a transport, and narrow and code the errors it produces,

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -23,8 +23,14 @@ export type {
 } from './client.js';
 export type { GrpcCoreClientOptions } from './core.js';
 
+// The transport `SuiGrpcClient` builds by default: grpc-web, with the error defects of the
+// upstream transport repaired. Construct it directly to configure a transport the client does not
+// take options for, such as one carrying interceptors.
+export { SuiGrpcWebTransport } from './transport.js';
+
 // Re-export transports and types so users can configure custom transports
-// without adding @protobuf-ts/* as direct dependencies.
+// without adding @protobuf-ts/* as direct dependencies. `GrpcWebFetchTransport` is upstream's,
+// unmodified; prefer `SuiGrpcWebTransport` above.
 export { GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 export type { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
 export type { RpcTransport } from '@protobuf-ts/runtime-rpc';

--- a/packages/sui/src/grpc/index.ts
+++ b/packages/sui/src/grpc/index.ts
@@ -27,8 +27,11 @@ export type { GrpcCoreClientOptions } from './core.js';
 // here instead of re-exporting that package's, so a custom transport gets the fixes too.
 export { GrpcWebFetchTransport } from './transport.js';
 
-// Re-exported so users can configure a transport without adding @protobuf-ts/* as a dependency.
+// Re-exported so users can configure a transport, and narrow and code the errors it produces,
+// without adding @protobuf-ts/* as a dependency.
+export { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
 export type { GrpcWebOptions } from '@protobuf-ts/grpcweb-transport';
+export { RpcError } from '@protobuf-ts/runtime-rpc';
 export type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 
 // Export all gRPC proto types as a namespace

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -27,11 +27,15 @@ function decodeGrpcStatusMessage(message: string): string {
 	}
 }
 
-function decodeStatusMessageOnce(error: RpcError): void {
-	if (MESSAGE_DECODED in error) return;
+function markStatusMessageRead(error: RpcError): boolean {
+	if (MESSAGE_DECODED in error) return false;
 	Object.defineProperty(error, MESSAGE_DECODED, { value: true, configurable: true });
 
-	error.message = decodeGrpcStatusMessage(error.message);
+	return true;
+}
+
+function decodeStatusMessageOnce(error: RpcError): void {
+	if (markStatusMessageRead(error)) error.message = decodeGrpcStatusMessage(error.message);
 }
 
 /** Whether this package's transport decoded the error's status text. */
@@ -67,6 +71,9 @@ function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): vo
 		(error.code === GrpcStatusCode[GrpcStatusCode.INTERNAL] ||
 			error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED])
 	) {
+		// The message is the abort reason's, so it is marked read without decoding. This also settles
+		// it for the other promises the call rejects, which no longer match the codes above.
+		markStatusMessageRead(error);
 		error.code = abortStatus(signal.reason);
 
 		return;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -11,18 +11,12 @@ import type {
 } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
-/**
- * A failed call rejects four promises with the same error object, so only decode it once. Registered
- * globally rather than module-local, so a transport from another installed copy of this package is
- * still recognised as having decoded.
- */
+// A failed call rejects four promises with the same error, so it is only decoded once. Registered
+// globally so another installed copy of this package sees the same marker.
 const MESSAGE_DECODED = Symbol.for('@mysten/sui/grpc/decoded-status-message');
 
-/**
- * Decodes `grpc-message`, which is percent-encoded on the wire and which the upstream transport
- * does not decode (https://github.com/timostamm/protobuf-ts/pull/739). The server escapes a literal
- * `%` as `%25`, so one decode is correct. Text that fails to decode is returned unchanged.
- */
+// `grpc-message` is percent-encoded on the wire and the upstream transport does not decode it:
+// https://github.com/timostamm/protobuf-ts/pull/739
 function decodeGrpcStatusMessage(message: string): string {
 	if (!message.includes('%')) return message;
 
@@ -40,30 +34,17 @@ function decodeStatusMessageOnce(error: RpcError): void {
 	error.message = decodeGrpcStatusMessage(error.message);
 }
 
-/**
- * Whether one of this package's transports has decoded the error's status text, in any installed
- * copy. False says nothing about the text itself: a transport this package did not build may hold
- * the wire form, or may have decoded it already.
- */
+/** Whether this package's transport decoded the error's status text. */
 export function hasDecodedStatusMessage(error: object): boolean {
 	return MESSAGE_DECODED in error;
 }
 
-/**
- * The status an abort should carry. The upstream transport uses `CANCELLED` only for an
- * `AbortError`, so a timeout or a reason of the caller's own arrives as `INTERNAL` and gets retried
- * as a server failure.
- *
- * The reason is caller-supplied data, read by shape rather than by `instanceof`: a second copy of
- * `@protobuf-ts/runtime-rpc`, or a signal from another realm, would fail an identity check and lose
- * the status. A reason carrying a gRPC status says what it is, and one named `TimeoutError` — which
- * is what `AbortSignal.timeout` aborts with — declares a deadline.
- */
+// The reason is read by shape, since another copy of runtime-rpc or another realm fails
+// `instanceof`. `AbortSignal.timeout` aborts with a `TimeoutError`.
 function abortStatus(reason: unknown): string {
 	const { code, name } = (reason ?? {}) as { code?: unknown; name?: unknown };
 
-	// `in` would also accept a numeric key of the enum's reverse mapping, or anything on the object
-	// prototype; a status name is the one that maps to a number.
+	// A status name maps to a number; `in` would also match the enum's reverse mapping.
 	if (
 		typeof code === 'string' &&
 		typeof GrpcStatusCode[code as keyof typeof GrpcStatusCode] === 'number'
@@ -76,15 +57,8 @@ function abortStatus(reason: unknown): string {
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
-/**
- * Rewrites the error in place, which keeps `instanceof RpcError`, the trailers and the stack, and
- * gives the same result on every promise the call rejects.
- *
- * An aborted call takes its status from the reason, and its message is left alone: what it holds is
- * the reason's own text, not `grpc-message`. A failure that merely raced the abort is relabelled
- * with it, which is the price of reading the signal rather than tracking where the failure came
- * from; the alternative is wrapping every request and response body to watch them.
- */
+// Rewritten in place, so every promise a call rejects surfaces the same error. Only the two codes
+// upstream uses for an abort are re-coded; a failure that raced the abort is relabelled with it.
 function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): void {
 	if (!(error instanceof RpcError)) return;
 
@@ -103,20 +77,17 @@ function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): vo
 
 function normalizeRejections(promises: Promise<unknown>[], signal: AbortSignal | undefined) {
 	for (const promise of promises) {
-		// Registered before the call is returned, so it runs before the consumer's own await. The
-		// original promise still rejects; this only changes the error it rejects with.
+		// Registered before the call is returned, so it runs before the consumer's own await.
 		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, signal));
 	}
 }
 
 /**
- * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix two defects it
- * has as of 2.11.1: status messages are left percent-encoded, and a call ended by a timeout or a
- * custom abort reason is coded `INTERNAL`. Fixing them here covers every consumer of a call.
+ * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to decode status
+ * messages and to code an aborted call from its reason rather than as `INTERNAL`.
  *
- * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients
- * or to subclass it further, then pass it as `transport`. A transport imported from
- * `@protobuf-ts/grpcweb-transport` keeps that package's behaviour.
+ * `SuiGrpcClient` builds one by default. A transport imported from `@protobuf-ts/grpcweb-transport`
+ * keeps that package's behaviour.
  */
 export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	override unary<I extends object, O extends object>(
@@ -138,8 +109,7 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	): ServerStreamingCall<I, O> {
 		const call = super.serverStreaming(method, input, options);
 
-		// A finite stream is often read through `responses` without awaiting `status`. Listeners run
-		// synchronously on error, so this lands before a `for await` resumes.
+		// A finite stream is often read through `responses` without awaiting `status`.
 		call.responses.onError((error) => normalizeGrpcError(error, options.abort));
 		normalizeRejections([call.headers, call.status, call.trailers], options.abort);
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -48,13 +48,19 @@ export function hasDecodedStatusMessage(error: RpcError): boolean {
 /**
  * The status an abort should carry. The upstream transport uses `CANCELLED` only for an
  * `AbortError`, so a timeout or a reason of the caller's own arrives as `INTERNAL` and gets retried
- * as a server failure. A reason that is already an `RpcError` says what it is, and a `DOMException`
- * named `TimeoutError` is what `AbortSignal.timeout` aborts with.
+ * as a server failure.
+ *
+ * The reason is caller-supplied data, read by shape rather than by `instanceof`: a second copy of
+ * `@protobuf-ts/runtime-rpc`, or a signal from another realm, would fail an identity check and lose
+ * the status. A reason carrying a gRPC status says what it is, and one named `TimeoutError` — which
+ * is what `AbortSignal.timeout` aborts with — declares a deadline.
  */
 function abortStatus(reason: unknown): string {
-	if (reason instanceof RpcError) return reason.code;
+	const { code, name } = (reason ?? {}) as { code?: unknown; name?: unknown };
 
-	return reason instanceof DOMException && reason.name === 'TimeoutError'
+	if (typeof code === 'string' && code in GrpcStatusCode) return code;
+
+	return name === 'TimeoutError'
 		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
@@ -86,7 +92,7 @@ function observingFetch(
 			// Spec fetch rejects with the reason itself; node-fetch substitutes its own `AbortError`.
 			if (
 				signal?.aborted &&
-				(error === signal.reason || (error instanceof Error && error.name === 'AbortError'))
+				(error === signal.reason || (error as { name?: unknown } | null)?.name === 'AbortError')
 			) {
 				state.abortCode = abortStatus(signal.reason);
 			}
@@ -132,7 +138,7 @@ function prepareCall(options: RpcOptions): { options: RpcOptions; state: CallSta
 
 /**
  * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix two defects it
- * has as of 2.11.1: status messages are left percent-encoded, and a call ended by a timeout or a
+ * has as of 2.11.1: status messages are left percent-encoded, and a request ended by a timeout or a
  * custom abort reason is coded `INTERNAL`. Fixing them here covers every consumer of a call.
  *
  * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -106,9 +106,40 @@ function normalizeRejections(promises: Promise<unknown>[], abort: AbortSignal | 
 }
 
 /**
+ * Turns `options.timeout` into a deadline this client enforces, by composing one into the signal
+ * the call aborts on.
+ *
+ * The base transport only puts `timeout` in the `grpc-timeout` header, which a node honours but
+ * which does nothing when the connection itself stalls: the call then hangs for as long as the
+ * fetch does. Sending the header as well is still right — the server should stop working on a
+ * request nobody is waiting for.
+ *
+ * Nothing is written to the options passed in. `mergeRpcOptions` returns the transport's own
+ * `defaultOptions` *by reference* when a generated method is called without call options, so
+ * assigning `abort` here would pin one call's deadline to every later call the client makes.
+ */
+function withDeadline(options: RpcOptions): RpcOptions {
+	if (options.timeout == null) return options;
+
+	const durationMs =
+		typeof options.timeout === 'number' ? options.timeout : options.timeout.getTime() - Date.now();
+
+	// An expired deadline is the base transport's to reject, which it does before sending anything.
+	if (durationMs <= 0) return options;
+
+	const deadline = AbortSignal.timeout(durationMs);
+
+	return {
+		...options,
+		abort: options.abort ? AbortSignal.any([options.abort, deadline]) : deadline,
+	};
+}
+
+/**
  * The grpc-web transport `@mysten/sui` ships: `@protobuf-ts/grpcweb-transport`'s, subclassed to
- * repair the two error defects it has as of 2.11.1 — status text arrives decoded, and a call cut
- * short by its own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`.
+ * repair three defects it has as of 2.11.1 — status text arrives decoded, a call cut short by its
+ * own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`, and `timeout` is a
+ * deadline this client enforces rather than one it only advertises to the server.
  *
  * Both belong to the transport — it is the layer that reads the wire — so this is where
  * `SuiGrpcClient` applies them, and every consumer of a call is served by one pass: `client.core`,
@@ -125,9 +156,13 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): UnaryCall<I, O> {
-		const call = super.unary(method, input, options);
+		const callOptions = withDeadline(options);
+		const call = super.unary(method, input, callOptions);
 
-		normalizeRejections([call.headers, call.response, call.status, call.trailers], options.abort);
+		normalizeRejections(
+			[call.headers, call.response, call.status, call.trailers],
+			callOptions.abort,
+		);
 
 		return call;
 	}
@@ -137,13 +172,16 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): ServerStreamingCall<I, O> {
-		const call = super.serverStreaming(method, input, options);
+		// A stream is bounded only if the caller asked for it to be: nothing here invents a deadline,
+		// so a subscription left without a `timeout` runs until it or the node ends it.
+		const callOptions = withDeadline(options);
+		const call = super.serverStreaming(method, input, callOptions);
 
 		// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
 		// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
 		// stream errors, so this rewrites the error before a `for await` resumes on it.
-		call.responses.onError((error) => normalizeGrpcError(error, options.abort));
-		normalizeRejections([call.headers, call.status, call.trailers], options.abort);
+		call.responses.onError((error) => normalizeGrpcError(error, callOptions.abort));
+		normalizeRejections([call.headers, call.status, call.trailers], callOptions.abort);
 
 		return call;
 	}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -51,23 +51,60 @@ function decodeStatusMessageOnce(error: RpcError): void {
 	error.message = decodeGrpcStatusMessage(error.message);
 }
 
+/** What one call was aborted by, as opposed to what happened to be aborted when it failed. */
+interface CallAbort {
+	/** The signal the call runs against: the caller's, the deadline below, or both composed. */
+	signal: AbortSignal | undefined;
+	/** The deadline this transport imposed for `options.timeout`, if it imposed one. */
+	deadline: AbortSignal | undefined;
+}
+
+/**
+ * Whether this error *is* the abort, rather than a failure that arrived while the call happened to
+ * be aborted.
+ *
+ * `signal.aborted` alone does not establish that. A call's headers resolve before a later
+ * server-side failure propagates, so a caller that aborts in a headers continuation — or simply
+ * races a truncated connection — would otherwise have a real `INTERNAL` rewritten as a
+ * cancellation. The transport rethrows the abort reason's own message verbatim, so carrying that
+ * message is what ties the failure to the abort.
+ */
+function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
+	const reason = signal.reason as { message?: unknown } | null | undefined;
+
+	return typeof reason?.message === 'string' && error.message === reason.message;
+}
+
+/**
+ * Whether the abort was a deadline expiring rather than someone cancelling.
+ *
+ * The deadline this transport composed is known by identity, not inferred: `AbortSignal.any`
+ * forwards the reason of whichever source fired, so comparing against it says which one did. A
+ * caller's own `AbortSignal.timeout` is a deadline too, and is recognised by its platform
+ * `DOMException` — which `Object.assign(new Error(), { name: 'TimeoutError' })` is not.
+ */
+function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
+	if (deadline?.aborted && signal?.reason === deadline.reason) return true;
+
+	return signal?.reason instanceof DOMException && signal.reason.name === 'TimeoutError';
+}
+
 /**
  * Codes a call that ended because its own signal aborted.
  *
  * The transport codes an aborted call `CANCELLED` only when the abort reason is an `AbortError`.
  * `AbortSignal.timeout` aborts with a `TimeoutError`, and `AbortController.abort(reason)` takes an
  * arbitrary reason, so both fall through to `INTERNAL` — indistinguishable from a server-side
- * failure, and retried as one. A deadline the caller set is a deadline exceeded; every other abort
- * is a cancellation.
+ * failure, and retried as one. A deadline is a deadline exceeded; every other abort is a
+ * cancellation.
  *
- * Idempotent without recording anything: re-running against the same signal reaches the same
- * answer, and a code outside the two the transport uses for an abort is left alone.
+ * Idempotent without recording anything: the same call and signal always reach the same answer.
  */
-function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void {
-	if (!abort?.aborted) return;
+function applyAbortStatus(error: RpcError, abort: CallAbort): void {
+	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return;
 
-	// A status the server actually answered with outranks the abort: it describes why the call
-	// failed, where the abort only says the caller stopped waiting.
+	// An abort reason that was itself an `RpcError` reaches the caller with the code they gave it,
+	// and a status the server answered with describes the failure better than the abort does.
 	if (
 		error.code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
 		error.code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
@@ -75,9 +112,7 @@ function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void
 		return;
 	}
 
-	const timedOut = (abort.reason as { name?: unknown } | null | undefined)?.name === 'TimeoutError';
-
-	error.code = timedOut
+	error.code = isDeadlineAbort(abort)
 		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
@@ -89,14 +124,16 @@ function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void
  * method names and the original stack, and means every promise a call rejects — plus its response
  * stream — surfaces the same normalized error.
  */
-function normalizeGrpcError(error: unknown, abort: AbortSignal | undefined): void {
+function normalizeGrpcError(error: unknown, abort: CallAbort): void {
 	if (!(error instanceof RpcError)) return;
 
-	decodeStatusMessageOnce(error);
+	// Coded before decoding, because provenance is established by comparing against the abort
+	// reason's message, and decoding rewrites the message being compared.
 	applyAbortStatus(error, abort);
+	decodeStatusMessageOnce(error);
 }
 
-function normalizeRejections(promises: Promise<unknown>[], abort: AbortSignal | undefined) {
+function normalizeRejections(promises: Promise<unknown>[], abort: CallAbort) {
 	for (const promise of promises) {
 		// Registered before the call is handed back, so this runs ahead of any consumer's continuation
 		// and the consumer's own `await` sees the rewritten error. Swallowing here is what the handler
@@ -118,21 +155,23 @@ function normalizeRejections(promises: Promise<unknown>[], abort: AbortSignal | 
  * `defaultOptions` *by reference* when a generated method is called without call options, so
  * assigning `abort` here would pin one call's deadline to every later call the client makes.
  */
-function withDeadline(options: RpcOptions): RpcOptions {
-	if (options.timeout == null) return options;
+function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAbort } {
+	if (options.timeout == null) {
+		return { options, abort: { signal: options.abort, deadline: undefined } };
+	}
 
 	const durationMs =
 		typeof options.timeout === 'number' ? options.timeout : options.timeout.getTime() - Date.now();
 
 	// An expired deadline is the base transport's to reject, which it does before sending anything.
-	if (durationMs <= 0) return options;
+	if (durationMs <= 0) {
+		return { options, abort: { signal: options.abort, deadline: undefined } };
+	}
 
 	const deadline = AbortSignal.timeout(durationMs);
+	const signal = options.abort ? AbortSignal.any([options.abort, deadline]) : deadline;
 
-	return {
-		...options,
-		abort: options.abort ? AbortSignal.any([options.abort, deadline]) : deadline,
-	};
+	return { options: { ...options, abort: signal }, abort: { signal, deadline } };
 }
 
 /**
@@ -146,9 +185,10 @@ function withDeadline(options: RpcOptions): RpcOptions {
  * the generated service clients, a response stream and any interceptor the caller installed.
  *
  * This is what `@mysten/sui/grpc` exports under this name and what `SuiGrpcClient` builds by
- * default. Construct it directly when you need transport options the client does not take, and
- * pass it as `transport`. A transport imported from `@protobuf-ts/grpcweb-transport` itself still
- * behaves the way that package behaves; the client does not reach into a transport it was handed.
+ * default from the options it is given. Construct it directly to share one transport between
+ * clients, or to subclass it further, and pass it as `transport`. A transport imported from
+ * `@protobuf-ts/grpcweb-transport` itself still behaves the way that package behaves; the client
+ * does not reach into a transport it was handed.
  */
 export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	override unary<I extends object, O extends object>(
@@ -156,13 +196,10 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): UnaryCall<I, O> {
-		const callOptions = withDeadline(options);
+		const { options: callOptions, abort } = withDeadline(options);
 		const call = super.unary(method, input, callOptions);
 
-		normalizeRejections(
-			[call.headers, call.response, call.status, call.trailers],
-			callOptions.abort,
-		);
+		normalizeRejections([call.headers, call.response, call.status, call.trailers], abort);
 
 		return call;
 	}
@@ -174,14 +211,14 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	): ServerStreamingCall<I, O> {
 		// A stream is bounded only if the caller asked for it to be: nothing here invents a deadline,
 		// so a subscription left without a `timeout` runs until it or the node ends it.
-		const callOptions = withDeadline(options);
+		const { options: callOptions, abort } = withDeadline(options);
 		const call = super.serverStreaming(method, input, callOptions);
 
 		// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
 		// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
 		// stream errors, so this rewrites the error before a `for await` resumes on it.
-		call.responses.onError((error) => normalizeGrpcError(error, callOptions.abort));
-		normalizeRejections([call.headers, call.status, call.trailers], callOptions.abort);
+		call.responses.onError((error) => normalizeGrpcError(error, abort));
+		normalizeRejections([call.headers, call.status, call.trailers], abort);
 
 		return call;
 	}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -85,33 +85,72 @@ interface CallState {
 }
 
 /**
- * Wraps `fetch` so a request that never returned a response is known as such, and so is an abort
- * that ended it. Read here rather than inferred from the error afterwards: a status the server
- * answered with arrives as a resolved response, so it can never be taken for a cancellation.
+ * Records that the request, rather than the server, is what failed — and whether the abort is what
+ * did it. Spec fetch rejects with the signal's reason itself; node-fetch substitutes its own
+ * `AbortError`.
+ */
+function markLocalFailure(error: unknown, signal: AbortSignal | undefined, state: CallState): void {
+	state.failedLocally = true;
+
+	if (
+		signal?.aborted &&
+		(error === signal.reason || (error as { name?: unknown } | null)?.name === 'AbortError')
+	) {
+		state.abortCode = abortStatus(signal.reason);
+	}
+}
+
+/**
+ * Wraps `fetch` so a failure of the request itself is known as such, whether it happened before the
+ * response arrived or while its body was being read. Read here rather than inferred from the error
+ * afterwards: a status the server answered with is parsed from a body that arrived intact, so it
+ * can never be taken for a cancellation, nor its text for a local diagnostic.
  *
- * A failure after the response arrives, such as an abort while a stream is being read or a body
- * that stops mid-frame, is not covered: it keeps whatever status the upstream transport gives it,
- * and its message is decoded as though it came off the wire. Covering those means wrapping the
- * response body as well, which costs a stream copy on every call.
+ * Errors raised while parsing that body — a truncated frame, a message that will not decode — are
+ * upstream's own, and still read as wire text.
  */
 function observingFetch(
 	base: typeof globalThis.fetch,
 	signal: AbortSignal | undefined,
 	state: CallState,
 ): typeof globalThis.fetch {
-	return (input, init) =>
-		base(input, init).catch((error: unknown) => {
-			state.failedLocally = true;
-			// Spec fetch rejects with the reason itself; node-fetch substitutes its own `AbortError`.
-			if (
-				signal?.aborted &&
-				(error === signal.reason || (error as { name?: unknown } | null)?.name === 'AbortError')
-			) {
-				state.abortCode = abortStatus(signal.reason);
-			}
+	return async (input, init) => {
+		let response: Response;
+
+		try {
+			response = await base(input, init);
+		} catch (error) {
+			markLocalFailure(error, signal, state);
 
 			throw error;
+		}
+
+		if (!response.body) return response;
+
+		const reader = response.body.getReader();
+		const body = new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				try {
+					const { done, value } = await reader.read();
+
+					if (done) controller.close();
+					else controller.enqueue(value);
+				} catch (error) {
+					markLocalFailure(error, signal, state);
+					controller.error(error);
+				}
+			},
+			cancel(reason) {
+				return reader.cancel(reason);
+			},
 		});
+
+		return new Response(body, {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
 }
 
 /**
@@ -151,7 +190,7 @@ function prepareCall(options: RpcOptions): { options: RpcOptions; state: CallSta
 
 /**
  * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix two defects it
- * has as of 2.11.1: status messages are left percent-encoded, and a request ended by a timeout or a
+ * has as of 2.11.1: status messages are left percent-encoded, and a call ended by a timeout or a
  * custom abort reason is coded `INTERNAL`. Fixing them here covers every consumer of a call.
  *
  * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -19,7 +19,7 @@ const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
  * does not decode (https://github.com/timostamm/protobuf-ts/pull/739). The server escapes a literal
  * `%` as `%25`, so one decode is correct. Text that fails to decode is returned unchanged.
  */
-export function decodeGrpcStatusMessage(message: string): string {
+function decodeGrpcStatusMessage(message: string): string {
 	if (!message.includes('%')) return message;
 
 	try {
@@ -37,12 +37,12 @@ function decodeStatusMessageOnce(error: RpcError): void {
 }
 
 /**
- * The status text of an error, decoded if nothing has decoded it yet. An error from a transport
- * this package did not build still holds the wire form, while one that has been decoded may hold a
- * literal `%20` that must not be decoded a second time.
+ * Whether this package's transport has decoded the error's status text. False says nothing about
+ * the text itself: a transport this package did not build may hold the wire form, or may have
+ * decoded it already.
  */
-export function grpcStatusMessage(error: RpcError): string {
-	return MESSAGE_DECODED in error ? error.message : decodeGrpcStatusMessage(error.message);
+export function hasDecodedStatusMessage(error: RpcError): boolean {
+	return MESSAGE_DECODED in error;
 }
 
 interface CallAbort {
@@ -150,8 +150,9 @@ function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAb
 
 /**
  * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix three defects it
- * has as of 2.11.1: status messages are left percent-encoded, an aborted call is coded `INTERNAL`,
- * and `timeout` is only advertised to the server. Fixing them here covers every consumer of a call.
+ * has as of 2.11.1: status messages are left percent-encoded, a timeout or a custom abort reason is
+ * coded `INTERNAL`, and `timeout` is only advertised to the server. Fixing them here covers every
+ * consumer of a call.
  *
  * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients
  * or to subclass it further, then pass it as `transport`. A transport imported from

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -11,8 +11,12 @@ import type {
 } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
-/** A failed call rejects four promises with the same error object, so only decode it once. */
-const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
+/**
+ * A failed call rejects four promises with the same error object, so only decode it once. Registered
+ * globally rather than module-local, so a transport from another installed copy of this package is
+ * still recognised as having decoded.
+ */
+const MESSAGE_DECODED = Symbol.for('@mysten/sui/grpc/decoded-status-message');
 
 /**
  * Decodes `grpc-message`, which is percent-encoded on the wire and which the upstream transport
@@ -37,9 +41,9 @@ function decodeStatusMessageOnce(error: RpcError): void {
 }
 
 /**
- * Whether this package's transport has decoded the error's status text. False says nothing about
- * the text itself: a transport this package did not build may hold the wire form, or may have
- * decoded it already.
+ * Whether one of this package's transports has decoded the error's status text, in any installed
+ * copy. False says nothing about the text itself: a transport this package did not build may hold
+ * the wire form, or may have decoded it already.
  */
 export function hasDecodedStatusMessage(error: RpcError): boolean {
 	return MESSAGE_DECODED in error;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -36,6 +36,15 @@ function decodeStatusMessageOnce(error: RpcError): void {
 	error.message = decodeGrpcStatusMessage(error.message);
 }
 
+/**
+ * The status text of an error, decoded if nothing has decoded it yet. An error from a transport
+ * this package did not build still holds the wire form, while one that has been decoded may hold a
+ * literal `%20` that must not be decoded a second time.
+ */
+export function grpcStatusMessage(error: RpcError): string {
+	return MESSAGE_DECODED in error ? error.message : decodeGrpcStatusMessage(error.message);
+}
+
 interface CallAbort {
 	/** What the call runs against: the caller's signal, the deadline below, or both composed. */
 	signal: AbortSignal | undefined;
@@ -46,19 +55,25 @@ interface CallAbort {
 /**
  * Whether the abort is what failed the call. `signal.aborted` is not enough, because headers
  * resolve before a later server failure propagates, so a call can be aborted while failing for an
- * unrelated reason. The transport reuses the abort reason's message, so matching it identifies the
- * abort.
+ * unrelated reason.
+ *
+ * The transport turns an abort into either `CANCELLED`, for a reason named `AbortError`, or an
+ * `INTERNAL` carrying the reason's own text. Some fetch implementations (node-fetch) substitute a
+ * generic `AbortError` for the reason, which is why the code is checked as well as the text.
  */
 function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
-	const reason = signal.reason as { message?: unknown } | null | undefined;
+	if (error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED]) return true;
 
-	return typeof reason?.message === 'string' && error.message === reason.message;
+	const reason = signal.reason;
+
+	return error.message === (reason instanceof Error ? reason.message : `${reason}`);
 }
 
 /**
- * Whether the abort was a deadline. `AbortSignal.any` forwards the reason of the signal that fired,
- * so the deadline below is matched by identity. A caller's `AbortSignal.timeout` aborts with a
- * `DOMException` named `TimeoutError`; a plain `Error` given that name does not count.
+ * Whether the abort was a deadline. A deadline this transport imposed is matched by identity, since
+ * `AbortSignal.any` forwards the reason of the signal that fired. Otherwise the caller's reason
+ * decides: a `DOMException` named `TimeoutError`, which is what `AbortSignal.timeout` aborts with,
+ * counts as a deadline they declared.
  */
 function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
 	if (deadline?.aborted && signal?.reason === deadline.reason) return true;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -107,7 +107,7 @@ function markLocalFailure(error: unknown, signal: AbortSignal | undefined, state
  * can never be taken for a cancellation, nor its text for a local diagnostic.
  *
  * Errors raised while parsing that body — a truncated frame, a message that will not decode — are
- * upstream's own, and still read as wire text.
+ * upstream's own, and still read as wire text, as is a failure in a body this cannot wrap.
  */
 function observingFetch(
 	base: typeof globalThis.fetch,
@@ -125,31 +125,46 @@ function observingFetch(
 			throw error;
 		}
 
-		if (!response.body) return response;
+		// Upstream reads a `node-fetch` body through `Symbol.asyncIterator` rather than `getReader`.
+		// Those are passed through untouched: a body failure there reads as it did before.
+		if (typeof response.body?.getReader !== 'function') return response;
 
-		const reader = response.body.getReader();
-		const body = new ReadableStream<Uint8Array>({
-			async pull(controller) {
-				try {
-					const { done, value } = await reader.read();
+		const source = response.body;
+		let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+		const body = new ReadableStream<Uint8Array>(
+			{
+				async pull(controller) {
+					try {
+						// Acquired on the first read, since taking a reader starts the source.
+						reader ??= source.getReader();
 
-					if (done) controller.close();
-					else controller.enqueue(value);
-				} catch (error) {
-					markLocalFailure(error, signal, state);
-					controller.error(error);
-				}
+						const { done, value } = await reader.read();
+
+						if (done) controller.close();
+						else controller.enqueue(value);
+					} catch (error) {
+						markLocalFailure(error, signal, state);
+						controller.error(error);
+					}
+				},
+				cancel(reason) {
+					return reader ? reader.cancel(reason) : source.cancel(reason);
+				},
 			},
-			cancel(reason) {
-				return reader.cancel(reason);
-			},
-		});
+			// Nothing is read until the transport asks for it, so a body that fails on its own cannot
+			// mark the call local while upstream is answering from a header status.
+			{ highWaterMark: 0 },
+		);
 
-		return new Response(body, {
+		// Handed back as a plain object rather than a `Response`: constructing one from a stream starts
+		// draining it immediately, which would read a body the transport may never ask for and buffer
+		// a subscription's stream without bound. Upstream reads only these four properties.
+		return {
 			status: response.status,
 			statusText: response.statusText,
 			headers: response.headers,
-		});
+			body,
+		} as unknown as Response;
 	};
 }
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -57,11 +57,14 @@ interface CallAbort {
  * resolve before a later server failure propagates, so a call can be aborted while failing for an
  * unrelated reason.
  *
- * The transport turns an abort into either `CANCELLED`, for a reason named `AbortError`, or an
- * `INTERNAL` carrying the reason's own text. Some fetch implementations (node-fetch) substitute a
- * generic `AbortError` for the reason, which is why the code is checked as well as the text.
+ * An error built from an abort carries no metadata, so anything holding response metadata is a
+ * status the server answered with. Past that, the transport turns an abort into either `CANCELLED`,
+ * for a reason named `AbortError`, or an `INTERNAL` carrying the reason's own text; some fetch
+ * implementations (node-fetch) substitute a generic `AbortError` for the reason, which is why the
+ * code is checked as well as the text.
  */
 function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
+	if (Object.keys(error.meta).length > 0) return false;
 	if (error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED]) return true;
 
 	const reason = signal.reason;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -34,7 +34,7 @@ const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
  * `a%20b`. Not every encoder is that careful (tonic 0.12 left `%` unescaped), so a message that
  * fails to decode is kept verbatim rather than failing a call over its status text.
  */
-function decodeGrpcStatusMessage(message: string): string {
+export function decodeGrpcStatusMessage(message: string): string {
 	if (!message.includes('%')) return message;
 
 	try {

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -61,6 +61,14 @@ function abortStatus(reason: unknown): string {
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
+// The transport reuses the abort reason's message, so matching it says the text is local. A fetch
+// that substitutes its own error (node-fetch) gives text of its own, which holds nothing to decode.
+function isAbortReasonText(message: string, reason: unknown): boolean {
+	const reasonMessage = (reason as { message?: unknown } | null)?.message;
+
+	return message === (typeof reasonMessage === 'string' ? reasonMessage : `${reason}`);
+}
+
 // Rewritten in place, so every promise a call rejects surfaces the same error. Only the two codes
 // upstream uses for an abort are re-coded; a failure that raced the abort is relabelled with it.
 function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): void {
@@ -71,10 +79,13 @@ function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): vo
 		(error.code === GrpcStatusCode[GrpcStatusCode.INTERNAL] ||
 			error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED])
 	) {
-		// The message is the abort reason's, so it is marked read without decoding. This also settles
-		// it for the other promises the call rejects, which no longer match the codes above.
-		markStatusMessageRead(error);
 		error.code = abortStatus(signal.reason);
+
+		// Text the abort reason supplied is local and holds nothing to decode; anything else came off
+		// the wire, even though the abort is what the caller sees. Settled here for the other promises
+		// the call rejects, which no longer match the codes above.
+		if (isAbortReasonText(error.message, signal.reason)) markStatusMessageRead(error);
+		else decodeStatusMessageOnce(error);
 
 		return;
 	}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -48,11 +48,45 @@ export function hasDecodedStatusMessage(error: RpcError): boolean {
 	return MESSAGE_DECODED in error;
 }
 
-interface CallAbort {
+interface CallState {
 	/** What the call runs against: the caller's signal, the deadline below, or both composed. */
 	signal: AbortSignal | undefined;
 	/** The deadline imposed for `options.timeout`, if there was one. */
 	deadline: AbortSignal | undefined;
+	/**
+	 * Set when the fetch rejected, so the failure was built from a local error rather than read off
+	 * the wire and holds no percent-encoded text.
+	 */
+	fetchFailed: boolean;
+}
+
+/** Reports a fetch that never delivered a response. The request itself is untouched. */
+function observingFetch(base: typeof globalThis.fetch, state: CallState): typeof globalThis.fetch {
+	return (input, init) =>
+		base(input, init).catch((error: unknown) => {
+			state.fetchFailed = true;
+
+			throw error;
+		});
+}
+
+/**
+ * A `grpc-timeout` value the server will accept. The header takes at most eight digits, and the
+ * upstream transport always writes milliseconds, so anything above about 27 hours goes out
+ * malformed. Rounded up, so the deadline sent is never shorter than the one asked for.
+ */
+function grpcTimeoutHeader(durationMs: number): string | undefined {
+	for (const [scale, unit] of [
+		[1, 'm'],
+		[1000, 'S'],
+		[60_000, 'M'],
+		[3_600_000, 'H'],
+	] as const) {
+		const value = Math.ceil(durationMs / scale);
+		if (value <= 99_999_999) return `${value}${unit}`;
+	}
+
+	return undefined;
 }
 
 /**
@@ -84,7 +118,7 @@ function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
  * decides: a `DOMException` named `TimeoutError`, which is what `AbortSignal.timeout` aborts with,
  * counts as a deadline they declared.
  */
-function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
+function isDeadlineAbort({ signal, deadline }: CallState): boolean {
 	if (deadline?.aborted && signal?.reason === deadline.reason) return true;
 
 	return signal?.reason instanceof DOMException && signal.reason.name === 'TimeoutError';
@@ -94,7 +128,7 @@ function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
  * Codes an aborted call. The upstream transport uses `CANCELLED` only for an `AbortError`, so a
  * timeout or a custom abort reason arrives as `INTERNAL` and gets retried as a server failure.
  */
-function applyAbortStatus(error: RpcError, abort: CallAbort): boolean {
+function applyAbortStatus(error: RpcError, abort: CallState): boolean {
 	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return false;
 
 	// The caller has already said what the status is. Copied rather than left alone, because a fetch
@@ -124,49 +158,78 @@ function applyAbortStatus(error: RpcError, abort: CallAbort): boolean {
  * Rewrites the error in place, which keeps `instanceof RpcError`, the trailers and the stack, and
  * gives the same result on every promise the call rejects.
  */
-function normalizeGrpcError(error: unknown, abort: CallAbort): void {
+function normalizeGrpcError(error: unknown, state: CallState): void {
 	if (!(error instanceof RpcError)) return;
 
 	// An error the abort produced carries the reason's own text, not `grpc-message`, so it is coded
 	// and left as it reads. Coding runs first either way, since decoding would rewrite the message
 	// `isAbortFailure` compares.
-	if (applyAbortStatus(error, abort)) return;
+	if (applyAbortStatus(error, state)) return;
+
+	// A fetch that never delivered a response failed with a local message, such as `request to
+	// http://host/a%2Fb failed`, which is not wire text to decode.
+	if (state.fetchFailed) return;
 
 	decodeStatusMessageOnce(error);
 }
 
-function normalizeRejections(promises: Promise<unknown>[], abort: CallAbort) {
+function normalizeRejections(promises: Promise<unknown>[], state: CallState) {
 	for (const promise of promises) {
 		// Registered before the call is returned, so it runs before the consumer's own await. The
 		// original promise still rejects; this only changes the error it rejects with.
-		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, abort));
+		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, state));
 	}
 }
 
 /**
- * Enforces `options.timeout` locally. The upstream transport only sends the `grpc-timeout` header,
- * which does not help when the connection stalls.
+ * Builds the options one call runs with: a deadline for `options.timeout`, a `grpc-timeout` header
+ * the server will accept, and a `fetch` that reports a request which never delivered a response.
+ *
+ * The upstream transport only sends the header, which does not help when the connection stalls, and
+ * always writes it in milliseconds, which is malformed above eight digits.
  *
  * The options are copied rather than written to. `mergeRpcOptions` returns the transport's
- * `defaultOptions` by reference for a call that passes no options of its own, so assigning `abort`
- * would apply one call's deadline to every later call.
+ * `defaultOptions` by reference for a call that passes no options of its own, so assigning to them
+ * would leak one call's deadline and fetch into every later call.
  */
-function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAbort } {
-	const unbounded = { options, abort: { signal: options.abort, deadline: undefined } };
-	if (options.timeout == null) return unbounded;
+function prepareCall(options: RpcOptions): { options: RpcOptions; state: CallState } {
+	const { fetch: callerFetch, meta } = options as RpcOptions & { fetch?: typeof globalThis.fetch };
+	const durationMs = timeoutDurationMs(options);
 
-	const durationMs =
-		typeof options.timeout === 'number' ? options.timeout : options.timeout.getTime() - Date.now();
+	// Past the timer ceiling `setTimeout` fires on the next tick, which would end the call at once,
+	// so those deadlines are left to the server. The upstream transport rejects an expired one
+	// itself, before sending anything.
+	const deadline =
+		durationMs !== undefined && durationMs > 0 && durationMs <= MAX_TIMER_DELAY_MS
+			? AbortSignal.timeout(durationMs)
+			: undefined;
+	const signal =
+		deadline && options.abort
+			? AbortSignal.any([options.abort, deadline])
+			: (deadline ?? options.abort);
+	const state: CallState = { signal, deadline, fetchFailed: false };
 
-	// The upstream transport rejects an expired deadline itself, before sending anything. A delay past
-	// the timer ceiling is left to the `grpc-timeout` header alone, since a timer given one fires on
-	// the next tick and would end the call immediately.
-	if (durationMs <= 0 || durationMs > MAX_TIMER_DELAY_MS) return unbounded;
+	// Written here only when the transport would write it malformed, so the common path is untouched.
+	const header =
+		durationMs !== undefined && durationMs > 99_999_999 ? grpcTimeoutHeader(durationMs) : undefined;
 
-	const deadline = AbortSignal.timeout(durationMs);
-	const signal = options.abort ? AbortSignal.any([options.abort, deadline]) : deadline;
+	return {
+		options: {
+			...options,
+			abort: signal,
+			fetch: observingFetch(callerFetch ?? globalThis.fetch, state),
+			...(header && { timeout: undefined, meta: { ...meta, 'grpc-timeout': header } }),
+		} as RpcOptions,
+		state,
+	};
+}
 
-	return { options: { ...options, abort: signal }, abort: { signal, deadline } };
+function timeoutDurationMs(options: RpcOptions): number | undefined {
+	if (options.timeout == null) return undefined;
+
+	return typeof options.timeout === 'number'
+		? options.timeout
+		: options.timeout.getTime() - Date.now();
 }
 
 /**
@@ -185,10 +248,10 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): UnaryCall<I, O> {
-		const { options: callOptions, abort } = withDeadline(options);
+		const { options: callOptions, state } = prepareCall(options);
 		const call = super.unary(method, input, callOptions);
 
-		normalizeRejections([call.headers, call.response, call.status, call.trailers], abort);
+		normalizeRejections([call.headers, call.response, call.status, call.trailers], state);
 
 		return call;
 	}
@@ -199,13 +262,13 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		options: RpcOptions,
 	): ServerStreamingCall<I, O> {
 		// No deadline is imposed, so a subscription without a `timeout` stays unbounded.
-		const { options: callOptions, abort } = withDeadline(options);
+		const { options: callOptions, state } = prepareCall(options);
 		const call = super.serverStreaming(method, input, callOptions);
 
 		// A finite stream is often read through `responses` without awaiting `status`. Listeners run
 		// synchronously on error, so this lands before a `for await` resumes.
-		call.responses.onError((error) => normalizeGrpcError(error, abort));
-		normalizeRejections([call.headers, call.status, call.trailers], abort);
+		call.responses.onError((error) => normalizeGrpcError(error, state));
+		normalizeRejections([call.headers, call.status, call.trailers], state);
 
 		return call;
 	}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -76,131 +76,37 @@ function abortStatus(reason: unknown): string {
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
-/** What one call learned from its own request, rather than guessed at from the error afterwards. */
-interface CallState {
-	/** Set when no response arrived, so the failure holds local text rather than `grpc-message`. */
-	failedLocally: boolean;
-	/** The status to give a call the abort ended. */
-	abortCode: string | undefined;
-}
-
-/**
- * Records that the request, rather than the server, is what failed — and whether the abort is what
- * did it. Spec fetch rejects with the signal's reason itself; node-fetch substitutes its own
- * `AbortError`.
- */
-function markLocalFailure(error: unknown, signal: AbortSignal | undefined, state: CallState): void {
-	state.failedLocally = true;
-
-	if (
-		signal?.aborted &&
-		(error === signal.reason || (error as { name?: unknown } | null)?.name === 'AbortError')
-	) {
-		state.abortCode = abortStatus(signal.reason);
-	}
-}
-
-/**
- * Wraps `fetch` so a failure of the request itself is known as such, whether it happened before the
- * response arrived or while its body was being read. Read here rather than inferred from the error
- * afterwards: a status the server answered with is parsed from a body that arrived intact, so it
- * can never be taken for a cancellation, nor its text for a local diagnostic.
- *
- * Errors raised while parsing that body — a truncated frame, a message that will not decode — are
- * upstream's own, and still read as wire text, as is a failure in a body this cannot wrap.
- */
-function observingFetch(
-	base: typeof globalThis.fetch,
-	signal: AbortSignal | undefined,
-	state: CallState,
-): typeof globalThis.fetch {
-	return async (input, init) => {
-		let response: Response;
-
-		try {
-			response = await base(input, init);
-		} catch (error) {
-			markLocalFailure(error, signal, state);
-
-			throw error;
-		}
-
-		// Upstream reads a `node-fetch` body through `Symbol.asyncIterator` rather than `getReader`.
-		// Those are passed through untouched: a body failure there reads as it did before.
-		if (typeof response.body?.getReader !== 'function') return response;
-
-		const source = response.body;
-		let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
-		const body = new ReadableStream<Uint8Array>(
-			{
-				async pull(controller) {
-					try {
-						// Acquired on the first read, since taking a reader starts the source.
-						reader ??= source.getReader();
-
-						const { done, value } = await reader.read();
-
-						if (done) controller.close();
-						else controller.enqueue(value);
-					} catch (error) {
-						markLocalFailure(error, signal, state);
-						controller.error(error);
-					}
-				},
-				cancel(reason) {
-					return reader ? reader.cancel(reason) : source.cancel(reason);
-				},
-			},
-			// Nothing is read until the transport asks for it, so a body that fails on its own cannot
-			// mark the call local while upstream is answering from a header status.
-			{ highWaterMark: 0 },
-		);
-
-		// Handed back as a plain object rather than a `Response`: constructing one from a stream starts
-		// draining it immediately, which would read a body the transport may never ask for and buffer
-		// a subscription's stream without bound. Upstream reads only these four properties.
-		return {
-			status: response.status,
-			statusText: response.statusText,
-			headers: response.headers,
-			body,
-		} as unknown as Response;
-	};
-}
-
 /**
  * Rewrites the error in place, which keeps `instanceof RpcError`, the trailers and the stack, and
  * gives the same result on every promise the call rejects.
+ *
+ * An aborted call takes its status from the reason, and its message is left alone: what it holds is
+ * the reason's own text, not `grpc-message`. A failure that merely raced the abort is relabelled
+ * with it, which is the price of reading the signal rather than tracking where the failure came
+ * from; the alternative is wrapping every request and response body to watch them.
  */
-function normalizeGrpcError(error: unknown, state: CallState): void {
+function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): void {
 	if (!(error instanceof RpcError)) return;
 
-	if (state.abortCode) error.code = state.abortCode;
+	if (
+		signal?.aborted &&
+		(error.code === GrpcStatusCode[GrpcStatusCode.INTERNAL] ||
+			error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED])
+	) {
+		error.code = abortStatus(signal.reason);
 
-	// Local text — an abort reason, or something like `request to http://host/a%2Fb failed` — is not
-	// `grpc-message`, and holds nothing to decode.
-	if (!state.failedLocally) decodeStatusMessageOnce(error);
+		return;
+	}
+
+	decodeStatusMessageOnce(error);
 }
 
-function normalizeRejections(promises: Promise<unknown>[], state: CallState) {
+function normalizeRejections(promises: Promise<unknown>[], signal: AbortSignal | undefined) {
 	for (const promise of promises) {
 		// Registered before the call is returned, so it runs before the consumer's own await. The
 		// original promise still rejects; this only changes the error it rejects with.
-		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, state));
+		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, signal));
 	}
-}
-
-/**
- * The options one call runs with, copied rather than written to: `mergeRpcOptions` returns the
- * transport's `defaultOptions` by reference for a call that passes none of its own, so assigning to
- * them would leak one call's `fetch` into every later call.
- */
-function prepareCall(options: RpcOptions): { options: RpcOptions; state: CallState } {
-	const { fetch: callerFetch } = options as RpcOptions & { fetch?: typeof globalThis.fetch };
-	const state: CallState = { failedLocally: false, abortCode: undefined };
-	const fetch = observingFetch(callerFetch ?? globalThis.fetch, options.abort, state);
-
-	return { options: { ...options, fetch } as RpcOptions, state };
 }
 
 /**
@@ -218,10 +124,9 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): UnaryCall<I, O> {
-		const { options: callOptions, state } = prepareCall(options);
-		const call = super.unary(method, input, callOptions);
+		const call = super.unary(method, input, options);
 
-		normalizeRejections([call.headers, call.response, call.status, call.trailers], state);
+		normalizeRejections([call.headers, call.response, call.status, call.trailers], options.abort);
 
 		return call;
 	}
@@ -231,13 +136,12 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): ServerStreamingCall<I, O> {
-		const { options: callOptions, state } = prepareCall(options);
-		const call = super.serverStreaming(method, input, callOptions);
+		const call = super.serverStreaming(method, input, options);
 
 		// A finite stream is often read through `responses` without awaiting `status`. Listeners run
 		// synchronously on error, so this lands before a `for await` resumes.
-		call.responses.onError((error) => normalizeGrpcError(error, state));
-		normalizeRejections([call.headers, call.status, call.trailers], state);
+		call.responses.onError((error) => normalizeGrpcError(error, options.abort));
+		normalizeRejections([call.headers, call.status, call.trailers], options.abort);
 
 		return call;
 	}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -88,20 +88,26 @@ function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
  * Codes an aborted call. The upstream transport uses `CANCELLED` only for an `AbortError`, so a
  * timeout or a custom abort reason arrives as `INTERNAL` and gets retried as a server failure.
  */
-function applyAbortStatus(error: RpcError, abort: CallAbort): void {
-	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return;
+function applyAbortStatus(error: RpcError, abort: CallAbort): boolean {
+	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return false;
 
-	// Any other code came from the server, or from an abort reason the caller coded themselves.
+	// The transport passes an `RpcError` reason through as the failure itself, so the caller has
+	// already said what the status is.
+	if (abort.signal.reason instanceof RpcError) return true;
+
+	// Any other code came from the server.
 	if (
 		error.code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
 		error.code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
 	) {
-		return;
+		return false;
 	}
 
 	error.code = isDeadlineAbort(abort)
 		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
+
+	return true;
 }
 
 /**
@@ -111,8 +117,11 @@ function applyAbortStatus(error: RpcError, abort: CallAbort): void {
 function normalizeGrpcError(error: unknown, abort: CallAbort): void {
 	if (!(error instanceof RpcError)) return;
 
-	// Coded first, because decoding rewrites the message `isAbortFailure` compares.
-	applyAbortStatus(error, abort);
+	// An error the abort produced carries the reason's own text, not `grpc-message`, so it is coded
+	// and left as it reads. Coding runs first either way, since decoding would rewrite the message
+	// `isAbortFailure` compares.
+	if (applyAbortStatus(error, abort)) return;
+
 	decodeStatusMessageOnce(error);
 }
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { GrpcStatusCode, GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+import { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
+import { GrpcWebFetchTransport as UpstreamGrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 import type {
 	MethodInfo,
 	RpcOptions,
@@ -104,20 +105,20 @@ function normalizeRejections(promises: Promise<unknown>[], abort: AbortSignal | 
 }
 
 /**
- * `GrpcWebFetchTransport` with the two error defects it has as of `@protobuf-ts/grpcweb-transport`
- * 2.11.1 repaired: status text arrives decoded, and a call cut short by its own signal is coded
- * `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`.
+ * The grpc-web transport `@mysten/sui` ships: `@protobuf-ts/grpcweb-transport`'s, subclassed to
+ * repair the two error defects it has as of 2.11.1 — status text arrives decoded, and a call cut
+ * short by its own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`.
  *
  * Both belong to the transport — it is the layer that reads the wire — so this is where
  * `SuiGrpcClient` applies them, and every consumer of a call is served by one pass: `client.core`,
  * the generated service clients, a response stream and any interceptor the caller installed.
  *
- * `SuiGrpcClient` builds one of these by default. Construct it directly when you need transport
- * options the client does not take, or pass it as `transport`. A plain `GrpcWebFetchTransport`
- * imported from `@protobuf-ts/grpcweb-transport` still behaves the way that package behaves; the
- * client does not reach into a transport it was handed.
+ * This is what `@mysten/sui/grpc` exports under this name and what `SuiGrpcClient` builds by
+ * default. Construct it directly when you need transport options the client does not take, and
+ * pass it as `transport`. A transport imported from `@protobuf-ts/grpcweb-transport` itself still
+ * behaves the way that package behaves; the client does not reach into a transport it was handed.
  */
-export class SuiGrpcWebTransport extends GrpcWebFetchTransport {
+export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	override unary<I extends object, O extends object>(
 		method: MethodInfo<I, O>,
 		input: I,

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -11,6 +11,9 @@ import type {
 } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
+/** What `setTimeout` takes before it overflows and fires on the next tick instead. */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 /** A failed call rejects four promises with the same error object, so only decode it once. */
 const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
 
@@ -64,6 +67,9 @@ interface CallAbort {
  * code is checked as well as the text.
  */
 function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
+	// The reason itself, which the transport passes through when it is already an `RpcError`.
+	if ((error as unknown) === signal.reason) return true;
+
 	if (Object.keys(error.meta).length > 0) return false;
 	if (error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED]) return true;
 
@@ -91,9 +97,13 @@ function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
 function applyAbortStatus(error: RpcError, abort: CallAbort): boolean {
 	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return false;
 
-	// The transport passes an `RpcError` reason through as the failure itself, so the caller has
-	// already said what the status is.
-	if (abort.signal.reason instanceof RpcError) return true;
+	// The caller has already said what the status is. Copied rather than left alone, because a fetch
+	// that substitutes its own `AbortError` for the reason (node-fetch) never propagates theirs.
+	if (abort.signal.reason instanceof RpcError) {
+		error.code = abort.signal.reason.code;
+
+		return true;
+	}
 
 	// Any other code came from the server.
 	if (
@@ -148,8 +158,10 @@ function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAb
 	const durationMs =
 		typeof options.timeout === 'number' ? options.timeout : options.timeout.getTime() - Date.now();
 
-	// The upstream transport rejects an expired deadline itself, before sending anything.
-	if (durationMs <= 0) return unbounded;
+	// The upstream transport rejects an expired deadline itself, before sending anything. A delay past
+	// the timer ceiling is left to the `grpc-timeout` header alone, since a timer given one fires on
+	// the next tick and would end the call immediately.
+	if (durationMs <= 0 || durationMs > MAX_TIMER_DELAY_MS) return unbounded;
 
 	const deadline = AbortSignal.timeout(durationMs);
 	const signal = options.abort ? AbortSignal.any([options.abort, deadline]) : deadline;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -43,10 +43,22 @@ export function hasDecodedStatusMessage(error: object): boolean {
 	return MESSAGE_DECODED in error;
 }
 
+// An abort reason is arbitrary, and reading a property on it runs code the caller wrote. A read
+// that throws counts as absent, so one bad accessor does not decide the status.
+function readProperty(value: unknown, key: 'code' | 'name' | 'message'): unknown {
+	if (typeof value !== 'object' || value === null) return undefined;
+
+	try {
+		return (value as Record<string, unknown>)[key];
+	} catch {
+		return undefined;
+	}
+}
+
 // The reason is read by shape, since another copy of runtime-rpc or another realm fails
 // `instanceof`. `AbortSignal.timeout` aborts with a `TimeoutError`.
 function abortStatus(reason: unknown): string {
-	const { code, name } = (reason ?? {}) as { code?: unknown; name?: unknown };
+	const code = readProperty(reason, 'code');
 
 	// A status name maps to a number; `in` would also match the enum's reverse mapping.
 	if (
@@ -56,18 +68,18 @@ function abortStatus(reason: unknown): string {
 		return code;
 	}
 
-	return name === 'TimeoutError'
+	return readProperty(reason, 'name') === 'TimeoutError'
 		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
 // The transport reuses the abort reason's message, so matching it says the text is local. A fetch
 // that substitutes its own error (node-fetch) gives text of its own, which holds nothing to decode.
-// The reason is arbitrary, so it is never coerced: a symbol or a throwing hook would throw here.
+// The reason is never coerced: a symbol or a throwing hook would throw here.
 function isAbortReasonText(message: string, reason: unknown): boolean {
 	if (typeof reason === 'string') return message === reason;
 
-	const reasonMessage = (reason as { message?: unknown } | null)?.message;
+	const reasonMessage = readProperty(reason, 'message');
 
 	return typeof reasonMessage === 'string' && message === reasonMessage;
 }
@@ -78,8 +90,8 @@ function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): vo
 	try {
 		normalize(error, signal);
 	} catch {
-		// Reading an abort reason runs code the caller supplied. A call reports whatever it was going
-		// to report rather than this, and never an unhandled rejection from a discarded handler.
+		// Never an unhandled rejection from a discarded handler: the call reports what it was going
+		// to report.
 	}
 }
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
+import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
+import { RpcError } from '@protobuf-ts/runtime-rpc';
+
+/**
+ * Marks an error this module has already normalized. A single failed call rejects its headers,
+ * response, status and trailers with the *same* error object, so without a marker a message that
+ * legitimately reads `a%20b` would be rewritten once per promise.
+ */
+const NORMALIZED = Symbol('@mysten/sui/grpc/normalized-error');
+
+/**
+ * `grpc-message` is percent-encoded on the wire, and the grpc-web transport reads the header
+ * verbatim (https://github.com/timostamm/protobuf-ts/pull/739), so status text otherwise reaches
+ * callers as `Object%20not%20found%3A%200x1`.
+ *
+ * A node is a correct percent-encoder — it escapes a literal `%` as `%25` — so decoding exactly
+ * once is right: `gas budget 100%25 consumed` is readable text, and `read_mask path: a%2520b`
+ * really does end in `a%20b`. A message that fails to decode was not written by a percent-encoder,
+ * so it is kept verbatim rather than failing a call over its status text.
+ */
+function decodeGrpcStatusMessage(message: string): string {
+	if (!message.includes('%')) return message;
+
+	try {
+		return decodeURIComponent(message);
+	} catch {
+		return message;
+	}
+}
+
+/**
+ * Makes a transport error readable and correctly coded, in place, at most once.
+ *
+ * Mutating rather than re-wrapping keeps `instanceof RpcError`, the status code, trailing metadata,
+ * the service and method names and the original stack, and means every promise a call rejects —
+ * plus its response stream — surfaces the same normalized error.
+ */
+function normalizeGrpcError(error: unknown, abort?: AbortSignal): void {
+	if (!(error instanceof RpcError) || NORMALIZED in error) return;
+	Object.defineProperty(error, NORMALIZED, { value: true, configurable: true });
+
+	error.message = decodeGrpcStatusMessage(error.message);
+
+	// The transport codes an aborted call `CANCELLED` only for an `AbortError`. `AbortSignal.timeout`
+	// aborts with a `TimeoutError`, which falls through to `INTERNAL` — indistinguishable from a
+	// server-side failure, and retried as one. A deadline the caller set is a deadline exceeded.
+	if (
+		abort?.aborted &&
+		(abort.reason as { name?: unknown } | null | undefined)?.name === 'TimeoutError' &&
+		(error.code === GrpcStatusCode[GrpcStatusCode.INTERNAL] ||
+			error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED])
+	) {
+		error.code = GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED];
+	}
+}
+
+function normalizeRejections(abort: AbortSignal | undefined, promises: Promise<unknown>[]) {
+	for (const promise of promises) {
+		// Registered before the call is handed back, so this runs ahead of any consumer's continuation
+		// and the consumer's own `await` sees the rewritten error. Swallowing here is what the handler
+		// is for: the original promise still rejects for whoever awaits it.
+		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, abort));
+	}
+}
+
+/**
+ * Wraps a transport so that every error it produces is normalized once, at the wire boundary,
+ * before any consumer sees it — `client.core` methods, the generated service clients, and any
+ * interceptors the caller installed alike.
+ */
+export function withNormalizedErrors(transport: RpcTransport): RpcTransport {
+	return {
+		mergeOptions(options) {
+			return transport.mergeOptions(options);
+		},
+
+		unary(method, input, options) {
+			const call = transport.unary(method, input, options);
+
+			normalizeRejections(options.abort, [call.headers, call.response, call.status, call.trailers]);
+
+			return call;
+		},
+
+		serverStreaming(method, input, options) {
+			const call = transport.serverStreaming(method, input, options);
+
+			// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
+			// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
+			// stream errors, so this rewrites the error before a `for await` resumes on it.
+			call.responses.onError((error) => normalizeGrpcError(error, options.abort));
+			normalizeRejections(options.abort, [call.headers, call.status, call.trailers]);
+
+			return call;
+		},
+
+		clientStreaming(method, options) {
+			return transport.clientStreaming(method, options);
+		},
+
+		duplex(method, options) {
+			return transport.duplex(method, options);
+		},
+	};
+}

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -11,9 +11,6 @@ import type {
 } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
-/** What `setTimeout` takes before it overflows and fires on the next tick instead. */
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
-
 /** A failed call rejects four promises with the same error object, so only decode it once. */
 const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
 
@@ -48,110 +45,54 @@ export function hasDecodedStatusMessage(error: RpcError): boolean {
 	return MESSAGE_DECODED in error;
 }
 
-interface CallState {
-	/** What the call runs against: the caller's signal, the deadline below, or both composed. */
-	signal: AbortSignal | undefined;
-	/** The deadline imposed for `options.timeout`, if there was one. */
-	deadline: AbortSignal | undefined;
-	/**
-	 * Set when the fetch rejected, so the failure was built from a local error rather than read off
-	 * the wire and holds no percent-encoded text.
-	 */
-	fetchFailed: boolean;
+/**
+ * The status an abort should carry. The upstream transport uses `CANCELLED` only for an
+ * `AbortError`, so a timeout or a reason of the caller's own arrives as `INTERNAL` and gets retried
+ * as a server failure. A reason that is already an `RpcError` says what it is, and a `DOMException`
+ * named `TimeoutError` is what `AbortSignal.timeout` aborts with.
+ */
+function abortStatus(reason: unknown): string {
+	if (reason instanceof RpcError) return reason.code;
+
+	return reason instanceof DOMException && reason.name === 'TimeoutError'
+		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
+		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
-/** Reports a fetch that never delivered a response. The request itself is untouched. */
-function observingFetch(base: typeof globalThis.fetch, state: CallState): typeof globalThis.fetch {
+/** What one call learned from its own request, rather than guessed at from the error afterwards. */
+interface CallState {
+	/** Set when no response arrived, so the failure holds local text rather than `grpc-message`. */
+	failedLocally: boolean;
+	/** The status to give a call the abort ended. */
+	abortCode: string | undefined;
+}
+
+/**
+ * Wraps `fetch` so a request that never returned a response is known as such, and so is an abort
+ * that ended it. Read here rather than inferred from the error afterwards: a status the server
+ * answered with arrives as a resolved response, so it can never be taken for a cancellation.
+ *
+ * A failure after the response arrives, such as an abort while a stream is being read, is not
+ * covered, and keeps whatever status the upstream transport gives it.
+ */
+function observingFetch(
+	base: typeof globalThis.fetch,
+	signal: AbortSignal | undefined,
+	state: CallState,
+): typeof globalThis.fetch {
 	return (input, init) =>
 		base(input, init).catch((error: unknown) => {
-			state.fetchFailed = true;
+			state.failedLocally = true;
+			// Spec fetch rejects with the reason itself; node-fetch substitutes its own `AbortError`.
+			if (
+				signal?.aborted &&
+				(error === signal.reason || (error instanceof Error && error.name === 'AbortError'))
+			) {
+				state.abortCode = abortStatus(signal.reason);
+			}
 
 			throw error;
 		});
-}
-
-/**
- * A `grpc-timeout` value the server will accept. The header takes at most eight digits, and the
- * upstream transport always writes milliseconds, so anything above about 27 hours goes out
- * malformed. Rounded up, so the deadline sent is never shorter than the one asked for.
- */
-function grpcTimeoutHeader(durationMs: number): string | undefined {
-	for (const [scale, unit] of [
-		[1, 'm'],
-		[1000, 'S'],
-		[60_000, 'M'],
-		[3_600_000, 'H'],
-	] as const) {
-		const value = Math.ceil(durationMs / scale);
-		if (value <= 99_999_999) return `${value}${unit}`;
-	}
-
-	return undefined;
-}
-
-/**
- * Whether the abort is what failed the call. `signal.aborted` is not enough, because headers
- * resolve before a later server failure propagates, so a call can be aborted while failing for an
- * unrelated reason.
- *
- * An error built from an abort carries no metadata, so anything holding response metadata is a
- * status the server answered with. Past that, the transport turns an abort into either `CANCELLED`,
- * for a reason named `AbortError`, or an `INTERNAL` carrying the reason's own text; some fetch
- * implementations (node-fetch) substitute a generic `AbortError` for the reason, which is why the
- * code is checked as well as the text.
- */
-function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
-	// The reason itself, which the transport passes through when it is already an `RpcError`.
-	if ((error as unknown) === signal.reason) return true;
-
-	if (Object.keys(error.meta).length > 0) return false;
-	if (error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED]) return true;
-
-	const reason = signal.reason;
-
-	return error.message === (reason instanceof Error ? reason.message : `${reason}`);
-}
-
-/**
- * Whether the abort was a deadline. A deadline this transport imposed is matched by identity, since
- * `AbortSignal.any` forwards the reason of the signal that fired. Otherwise the caller's reason
- * decides: a `DOMException` named `TimeoutError`, which is what `AbortSignal.timeout` aborts with,
- * counts as a deadline they declared.
- */
-function isDeadlineAbort({ signal, deadline }: CallState): boolean {
-	if (deadline?.aborted && signal?.reason === deadline.reason) return true;
-
-	return signal?.reason instanceof DOMException && signal.reason.name === 'TimeoutError';
-}
-
-/**
- * Codes an aborted call. The upstream transport uses `CANCELLED` only for an `AbortError`, so a
- * timeout or a custom abort reason arrives as `INTERNAL` and gets retried as a server failure.
- */
-function applyAbortStatus(error: RpcError, abort: CallState): boolean {
-	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return false;
-
-	// The caller has already said what the status is. Copied rather than left alone, because a fetch
-	// that substitutes its own `AbortError` for the reason (node-fetch) never propagates theirs.
-	if (abort.signal.reason instanceof RpcError) {
-		error.code = abort.signal.reason.code;
-
-		return true;
-	}
-
-	// Any other code came from the server.
-	if (
-		error.code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
-		error.code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
-	) {
-		return false;
-	}
-
-	error.code = isDeadlineAbort(abort)
-		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
-		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
-
-	return true;
 }
 
 /**
@@ -161,16 +102,11 @@ function applyAbortStatus(error: RpcError, abort: CallState): boolean {
 function normalizeGrpcError(error: unknown, state: CallState): void {
 	if (!(error instanceof RpcError)) return;
 
-	// An error the abort produced carries the reason's own text, not `grpc-message`, so it is coded
-	// and left as it reads. Coding runs first either way, since decoding would rewrite the message
-	// `isAbortFailure` compares.
-	if (applyAbortStatus(error, state)) return;
+	if (state.abortCode) error.code = state.abortCode;
 
-	// A fetch that never delivered a response failed with a local message, such as `request to
-	// http://host/a%2Fb failed`, which is not wire text to decode.
-	if (state.fetchFailed) return;
-
-	decodeStatusMessageOnce(error);
+	// Local text — an abort reason, or something like `request to http://host/a%2Fb failed` — is not
+	// `grpc-message`, and holds nothing to decode.
+	if (!state.failedLocally) decodeStatusMessageOnce(error);
 }
 
 function normalizeRejections(promises: Promise<unknown>[], state: CallState) {
@@ -182,61 +118,22 @@ function normalizeRejections(promises: Promise<unknown>[], state: CallState) {
 }
 
 /**
- * Builds the options one call runs with: a deadline for `options.timeout`, a `grpc-timeout` header
- * the server will accept, and a `fetch` that reports a request which never delivered a response.
- *
- * The upstream transport only sends the header, which does not help when the connection stalls, and
- * always writes it in milliseconds, which is malformed above eight digits.
- *
- * The options are copied rather than written to. `mergeRpcOptions` returns the transport's
- * `defaultOptions` by reference for a call that passes no options of its own, so assigning to them
- * would leak one call's deadline and fetch into every later call.
+ * The options one call runs with, copied rather than written to: `mergeRpcOptions` returns the
+ * transport's `defaultOptions` by reference for a call that passes none of its own, so assigning to
+ * them would leak one call's `fetch` into every later call.
  */
 function prepareCall(options: RpcOptions): { options: RpcOptions; state: CallState } {
-	const { fetch: callerFetch, meta } = options as RpcOptions & { fetch?: typeof globalThis.fetch };
-	const durationMs = timeoutDurationMs(options);
+	const { fetch: callerFetch } = options as RpcOptions & { fetch?: typeof globalThis.fetch };
+	const state: CallState = { failedLocally: false, abortCode: undefined };
+	const fetch = observingFetch(callerFetch ?? globalThis.fetch, options.abort, state);
 
-	// Past the timer ceiling `setTimeout` fires on the next tick, which would end the call at once,
-	// so those deadlines are left to the server. The upstream transport rejects an expired one
-	// itself, before sending anything.
-	const deadline =
-		durationMs !== undefined && durationMs > 0 && durationMs <= MAX_TIMER_DELAY_MS
-			? AbortSignal.timeout(durationMs)
-			: undefined;
-	const signal =
-		deadline && options.abort
-			? AbortSignal.any([options.abort, deadline])
-			: (deadline ?? options.abort);
-	const state: CallState = { signal, deadline, fetchFailed: false };
-
-	// Written here only when the transport would write it malformed, so the common path is untouched.
-	const header =
-		durationMs !== undefined && durationMs > 99_999_999 ? grpcTimeoutHeader(durationMs) : undefined;
-
-	return {
-		options: {
-			...options,
-			abort: signal,
-			fetch: observingFetch(callerFetch ?? globalThis.fetch, state),
-			...(header && { timeout: undefined, meta: { ...meta, 'grpc-timeout': header } }),
-		} as RpcOptions,
-		state,
-	};
-}
-
-function timeoutDurationMs(options: RpcOptions): number | undefined {
-	if (options.timeout == null) return undefined;
-
-	return typeof options.timeout === 'number'
-		? options.timeout
-		: options.timeout.getTime() - Date.now();
+	return { options: { ...options, fetch } as RpcOptions, state };
 }
 
 /**
- * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix three defects it
- * has as of 2.11.1: status messages are left percent-encoded, a timeout or a custom abort reason is
- * coded `INTERNAL`, and `timeout` is only advertised to the server. Fixing them here covers every
- * consumer of a call.
+ * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix two defects it
+ * has as of 2.11.1: status messages are left percent-encoded, and a call ended by a timeout or a
+ * custom abort reason is coded `INTERNAL`. Fixing them here covers every consumer of a call.
  *
  * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients
  * or to subclass it further, then pass it as `transport`. A transport imported from
@@ -261,7 +158,6 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): ServerStreamingCall<I, O> {
-		// No deadline is imposed, so a subscription without a `timeout` stays unbounded.
 		const { options: callOptions, state } = prepareCall(options);
 		const call = super.serverStreaming(method, input, callOptions);
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -45,7 +45,7 @@ function decodeStatusMessageOnce(error: RpcError): void {
  * copy. False says nothing about the text itself: a transport this package did not build may hold
  * the wire form, or may have decoded it already.
  */
-export function hasDecodedStatusMessage(error: RpcError): boolean {
+export function hasDecodedStatusMessage(error: object): boolean {
 	return MESSAGE_DECODED in error;
 }
 
@@ -62,7 +62,14 @@ export function hasDecodedStatusMessage(error: RpcError): boolean {
 function abortStatus(reason: unknown): string {
 	const { code, name } = (reason ?? {}) as { code?: unknown; name?: unknown };
 
-	if (typeof code === 'string' && code in GrpcStatusCode) return code;
+	// `in` would also accept a numeric key of the enum's reverse mapping, or anything on the object
+	// prototype; a status name is the one that maps to a number.
+	if (
+		typeof code === 'string' &&
+		typeof GrpcStatusCode[code as keyof typeof GrpcStatusCode] === 'number'
+	) {
+		return code;
+	}
 
 	return name === 'TimeoutError'
 		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
@@ -82,8 +89,10 @@ interface CallState {
  * that ended it. Read here rather than inferred from the error afterwards: a status the server
  * answered with arrives as a resolved response, so it can never be taken for a cancellation.
  *
- * A failure after the response arrives, such as an abort while a stream is being read, is not
- * covered, and keeps whatever status the upstream transport gives it.
+ * A failure after the response arrives, such as an abort while a stream is being read or a body
+ * that stops mid-frame, is not covered: it keeps whatever status the upstream transport gives it,
+ * and its message is decoded as though it came off the wire. Covering those means wrapping the
+ * response body as well, which costs a stream copy on every call.
  */
 function observingFetch(
 	base: typeof globalThis.fetch,

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -1,25 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { GrpcStatusCode } from '@protobuf-ts/grpcweb-transport';
-import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
+import { GrpcStatusCode, GrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
+import type {
+	MethodInfo,
+	RpcOptions,
+	ServerStreamingCall,
+	UnaryCall,
+} from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
 /**
- * Marks an error whose message this module has already decoded. A single failed call rejects its
- * headers, response, status and trailers with the *same* error object, so without a marker a
- * message that legitimately reads `a%20b` would be rewritten once per promise.
+ * Marks an error whose message has already been decoded. One failed call rejects its headers,
+ * response, status and trailers with the *same* error object, so without a marker a message that
+ * legitimately reads `a%20b` would be rewritten once per promise.
  *
- * Only the decode is recorded here, because it is a property of the message: decoding text that
- * has already been decoded is what the marker exists to prevent, and the answer does not depend on
- * which call is asking. Nothing call-specific is stored on the error — see {@link applyAbortStatus}.
+ * This records a property of the message, not of the call: whether text has already been decoded
+ * does not depend on who is asking. Nothing call-specific is stored on the error — {@link
+ * applyAbortStatus} re-derives its answer every time.
  */
 const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
 
 /**
- * `grpc-message` is percent-encoded on the wire, and the grpc-web transport reads the header
- * verbatim (https://github.com/timostamm/protobuf-ts/pull/739), so status text otherwise reaches
- * callers as `Object%20not%20found%3A%200x1`.
+ * `grpc-message` is percent-encoded on the wire, and `GrpcWebFetchTransport` reads the header
+ * verbatim (https://github.com/timostamm/protobuf-ts/pull/739, and the same complaint in
+ * https://github.com/timostamm/protobuf-ts/issues/631), so status text otherwise reaches callers as
+ * `Object%20not%20found%3A%200x1` — or, for a non-ASCII message, as raw UTF-8 escapes.
  *
  * A node is a correct percent-encoder — it escapes a literal `%` as `%25` — so decoding exactly
  * once is right: `gas budget 100%25 consumed` is readable text, and `read_mask path: a%2520b`
@@ -44,21 +50,6 @@ function decodeStatusMessageOnce(error: RpcError): void {
 }
 
 /**
- * Remembers the code the transport produced, before {@link applyAbortStatus} derived anything from
- * it. That is a property of the error rather than of a call, so recording it keeps re-derivation
- * stable without pinning one call's outcome to a shared error object.
- */
-const TRANSPORT_STATUS_CODE = Symbol('@mysten/sui/grpc/transport-status-code');
-
-function transportStatusCode(error: RpcError): string {
-	if (!(TRANSPORT_STATUS_CODE in error)) {
-		Object.defineProperty(error, TRANSPORT_STATUS_CODE, { value: error.code, configurable: true });
-	}
-
-	return (error as unknown as Record<symbol, string>)[TRANSPORT_STATUS_CODE];
-}
-
-/**
  * Codes a call that ended because its own signal aborted.
  *
  * The transport codes an aborted call `CANCELLED` only when the abort reason is an `AbortError`.
@@ -67,22 +58,17 @@ function transportStatusCode(error: RpcError): string {
  * failure, and retried as one. A deadline the caller set is a deadline exceeded; every other abort
  * is a cancellation.
  *
- * Derived from the signal of the call being normalized on every pass rather than recorded on the
- * error, so a transport that reuses one error instance across calls cannot have the first call
- * decide the code every later call observes. Re-deriving is stable: the same call and signal always
- * produce the same code.
+ * Idempotent without recording anything: re-running against the same signal reaches the same
+ * answer, and a code outside the two the transport uses for an abort is left alone.
  */
 function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void {
 	if (!abort?.aborted) return;
 
 	// A status the server actually answered with outranks the abort: it describes why the call
-	// failed, where the abort only says the caller stopped waiting. Read from the code the transport
-	// produced, not the current one, so a code this function derived for an earlier call is never
-	// mistaken for one the server sent.
-	const code = transportStatusCode(error);
+	// failed, where the abort only says the caller stopped waiting.
 	if (
-		code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
-		code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
+		error.code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
+		error.code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
 	) {
 		return;
 	}
@@ -94,16 +80,6 @@ function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void
 		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
 }
 
-interface NormalizeOptions {
-	/**
-	 * Whether the message still holds the percent-encoded wire form. True for grpc-web, which reads
-	 * `grpc-message` verbatim; false for a transport that decodes for itself, where decoding again
-	 * would rewrite a status that really does contain `%20`.
-	 */
-	decodeMessages: boolean;
-	abort: AbortSignal | undefined;
-}
-
 /**
  * Makes a transport error readable and correctly coded, in place.
  *
@@ -111,78 +87,62 @@ interface NormalizeOptions {
  * method names and the original stack, and means every promise a call rejects — plus its response
  * stream — surfaces the same normalized error.
  */
-function normalizeGrpcError(error: unknown, { decodeMessages, abort }: NormalizeOptions): void {
+function normalizeGrpcError(error: unknown, abort: AbortSignal | undefined): void {
 	if (!(error instanceof RpcError)) return;
 
-	if (decodeMessages) {
-		decodeStatusMessageOnce(error);
-	}
-
+	decodeStatusMessageOnce(error);
 	applyAbortStatus(error, abort);
 }
 
-function normalizeRejections(promises: Promise<unknown>[], options: NormalizeOptions) {
+function normalizeRejections(promises: Promise<unknown>[], abort: AbortSignal | undefined) {
 	for (const promise of promises) {
 		// Registered before the call is handed back, so this runs ahead of any consumer's continuation
 		// and the consumer's own `await` sees the rewritten error. Swallowing here is what the handler
 		// is for: the original promise still rejects for whoever awaits it.
-		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, options));
+		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, abort));
 	}
 }
 
-export interface NormalizedTransportOptions {
-	/**
-	 * Decode percent-encoded status messages. Set only for transports that hand `grpc-message`
-	 * through in its wire form.
-	 */
-	decodeMessages: boolean;
-}
-
 /**
- * Wraps a transport so that every error it produces is normalized at the wire boundary, before any
- * consumer sees it — `client.core` methods, the generated service clients, and any interceptors the
- * caller installed alike.
+ * `GrpcWebFetchTransport` with the two error defects it has as of `@protobuf-ts/grpcweb-transport`
+ * 2.11.1 repaired: status text arrives decoded, and a call cut short by its own signal is coded
+ * `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`.
+ *
+ * Both belong to the transport — it is the layer that reads the wire — so this is where
+ * `SuiGrpcClient` applies them, and every consumer of a call is served by one pass: `client.core`,
+ * the generated service clients, a response stream and any interceptor the caller installed.
+ *
+ * `SuiGrpcClient` builds one of these by default. Construct it directly when you need transport
+ * options the client does not take, or pass it as `transport`. A plain `GrpcWebFetchTransport`
+ * imported from `@protobuf-ts/grpcweb-transport` still behaves the way that package behaves; the
+ * client does not reach into a transport it was handed.
  */
-export function withNormalizedErrors(
-	transport: RpcTransport,
-	{ decodeMessages }: NormalizedTransportOptions,
-): RpcTransport {
-	return {
-		mergeOptions(options) {
-			return transport.mergeOptions(options);
-		},
+export class SuiGrpcWebTransport extends GrpcWebFetchTransport {
+	override unary<I extends object, O extends object>(
+		method: MethodInfo<I, O>,
+		input: I,
+		options: RpcOptions,
+	): UnaryCall<I, O> {
+		const call = super.unary(method, input, options);
 
-		unary(method, input, options) {
-			const call = transport.unary(method, input, options);
-			const normalizeOptions = { decodeMessages, abort: options.abort };
+		normalizeRejections([call.headers, call.response, call.status, call.trailers], options.abort);
 
-			normalizeRejections(
-				[call.headers, call.response, call.status, call.trailers],
-				normalizeOptions,
-			);
+		return call;
+	}
 
-			return call;
-		},
+	override serverStreaming<I extends object, O extends object>(
+		method: MethodInfo<I, O>,
+		input: I,
+		options: RpcOptions,
+	): ServerStreamingCall<I, O> {
+		const call = super.serverStreaming(method, input, options);
 
-		serverStreaming(method, input, options) {
-			const call = transport.serverStreaming(method, input, options);
-			const normalizeOptions = { decodeMessages, abort: options.abort };
+		// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
+		// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
+		// stream errors, so this rewrites the error before a `for await` resumes on it.
+		call.responses.onError((error) => normalizeGrpcError(error, options.abort));
+		normalizeRejections([call.headers, call.status, call.trailers], options.abort);
 
-			// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
-			// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
-			// stream errors, so this rewrites the error before a `for await` resumes on it.
-			call.responses.onError((error) => normalizeGrpcError(error, normalizeOptions));
-			normalizeRejections([call.headers, call.status, call.trailers], normalizeOptions);
-
-			return call;
-		},
-
-		clientStreaming(method, options) {
-			return transport.clientStreaming(method, options);
-		},
-
-		duplex(method, options) {
-			return transport.duplex(method, options);
-		},
-	};
+		return call;
+	}
 }

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -6,11 +6,15 @@ import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
 /**
- * Marks an error this module has already normalized. A single failed call rejects its headers,
- * response, status and trailers with the *same* error object, so without a marker a message that
- * legitimately reads `a%20b` would be rewritten once per promise.
+ * Marks an error whose message this module has already decoded. A single failed call rejects its
+ * headers, response, status and trailers with the *same* error object, so without a marker a
+ * message that legitimately reads `a%20b` would be rewritten once per promise.
+ *
+ * Only the decode is recorded here, because it is a property of the message: decoding text that
+ * has already been decoded is what the marker exists to prevent, and the answer does not depend on
+ * which call is asking. Nothing call-specific is stored on the error — see {@link applyAbortStatus}.
  */
-const NORMALIZED = Symbol('@mysten/sui/grpc/normalized-error');
+const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
 
 /**
  * `grpc-message` is percent-encoded on the wire, and the grpc-web transport reads the header
@@ -32,47 +36,117 @@ function decodeGrpcStatusMessage(message: string): string {
 	}
 }
 
-/**
- * Makes a transport error readable and correctly coded, in place, at most once.
- *
- * Mutating rather than re-wrapping keeps `instanceof RpcError`, the status code, trailing metadata,
- * the service and method names and the original stack, and means every promise a call rejects —
- * plus its response stream — surfaces the same normalized error.
- */
-function normalizeGrpcError(error: unknown, abort?: AbortSignal): void {
-	if (!(error instanceof RpcError) || NORMALIZED in error) return;
-	Object.defineProperty(error, NORMALIZED, { value: true, configurable: true });
+function decodeStatusMessageOnce(error: RpcError): void {
+	if (MESSAGE_DECODED in error) return;
+	Object.defineProperty(error, MESSAGE_DECODED, { value: true, configurable: true });
 
 	error.message = decodeGrpcStatusMessage(error.message);
-
-	// The transport codes an aborted call `CANCELLED` only for an `AbortError`. `AbortSignal.timeout`
-	// aborts with a `TimeoutError`, which falls through to `INTERNAL` — indistinguishable from a
-	// server-side failure, and retried as one. A deadline the caller set is a deadline exceeded.
-	if (
-		abort?.aborted &&
-		(abort.reason as { name?: unknown } | null | undefined)?.name === 'TimeoutError' &&
-		(error.code === GrpcStatusCode[GrpcStatusCode.INTERNAL] ||
-			error.code === GrpcStatusCode[GrpcStatusCode.CANCELLED])
-	) {
-		error.code = GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED];
-	}
 }
 
-function normalizeRejections(abort: AbortSignal | undefined, promises: Promise<unknown>[]) {
+/**
+ * Remembers the code the transport produced, before {@link applyAbortStatus} derived anything from
+ * it. That is a property of the error rather than of a call, so recording it keeps re-derivation
+ * stable without pinning one call's outcome to a shared error object.
+ */
+const TRANSPORT_STATUS_CODE = Symbol('@mysten/sui/grpc/transport-status-code');
+
+function transportStatusCode(error: RpcError): string {
+	if (!(TRANSPORT_STATUS_CODE in error)) {
+		Object.defineProperty(error, TRANSPORT_STATUS_CODE, { value: error.code, configurable: true });
+	}
+
+	return (error as unknown as Record<symbol, string>)[TRANSPORT_STATUS_CODE];
+}
+
+/**
+ * Codes a call that ended because its own signal aborted.
+ *
+ * The transport codes an aborted call `CANCELLED` only when the abort reason is an `AbortError`.
+ * `AbortSignal.timeout` aborts with a `TimeoutError`, and `AbortController.abort(reason)` takes an
+ * arbitrary reason, so both fall through to `INTERNAL` — indistinguishable from a server-side
+ * failure, and retried as one. A deadline the caller set is a deadline exceeded; every other abort
+ * is a cancellation.
+ *
+ * Derived from the signal of the call being normalized on every pass rather than recorded on the
+ * error, so a transport that reuses one error instance across calls cannot have the first call
+ * decide the code every later call observes. Re-deriving is stable: the same call and signal always
+ * produce the same code.
+ */
+function applyAbortStatus(error: RpcError, abort: AbortSignal | undefined): void {
+	if (!abort?.aborted) return;
+
+	// A status the server actually answered with outranks the abort: it describes why the call
+	// failed, where the abort only says the caller stopped waiting. Read from the code the transport
+	// produced, not the current one, so a code this function derived for an earlier call is never
+	// mistaken for one the server sent.
+	const code = transportStatusCode(error);
+	if (
+		code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
+		code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
+	) {
+		return;
+	}
+
+	const timedOut = (abort.reason as { name?: unknown } | null | undefined)?.name === 'TimeoutError';
+
+	error.code = timedOut
+		? GrpcStatusCode[GrpcStatusCode.DEADLINE_EXCEEDED]
+		: GrpcStatusCode[GrpcStatusCode.CANCELLED];
+}
+
+interface NormalizeOptions {
+	/**
+	 * Whether the message still holds the percent-encoded wire form. True for grpc-web, which reads
+	 * `grpc-message` verbatim; false for a transport that decodes for itself, where decoding again
+	 * would rewrite a status that really does contain `%20`.
+	 */
+	decodeMessages: boolean;
+	abort: AbortSignal | undefined;
+}
+
+/**
+ * Makes a transport error readable and correctly coded, in place.
+ *
+ * Mutating rather than re-wrapping keeps `instanceof RpcError`, trailing metadata, the service and
+ * method names and the original stack, and means every promise a call rejects — plus its response
+ * stream — surfaces the same normalized error.
+ */
+function normalizeGrpcError(error: unknown, { decodeMessages, abort }: NormalizeOptions): void {
+	if (!(error instanceof RpcError)) return;
+
+	if (decodeMessages) {
+		decodeStatusMessageOnce(error);
+	}
+
+	applyAbortStatus(error, abort);
+}
+
+function normalizeRejections(promises: Promise<unknown>[], options: NormalizeOptions) {
 	for (const promise of promises) {
 		// Registered before the call is handed back, so this runs ahead of any consumer's continuation
 		// and the consumer's own `await` sees the rewritten error. Swallowing here is what the handler
 		// is for: the original promise still rejects for whoever awaits it.
-		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, abort));
+		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, options));
 	}
 }
 
+export interface NormalizedTransportOptions {
+	/**
+	 * Decode percent-encoded status messages. Set only for transports that hand `grpc-message`
+	 * through in its wire form.
+	 */
+	decodeMessages: boolean;
+}
+
 /**
- * Wraps a transport so that every error it produces is normalized once, at the wire boundary,
- * before any consumer sees it — `client.core` methods, the generated service clients, and any
- * interceptors the caller installed alike.
+ * Wraps a transport so that every error it produces is normalized at the wire boundary, before any
+ * consumer sees it — `client.core` methods, the generated service clients, and any interceptors the
+ * caller installed alike.
  */
-export function withNormalizedErrors(transport: RpcTransport): RpcTransport {
+export function withNormalizedErrors(
+	transport: RpcTransport,
+	{ decodeMessages }: NormalizedTransportOptions,
+): RpcTransport {
 	return {
 		mergeOptions(options) {
 			return transport.mergeOptions(options);
@@ -80,20 +154,25 @@ export function withNormalizedErrors(transport: RpcTransport): RpcTransport {
 
 		unary(method, input, options) {
 			const call = transport.unary(method, input, options);
+			const normalizeOptions = { decodeMessages, abort: options.abort };
 
-			normalizeRejections(options.abort, [call.headers, call.response, call.status, call.trailers]);
+			normalizeRejections(
+				[call.headers, call.response, call.status, call.trailers],
+				normalizeOptions,
+			);
 
 			return call;
 		},
 
 		serverStreaming(method, input, options) {
 			const call = transport.serverStreaming(method, input, options);
+			const normalizeOptions = { decodeMessages, abort: options.abort };
 
 			// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
 			// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
 			// stream errors, so this rewrites the error before a `for await` resumes on it.
-			call.responses.onError((error) => normalizeGrpcError(error, options.abort));
-			normalizeRejections(options.abort, [call.headers, call.status, call.trailers]);
+			call.responses.onError((error) => normalizeGrpcError(error, normalizeOptions));
+			normalizeRejections([call.headers, call.status, call.trailers], normalizeOptions);
 
 			return call;
 		},

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -11,28 +11,13 @@ import type {
 } from '@protobuf-ts/runtime-rpc';
 import { RpcError } from '@protobuf-ts/runtime-rpc';
 
-/**
- * Marks an error whose message has already been decoded. One failed call rejects its headers,
- * response, status and trailers with the *same* error object, so without a marker a message that
- * legitimately reads `a%20b` would be rewritten once per promise.
- *
- * This records a property of the message, not of the call: whether text has already been decoded
- * does not depend on who is asking. Nothing call-specific is stored on the error — {@link
- * applyAbortStatus} re-derives its answer every time.
- */
+/** A failed call rejects four promises with the same error object, so only decode it once. */
 const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
 
 /**
- * `grpc-message` is percent-encoded on the wire, and `GrpcWebFetchTransport` reads the header
- * verbatim (https://github.com/timostamm/protobuf-ts/pull/739, and the same complaint in
- * https://github.com/timostamm/protobuf-ts/issues/631), so status text otherwise reaches callers as
- * `Object%20not%20found%3A%200x1` — or, for a non-ASCII message, as raw UTF-8 escapes.
- *
- * Decoding exactly once is right, because the server escapes a literal `%` as `%25`: tonic 0.14 —
- * what a Sui node serves gRPC with — percent-encodes control bytes plus ``  " # % < > ` ? { }  ``,
- * so `gas budget 100%25 consumed` is readable text and `read_mask path: a%2520b` really does end in
- * `a%20b`. Not every encoder is that careful (tonic 0.12 left `%` unescaped), so a message that
- * fails to decode is kept verbatim rather than failing a call over its status text.
+ * Decodes `grpc-message`, which is percent-encoded on the wire and which the upstream transport
+ * does not decode (https://github.com/timostamm/protobuf-ts/pull/739). The server escapes a literal
+ * `%` as `%25`, so one decode is correct. Text that fails to decode is returned unchanged.
  */
 export function decodeGrpcStatusMessage(message: string): string {
 	if (!message.includes('%')) return message;
@@ -51,23 +36,18 @@ function decodeStatusMessageOnce(error: RpcError): void {
 	error.message = decodeGrpcStatusMessage(error.message);
 }
 
-/** What one call was aborted by, as opposed to what happened to be aborted when it failed. */
 interface CallAbort {
-	/** The signal the call runs against: the caller's, the deadline below, or both composed. */
+	/** What the call runs against: the caller's signal, the deadline below, or both composed. */
 	signal: AbortSignal | undefined;
-	/** The deadline this transport imposed for `options.timeout`, if it imposed one. */
+	/** The deadline imposed for `options.timeout`, if there was one. */
 	deadline: AbortSignal | undefined;
 }
 
 /**
- * Whether this error *is* the abort, rather than a failure that arrived while the call happened to
- * be aborted.
- *
- * `signal.aborted` alone does not establish that. A call's headers resolve before a later
- * server-side failure propagates, so a caller that aborts in a headers continuation — or simply
- * races a truncated connection — would otherwise have a real `INTERNAL` rewritten as a
- * cancellation. The transport rethrows the abort reason's own message verbatim, so carrying that
- * message is what ties the failure to the abort.
+ * Whether the abort is what failed the call. `signal.aborted` is not enough, because headers
+ * resolve before a later server failure propagates, so a call can be aborted while failing for an
+ * unrelated reason. The transport reuses the abort reason's message, so matching it identifies the
+ * abort.
  */
 function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
 	const reason = signal.reason as { message?: unknown } | null | undefined;
@@ -76,12 +56,9 @@ function isAbortFailure(error: RpcError, signal: AbortSignal): boolean {
 }
 
 /**
- * Whether the abort was a deadline expiring rather than someone cancelling.
- *
- * The deadline this transport composed is known by identity, not inferred: `AbortSignal.any`
- * forwards the reason of whichever source fired, so comparing against it says which one did. A
- * caller's own `AbortSignal.timeout` is a deadline too, and is recognised by its platform
- * `DOMException` — which `Object.assign(new Error(), { name: 'TimeoutError' })` is not.
+ * Whether the abort was a deadline. `AbortSignal.any` forwards the reason of the signal that fired,
+ * so the deadline below is matched by identity. A caller's `AbortSignal.timeout` aborts with a
+ * `DOMException` named `TimeoutError`; a plain `Error` given that name does not count.
  */
 function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
 	if (deadline?.aborted && signal?.reason === deadline.reason) return true;
@@ -90,21 +67,13 @@ function isDeadlineAbort({ signal, deadline }: CallAbort): boolean {
 }
 
 /**
- * Codes a call that ended because its own signal aborted.
- *
- * The transport codes an aborted call `CANCELLED` only when the abort reason is an `AbortError`.
- * `AbortSignal.timeout` aborts with a `TimeoutError`, and `AbortController.abort(reason)` takes an
- * arbitrary reason, so both fall through to `INTERNAL` — indistinguishable from a server-side
- * failure, and retried as one. A deadline is a deadline exceeded; every other abort is a
- * cancellation.
- *
- * Idempotent without recording anything: the same call and signal always reach the same answer.
+ * Codes an aborted call. The upstream transport uses `CANCELLED` only for an `AbortError`, so a
+ * timeout or a custom abort reason arrives as `INTERNAL` and gets retried as a server failure.
  */
 function applyAbortStatus(error: RpcError, abort: CallAbort): void {
 	if (!abort.signal?.aborted || !isAbortFailure(error, abort.signal)) return;
 
-	// An abort reason that was itself an `RpcError` reaches the caller with the code they gave it,
-	// and a status the server answered with describes the failure better than the abort does.
+	// Any other code came from the server, or from an abort reason the caller coded themselves.
 	if (
 		error.code !== GrpcStatusCode[GrpcStatusCode.INTERNAL] &&
 		error.code !== GrpcStatusCode[GrpcStatusCode.CANCELLED]
@@ -118,55 +87,42 @@ function applyAbortStatus(error: RpcError, abort: CallAbort): void {
 }
 
 /**
- * Makes a transport error readable and correctly coded, in place.
- *
- * Mutating rather than re-wrapping keeps `instanceof RpcError`, trailing metadata, the service and
- * method names and the original stack, and means every promise a call rejects — plus its response
- * stream — surfaces the same normalized error.
+ * Rewrites the error in place, which keeps `instanceof RpcError`, the trailers and the stack, and
+ * gives the same result on every promise the call rejects.
  */
 function normalizeGrpcError(error: unknown, abort: CallAbort): void {
 	if (!(error instanceof RpcError)) return;
 
-	// Coded before decoding, because provenance is established by comparing against the abort
-	// reason's message, and decoding rewrites the message being compared.
+	// Coded first, because decoding rewrites the message `isAbortFailure` compares.
 	applyAbortStatus(error, abort);
 	decodeStatusMessageOnce(error);
 }
 
 function normalizeRejections(promises: Promise<unknown>[], abort: CallAbort) {
 	for (const promise of promises) {
-		// Registered before the call is handed back, so this runs ahead of any consumer's continuation
-		// and the consumer's own `await` sees the rewritten error. Swallowing here is what the handler
-		// is for: the original promise still rejects for whoever awaits it.
+		// Registered before the call is returned, so it runs before the consumer's own await. The
+		// original promise still rejects; this only changes the error it rejects with.
 		promise.then(undefined, (error: unknown) => normalizeGrpcError(error, abort));
 	}
 }
 
 /**
- * Turns `options.timeout` into a deadline this client enforces, by composing one into the signal
- * the call aborts on.
+ * Enforces `options.timeout` locally. The upstream transport only sends the `grpc-timeout` header,
+ * which does not help when the connection stalls.
  *
- * The base transport only puts `timeout` in the `grpc-timeout` header, which a node honours but
- * which does nothing when the connection itself stalls: the call then hangs for as long as the
- * fetch does. Sending the header as well is still right — the server should stop working on a
- * request nobody is waiting for.
- *
- * Nothing is written to the options passed in. `mergeRpcOptions` returns the transport's own
- * `defaultOptions` *by reference* when a generated method is called without call options, so
- * assigning `abort` here would pin one call's deadline to every later call the client makes.
+ * The options are copied rather than written to. `mergeRpcOptions` returns the transport's
+ * `defaultOptions` by reference for a call that passes no options of its own, so assigning `abort`
+ * would apply one call's deadline to every later call.
  */
 function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAbort } {
-	if (options.timeout == null) {
-		return { options, abort: { signal: options.abort, deadline: undefined } };
-	}
+	const unbounded = { options, abort: { signal: options.abort, deadline: undefined } };
+	if (options.timeout == null) return unbounded;
 
 	const durationMs =
 		typeof options.timeout === 'number' ? options.timeout : options.timeout.getTime() - Date.now();
 
-	// An expired deadline is the base transport's to reject, which it does before sending anything.
-	if (durationMs <= 0) {
-		return { options, abort: { signal: options.abort, deadline: undefined } };
-	}
+	// The upstream transport rejects an expired deadline itself, before sending anything.
+	if (durationMs <= 0) return unbounded;
 
 	const deadline = AbortSignal.timeout(durationMs);
 	const signal = options.abort ? AbortSignal.any([options.abort, deadline]) : deadline;
@@ -175,20 +131,13 @@ function withDeadline(options: RpcOptions): { options: RpcOptions; abort: CallAb
 }
 
 /**
- * The grpc-web transport `@mysten/sui` ships: `@protobuf-ts/grpcweb-transport`'s, subclassed to
- * repair three defects it has as of 2.11.1 — status text arrives decoded, a call cut short by its
- * own signal is coded `DEADLINE_EXCEEDED` or `CANCELLED` rather than `INTERNAL`, and `timeout` is a
- * deadline this client enforces rather than one it only advertises to the server.
+ * `GrpcWebFetchTransport` from `@protobuf-ts/grpcweb-transport`, subclassed to fix three defects it
+ * has as of 2.11.1: status messages are left percent-encoded, an aborted call is coded `INTERNAL`,
+ * and `timeout` is only advertised to the server. Fixing them here covers every consumer of a call.
  *
- * Both belong to the transport — it is the layer that reads the wire — so this is where
- * `SuiGrpcClient` applies them, and every consumer of a call is served by one pass: `client.core`,
- * the generated service clients, a response stream and any interceptor the caller installed.
- *
- * This is what `@mysten/sui/grpc` exports under this name and what `SuiGrpcClient` builds by
- * default from the options it is given. Construct it directly to share one transport between
- * clients, or to subclass it further, and pass it as `transport`. A transport imported from
- * `@protobuf-ts/grpcweb-transport` itself still behaves the way that package behaves; the client
- * does not reach into a transport it was handed.
+ * `SuiGrpcClient` builds one by default. Construct it directly to share a transport between clients
+ * or to subclass it further, then pass it as `transport`. A transport imported from
+ * `@protobuf-ts/grpcweb-transport` keeps that package's behaviour.
  */
 export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 	override unary<I extends object, O extends object>(
@@ -209,14 +158,12 @@ export class GrpcWebFetchTransport extends UpstreamGrpcWebFetchTransport {
 		input: I,
 		options: RpcOptions,
 	): ServerStreamingCall<I, O> {
-		// A stream is bounded only if the caller asked for it to be: nothing here invents a deadline,
-		// so a subscription left without a `timeout` runs until it or the node ends it.
+		// No deadline is imposed, so a subscription without a `timeout` stays unbounded.
 		const { options: callOptions, abort } = withDeadline(options);
 		const call = super.serverStreaming(method, input, callOptions);
 
-		// grpc-web pushes a failure into the response stream, and a finite stream is often consumed
-		// through `responses` alone, without awaiting `status`. Listeners run synchronously when the
-		// stream errors, so this rewrites the error before a `for await` resumes on it.
+		// A finite stream is often read through `responses` without awaiting `status`. Listeners run
+		// synchronously on error, so this lands before a `for await` resumes.
 		call.responses.onError((error) => normalizeGrpcError(error, abort));
 		normalizeRejections([call.headers, call.status, call.trailers], abort);
 

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -28,10 +28,11 @@ const MESSAGE_DECODED = Symbol('@mysten/sui/grpc/decoded-status-message');
  * https://github.com/timostamm/protobuf-ts/issues/631), so status text otherwise reaches callers as
  * `Object%20not%20found%3A%200x1` — or, for a non-ASCII message, as raw UTF-8 escapes.
  *
- * A node is a correct percent-encoder — it escapes a literal `%` as `%25` — so decoding exactly
- * once is right: `gas budget 100%25 consumed` is readable text, and `read_mask path: a%2520b`
- * really does end in `a%20b`. A message that fails to decode was not written by a percent-encoder,
- * so it is kept verbatim rather than failing a call over its status text.
+ * Decoding exactly once is right, because the server escapes a literal `%` as `%25`: tonic 0.14 —
+ * what a Sui node serves gRPC with — percent-encodes control bytes plus ``  " # % < > ` ? { }  ``,
+ * so `gas budget 100%25 consumed` is readable text and `read_mask path: a%2520b` really does end in
+ * `a%20b`. Not every encoder is that careful (tonic 0.12 left `%` unescaped), so a message that
+ * fails to decode is kept verbatim rather than failing a call over its status text.
  */
 function decodeGrpcStatusMessage(message: string): string {
 	if (!message.includes('%')) return message;

--- a/packages/sui/src/grpc/transport.ts
+++ b/packages/sui/src/grpc/transport.ts
@@ -63,15 +63,27 @@ function abortStatus(reason: unknown): string {
 
 // The transport reuses the abort reason's message, so matching it says the text is local. A fetch
 // that substitutes its own error (node-fetch) gives text of its own, which holds nothing to decode.
+// The reason is arbitrary, so it is never coerced: a symbol or a throwing hook would throw here.
 function isAbortReasonText(message: string, reason: unknown): boolean {
+	if (typeof reason === 'string') return message === reason;
+
 	const reasonMessage = (reason as { message?: unknown } | null)?.message;
 
-	return message === (typeof reasonMessage === 'string' ? reasonMessage : `${reason}`);
+	return typeof reasonMessage === 'string' && message === reasonMessage;
 }
 
 // Rewritten in place, so every promise a call rejects surfaces the same error. Only the two codes
 // upstream uses for an abort are re-coded; a failure that raced the abort is relabelled with it.
 function normalizeGrpcError(error: unknown, signal: AbortSignal | undefined): void {
+	try {
+		normalize(error, signal);
+	} catch {
+		// Reading an abort reason runs code the caller supplied. A call reports whatever it was going
+		// to report rather than this, and never an unhandled rejection from a discarded handler.
+	}
+}
+
+function normalize(error: unknown, signal: AbortSignal | undefined): void {
 	if (!(error instanceof RpcError)) return;
 
 	if (

--- a/packages/sui/test/unit/client/name-service.test.ts
+++ b/packages/sui/test/unit/client/name-service.test.ts
@@ -28,8 +28,8 @@ describe('resolveNameServiceAddress', () => {
 		expect(lookupName).toHaveBeenCalledWith({ name }, { abort: signal });
 	});
 
-	// The encoded form still has to match: a caller-supplied transport is passed through untouched,
-	// so `grpc-message` reaches this layer in its wire form (see test/unit/grpc/transport-errors.test.ts).
+	// The encoded form still has to match: a caller-supplied transport is used as given, so
+	// `grpc-message` reaches this layer in its wire form.
 	it.each([
 		new RpcError('not found', 'NOT_FOUND'),
 		new RpcError('name has expired', 'RESOURCE_EXHAUSTED'),

--- a/packages/sui/test/unit/client/name-service.test.ts
+++ b/packages/sui/test/unit/client/name-service.test.ts
@@ -28,11 +28,12 @@ describe('resolveNameServiceAddress', () => {
 		expect(lookupName).toHaveBeenCalledWith({ name }, { abort: signal });
 	});
 
-	// Status text arrives decoded: the transport wrapper percent-decodes `grpc-message` before any
-	// consumer sees it (see test/unit/grpc/transport-errors.test.ts).
+	// The encoded form still has to match: a caller-supplied transport is passed through untouched,
+	// so `grpc-message` reaches this layer in its wire form (see test/unit/grpc/transport-errors.test.ts).
 	it.each([
 		new RpcError('not found', 'NOT_FOUND'),
 		new RpcError('name has expired', 'RESOURCE_EXHAUSTED'),
+		new RpcError('name%20has%20expired', 'RESOURCE_EXHAUSTED'),
 	])('maps absent gRPC names to null ($code)', async (error) => {
 		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
 		client.nameService.lookupName = (() => Promise.reject(error)) as never;

--- a/packages/sui/test/unit/client/name-service.test.ts
+++ b/packages/sui/test/unit/client/name-service.test.ts
@@ -28,10 +28,11 @@ describe('resolveNameServiceAddress', () => {
 		expect(lookupName).toHaveBeenCalledWith({ name }, { abort: signal });
 	});
 
+	// Status text arrives decoded: the transport wrapper percent-decodes `grpc-message` before any
+	// consumer sees it (see test/unit/grpc/transport-errors.test.ts).
 	it.each([
 		new RpcError('not found', 'NOT_FOUND'),
 		new RpcError('name has expired', 'RESOURCE_EXHAUSTED'),
-		new RpcError('name%20has%20expired', 'RESOURCE_EXHAUSTED'),
 	])('maps absent gRPC names to null ($code)', async (error) => {
 		const client = new SuiGrpcClient({ baseUrl: 'http://localhost', network: 'mainnet' });
 		client.nameService.lookupName = (() => Promise.reject(error)) as never;

--- a/packages/sui/test/unit/grpc/exports.test.ts
+++ b/packages/sui/test/unit/grpc/exports.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { GrpcStatusCode, RpcError } from '../../../src/grpc/index.js';
+
+describe('grpc error exports', () => {
+	it('narrows and codes a failure without a protobuf-ts import', () => {
+		const error: unknown = new RpcError('gone', GrpcStatusCode[GrpcStatusCode.NOT_FOUND]);
+
+		expect(error).toBeInstanceOf(RpcError);
+		expect((error as RpcError).code).toBe('NOT_FOUND');
+	});
+});

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -372,6 +372,46 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('INTERNAL');
 	});
 
+	it('passes through a body it cannot wrap, as node-fetch returns', async () => {
+		// Upstream reads those through `Symbol.asyncIterator`; calling `getReader` on one would throw.
+		const client = makeClient((async () => ({
+			status: 200,
+			statusText: 'OK',
+			headers: new Headers({ 'content-type': 'application/grpc-web+proto' }),
+			body: (async function* () {
+				yield new Uint8Array();
+			})(),
+		})) as unknown as typeof globalThis.fetch);
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error.message).not.toContain('getReader');
+	});
+
+	it('answers from a header status without consuming the body', async () => {
+		// The transport never reads the body of a header-carried status, so a body that fails on its
+		// own must not mark the call a local failure and suppress decoding.
+		const client = makeClient((async () => ({
+			status: 200,
+			statusText: 'OK',
+			headers: new Headers({
+				'content-type': 'application/grpc-web+proto',
+				'grpc-status': '5',
+				'grpc-message': 'Object%20not%20found',
+			}),
+			body: new ReadableStream({
+				pull(streamController) {
+					streamController.error(new Error('connection reset'));
+				},
+			}),
+		})) as unknown as typeof globalThis.fetch);
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error.message).toBe('Object not found');
+		expect(error.code).toBe('NOT_FOUND');
+	});
+
 	it('codes an abort that lands while the body is being read', async () => {
 		const controller = new AbortController();
 		const client = clientRespondingWith(() =>

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -430,6 +430,21 @@ describe('a caller-supplied transport', () => {
 		});
 	});
 
+	it('honours the decoded marker set by another copy of this package', async () => {
+		// A transport from a duplicate install decodes with the same registered symbol, so its errors
+		// are not decoded again, and their text is not read as a wire form.
+		const decoded = new RpcError('name%20has%20expired', 'RESOURCE_EXHAUSTED');
+		Object.defineProperty(decoded, Symbol.for('@mysten/sui/grpc/decoded-status-message'), {
+			value: true,
+		});
+		const client = new SuiGrpcClient({
+			network: 'mainnet',
+			transport: transportRejectingWith(decoded),
+		});
+
+		await expect(client.core.resolveNameServiceAddress({ name: '@mysten' })).rejects.toBe(decoded);
+	});
+
 	it('does not decode a status the transport already decoded', async () => {
 		// The wire form of a message that literally reads `name%20has%20expired`. Decoding it twice
 		// would turn an unrelated failure into a resolved-to-null name.

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
+import type { RpcOptions, RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
 
@@ -64,6 +64,17 @@ function transportRejectingWith(error: RpcError): RpcTransport {
 			throw new Error('unused');
 		},
 	};
+}
+
+/** A server that accepts the request and then never answers, until the call's signal aborts. */
+function hangingFetch(onRequest?: (init: RequestInit) => void): typeof globalThis.fetch {
+	return ((_input: unknown, init: RequestInit) => {
+		onRequest?.(init);
+
+		return new Promise<Response>((_, reject) => {
+			init.signal?.addEventListener('abort', () => reject(init.signal!.reason));
+		});
+	}) as unknown as typeof globalThis.fetch;
 }
 
 async function captureError(promise: Promise<unknown>) {
@@ -232,5 +243,63 @@ describe('a caller-supplied transport', () => {
 		const caught = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
 
 		expect(caught.message).toBe('Object not found: 0x1');
+	});
+});
+
+describe('gRPC transport deadlines', () => {
+	it('enforces a timeout the base transport only advertises', async () => {
+		// `grpc-timeout` asks the node to give up; it does nothing when the connection itself stalls.
+		const client = makeClient(hangingFetch());
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 5 }).response,
+		);
+
+		expect(error.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('still sends the grpc-timeout header', async () => {
+		let sent: RequestInit | undefined;
+		const client = makeClient(hangingFetch((init) => (sent = init)));
+
+		await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 50 }).response,
+		);
+
+		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('50m');
+	});
+
+	it('lets a caller cancellation win over a deadline that has not arrived', async () => {
+		const controller = new AbortController();
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(), 1)));
+
+		const error = await captureError(
+			client.ledgerService.getObject(
+				{ objectId: '0x1' },
+				{ timeout: 10_000, abort: controller.signal },
+			).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
+	it('gives every call its own deadline when the timeout comes from the transport options', async () => {
+		const transport = new GrpcWebFetchTransport({
+			baseUrl: 'http://localhost',
+			fetch: hangingFetch(),
+			timeout: 5,
+		});
+		const client = new SuiGrpcClient({ network: 'testnet', transport });
+
+		const first = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+		const second = await captureError(client.ledgerService.getObject({ objectId: '0x2' }).response);
+
+		expect(first.code).toBe('DEADLINE_EXCEEDED');
+		expect(second.code).toBe('DEADLINE_EXCEEDED');
+
+		// `mergeRpcOptions` hands these very options to a call that passes none of its own, so writing
+		// the composed signal onto them would leave every later call born already aborted.
+		const defaults = (transport as unknown as { defaultOptions: RpcOptions }).defaultOptions;
+		expect(defaults.abort).toBeUndefined();
 	});
 });

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -318,6 +318,32 @@ describe('gRPC transport error normalization', () => {
 		expect(error.message).toBe('cancel /objects/a%2Fb');
 	});
 
+	it('gives every promise of an aborted call the same message and code', async () => {
+		// Re-coding to a status outside the abort branch would leave later handlers decoding the
+		// reason's own text.
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() =>
+				setTimeout(
+					() => controller.abort(Object.assign(new Error('retry /a%2Fb'), { code: 'UNAVAILABLE' })),
+					1,
+				),
+			),
+		);
+
+		const call = client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal });
+		const [fromResponse, fromStatus, fromTrailers] = await Promise.all([
+			captureError(call.response),
+			captureError(call.status),
+			captureError(call.trailers),
+		]);
+
+		for (const error of [fromResponse, fromStatus, fromTrailers]) {
+			expect(error.message).toBe('retry /a%2Fb');
+			expect(error.code).toBe('UNAVAILABLE');
+		}
+	});
+
 	it('does not decode the text of an abort reason', async () => {
 		// The reason's message is local text, not `grpc-message` off the wire.
 		const controller = new AbortController();

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { RpcError } from '@protobuf-ts/runtime-rpc';
+import { describe, expect, it } from 'vitest';
+
+import { SuiGrpcClient } from '../../../src/grpc/index.js';
+
+/**
+ * A grpc-web response that carries its status in the headers, which is how a fullnode answers a
+ * request it rejected outright. `grpc-message` is percent-encoded, per the protocol.
+ */
+function statusResponse(status: number, message: string) {
+	return new Response(null, {
+		status: 200,
+		headers: {
+			'content-type': 'application/grpc-web+proto',
+			'grpc-status': String(status),
+			'grpc-message': message,
+		},
+	});
+}
+
+function makeClient(fetch: typeof globalThis.fetch) {
+	return new SuiGrpcClient({
+		baseUrl: 'http://localhost',
+		network: 'testnet',
+		fetch,
+	});
+}
+
+function clientRespondingWith(response: Response | (() => Promise<Response>)) {
+	return makeClient((async () =>
+		typeof response === 'function' ? response() : response) as typeof globalThis.fetch);
+}
+
+async function captureError(promise: Promise<unknown>) {
+	try {
+		await promise;
+	} catch (error) {
+		return error as RpcError;
+	}
+
+	throw new Error('expected the call to fail');
+}
+
+describe('gRPC transport error normalization', () => {
+	it('decodes percent-encoded status text on the native service clients', async () => {
+		const client = clientRespondingWith(
+			statusResponse(5, 'Object%20not%20found%3A%200x1%20%25%20invalid'),
+		);
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error).toBeInstanceOf(RpcError);
+		expect(error.message).toBe('Object not found: 0x1 % invalid');
+		expect(error.code).toBe('NOT_FOUND');
+	});
+
+	it('decodes status text reached through client.core', async () => {
+		const client = clientRespondingWith(statusResponse(5, 'Object%20not%20found%3A%200x1'));
+
+		const error = await captureError(client.core.getObject({ objectId: '0x1' }));
+
+		expect(error.message).toContain('Object not found: 0x1');
+	});
+
+	it('normalizes every promise a failed call rejects, and only decodes once', async () => {
+		const client = clientRespondingWith(
+			statusResponse(3, 'invalid%20read_mask%20path%3A%20a%2520b'),
+		);
+
+		const call = client.ledgerService.getObject({ objectId: '0x1' });
+		const [fromResponse, fromStatus, fromTrailers] = await Promise.all([
+			captureError(call.response),
+			captureError(call.status),
+			captureError(call.trailers),
+		]);
+
+		// A single decode: `%2520` is a literal `%20` in the message, not a second escape to unwrap.
+		expect(fromResponse.message).toBe('invalid read_mask path: a%20b');
+		expect(fromStatus).toBe(fromResponse);
+		expect(fromTrailers).toBe(fromResponse);
+	});
+
+	it('keeps a message that is not percent-encoded verbatim', async () => {
+		// A bare `%` is not a valid escape; decoding would throw and lose the status text entirely.
+		const client = clientRespondingWith(statusResponse(8, 'rate limit: 100% of quota used'));
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error.message).toBe('rate limit: 100% of quota used');
+		expect(error.code).toBe('RESOURCE_EXHAUSTED');
+	});
+
+	it('decodes status text on a server-streaming call', async () => {
+		const client = clientRespondingWith(statusResponse(7, 'permission%20denied%3A%20key'));
+
+		const error = await captureError(
+			(async () => {
+				for await (const _ of client.ledgerService.listTransactions({}).responses) {
+					// the call fails before any response frame arrives
+				}
+			})(),
+		);
+
+		expect(error.message).toBe('permission denied: key');
+	});
+
+	it('codes a caller deadline as DEADLINE_EXCEEDED rather than INTERNAL', async () => {
+		const client = clientRespondingWith(
+			() =>
+				new Promise<Response>((_, reject) => {
+					setTimeout(() => {
+						reject(Object.assign(new Error('The operation was aborted'), { name: 'TimeoutError' }));
+					}, 1);
+				}),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: AbortSignal.timeout(1) })
+				.response,
+		);
+
+		expect(error.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('leaves a genuine cancellation coded CANCELLED', async () => {
+		const controller = new AbortController();
+		const client = clientRespondingWith(
+			() =>
+				new Promise<Response>((_, reject) => {
+					setTimeout(() => {
+						controller.abort();
+						reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }));
+					}, 1);
+				}),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+});

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { GrpcWebFetchTransport as UpstreamGrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
-import type { RpcOptions, RpcTransport } from '@protobuf-ts/runtime-rpc';
+import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
 
@@ -190,8 +190,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('codes a deadline as DEADLINE_EXCEEDED when the fetch substitutes its own AbortError', async () => {
-		// node-fetch rejects with a generic AbortError rather than the signal's reason, so the reason's
-		// text is not there to match on.
+		// node-fetch rejects with a generic AbortError rather than the signal's reason.
 		const client = makeClient(
 			((_input: unknown, init: RequestInit) =>
 				new Promise((_, reject) => {
@@ -202,12 +201,12 @@ describe('gRPC transport error normalization', () => {
 		);
 
 		const error = await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 5 }).response,
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: AbortSignal.timeout(1) })
+				.response,
 		);
 
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
-
 	it('codes an abort with a primitive reason CANCELLED', async () => {
 		// `abort('stop')` takes a string, which the transport stringifies into an INTERNAL error.
 		const controller = new AbortController();
@@ -423,86 +422,20 @@ describe('a caller-supplied transport', () => {
 	});
 });
 
-describe('gRPC transport deadlines', () => {
-	it('enforces a timeout the base transport only advertises', async () => {
-		// The header asks the node to give up. It does nothing when the connection stalls.
-		const client = makeClient(hangingFetch());
-
-		const error = await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 5 }).response,
-		);
-
-		expect(error.code).toBe('DEADLINE_EXCEEDED');
-	});
-
-	it('leaves a deadline past the timer ceiling to the server, in a unit it will accept', async () => {
-		// `setTimeout` overflows beyond 2^31-1 ms and fires on the next tick, so a 30-day deadline
-		// would end the call immediately. `grpc-timeout` takes eight digits, so it cannot be sent in
-		// milliseconds either.
-		let sent: RequestInit | undefined;
-		const client = makeClient(hangingFetch((init) => (sent = init)));
-
-		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 30 * 24 * 60 * 60 * 1000 });
-		await new Promise((resolve) => setTimeout(resolve, 5));
-
-		expect(sent?.signal ?? null).toBeNull();
-		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('2592000S');
-	});
-
-	it('sends a deadline the header cannot hold in milliseconds while still enforcing it', async () => {
-		// Two days fits a timer but not eight digits of milliseconds.
-		let sent: RequestInit | undefined;
-		const client = makeClient(hangingFetch((init) => (sent = init)));
-
-		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 2 * 24 * 60 * 60 * 1000 });
-		await new Promise((resolve) => setTimeout(resolve, 5));
-
-		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('172800S');
-		expect(sent?.signal?.aborted).toBe(false);
-	});
-
-	it('still sends the grpc-timeout header', async () => {
-		let sent: RequestInit | undefined;
-		const client = makeClient(hangingFetch((init) => (sent = init)));
-
-		await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 50 }).response,
-		);
-
-		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('50m');
-	});
-
-	it('lets a caller cancellation win over a deadline that has not arrived', async () => {
-		const controller = new AbortController();
-		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(), 1)));
-
-		const error = await captureError(
-			client.ledgerService.getObject(
-				{ objectId: '0x1' },
-				{ timeout: 10_000, abort: controller.signal },
-			).response,
-		);
-
-		expect(error.code).toBe('CANCELLED');
-	});
-
-	it('gives every call its own deadline when the timeout comes from the transport options', async () => {
-		const transport = new GrpcWebFetchTransport({
-			baseUrl: 'http://localhost',
-			fetch: hangingFetch(),
-			timeout: 5,
-		});
+describe('gRPC transport call options', () => {
+	it("gives every call its own options rather than writing to the transport's", async () => {
+		const fetch = (async () => statusResponse(5, 'gone')) as typeof globalThis.fetch;
+		const transport = new GrpcWebFetchTransport({ baseUrl: 'http://localhost', fetch });
 		const client = new SuiGrpcClient({ network: 'testnet', transport });
 
-		const first = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
-		const second = await captureError(client.ledgerService.getObject({ objectId: '0x2' }).response);
-
-		expect(first.code).toBe('DEADLINE_EXCEEDED');
-		expect(second.code).toBe('DEADLINE_EXCEEDED');
+		await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+		await captureError(client.ledgerService.getObject({ objectId: '0x2' }).response);
 
 		// `mergeRpcOptions` hands these options to a call that passes none of its own, so writing the
-		// composed signal onto them would leave every later call already aborted.
-		const defaults = (transport as unknown as { defaultOptions: RpcOptions }).defaultOptions;
-		expect(defaults.abort).toBeUndefined();
+		// observing fetch onto them would install one call's state on every later call.
+		const defaults = (transport as unknown as { defaultOptions: { fetch?: unknown } })
+			.defaultOptions;
+
+		expect(defaults.fetch).toBe(fetch);
 	});
 });

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -272,6 +272,16 @@ describe('gRPC transport error normalization', () => {
 		expect(error.message).toBe('cancel /objects/a%2Fb');
 	});
 
+	it('does not decode the text of a fetch failure', async () => {
+		// The message is the fetch's own, not `grpc-message`.
+		const client = makeClient((() =>
+			Promise.reject(new Error('request to http://host/a%2Fb failed'))) as typeof globalThis.fetch);
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error.message).toBe('request to http://host/a%2Fb failed');
+	});
+
 	it('does not decode the text of an abort reason', async () => {
 		// The reason's message is local text, not `grpc-message` off the wire.
 		const controller = new AbortController();
@@ -425,18 +435,30 @@ describe('gRPC transport deadlines', () => {
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
 
-	it('leaves a deadline past the timer ceiling to the header', async () => {
+	it('leaves a deadline past the timer ceiling to the server, in a unit it will accept', async () => {
 		// `setTimeout` overflows beyond 2^31-1 ms and fires on the next tick, so a 30-day deadline
-		// would end the call immediately.
+		// would end the call immediately. `grpc-timeout` takes eight digits, so it cannot be sent in
+		// milliseconds either.
 		let sent: RequestInit | undefined;
 		const client = makeClient(hangingFetch((init) => (sent = init)));
-		const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
 
-		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: thirtyDaysMs });
+		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 30 * 24 * 60 * 60 * 1000 });
 		await new Promise((resolve) => setTimeout(resolve, 5));
 
 		expect(sent?.signal ?? null).toBeNull();
-		expect((sent!.headers as Headers).get('grpc-timeout')).toBe(`${thirtyDaysMs}m`);
+		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('2592000S');
+	});
+
+	it('sends a deadline the header cannot hold in milliseconds while still enforcing it', async () => {
+		// Two days fits a timer but not eight digits of milliseconds.
+		let sent: RequestInit | undefined;
+		const client = makeClient(hangingFetch((init) => (sent = init)));
+
+		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 2 * 24 * 60 * 60 * 1000 });
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		expect((sent!.headers as Headers).get('grpc-timeout')).toBe('172800S');
+		expect(sent?.signal?.aborted).toBe(false);
 	});
 
 	it('still sends the grpc-timeout header', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -170,13 +170,34 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
-	it('does not read a fabricated TimeoutError name as a deadline', async () => {
-		// Only `AbortSignal.timeout`, or a deadline this transport imposed, counts as a deadline.
+	it('reads a reason named TimeoutError as a deadline, whatever built it', async () => {
+		// The reason is the caller's own data. Requiring a `DOMException` would lose a genuine timeout
+		// from another realm, and a caller naming their reason `TimeoutError` is declaring the same
+		// thing either way.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() =>
 				setTimeout(
 					() => controller.abort(Object.assign(new Error('stop'), { name: 'TimeoutError' })),
+					1,
+				),
+			),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('ignores a reason whose code is not a gRPC status', async () => {
+		// A Node system error carries `code`, which must not be mistaken for a status.
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() =>
+				setTimeout(
+					() => controller.abort(Object.assign(new Error('dns'), { code: 'ENOTFOUND' })),
 					1,
 				),
 			),
@@ -217,6 +238,19 @@ describe('gRPC transport error normalization', () => {
 		);
 
 		expect(error.code).toBe('CANCELLED');
+	});
+
+	it('keeps the status of a coded reason from another copy of runtime-rpc', async () => {
+		// A duplicate install, or another realm, fails `instanceof` while carrying the same shape.
+		const controller = new AbortController();
+		const foreign = Object.assign(new Error('retry'), { code: 'UNAVAILABLE', meta: {} });
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(foreign), 1)));
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('UNAVAILABLE');
 	});
 
 	it('keeps the status a caller put on an RpcError abort reason', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -220,6 +220,34 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
+	it('keeps the status a caller put on an RpcError abort reason', async () => {
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() => setTimeout(() => controller.abort(new RpcError('gone', 'INTERNAL')), 1)),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('INTERNAL');
+	});
+
+	it('does not decode the text of an abort reason', async () => {
+		// The reason's message is local text, not `grpc-message` off the wire.
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() => setTimeout(() => controller.abort(new Error('cancel /objects/a%2Fb')), 1)),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.message).toBe('cancel /objects/a%2Fb');
+		expect(error.code).toBe('CANCELLED');
+	});
+
 	it('keeps a server status that came with metadata, whatever the abort reason says', async () => {
 		// An error built from an abort carries no metadata, so matching text cannot make this one look
 		// like a cancellation.

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -241,11 +241,15 @@ describe('gRPC transport error normalization', () => {
 
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
+
 	it('survives a reason whose properties throw when read', async () => {
 		// `abort()` takes anything. Reading one must not throw out of a rejection handler, which would
-		// surface as an unhandled rejection.
+		// surface as an unhandled rejection, and a throwing accessor must not leave the call INTERNAL.
 		const controller = new AbortController();
 		const reason = {
+			get code(): string {
+				throw new Error('nope');
+			},
 			get message(): string {
 				throw new Error('nope');
 			},
@@ -257,6 +261,24 @@ describe('gRPC transport error normalization', () => {
 		);
 
 		expect(error.code).toBe('CANCELLED');
+	});
+
+	it('still reads a deadline when only the code accessor throws', async () => {
+		// Each property is read on its own, so one bad accessor does not hide the others.
+		const controller = new AbortController();
+		const reason = Object.defineProperty(new Error('stop'), 'code', {
+			get() {
+				throw new Error('nope');
+			},
+		});
+		reason.name = 'TimeoutError';
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(reason), 1)));
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
 
 	it('codes an abort with a primitive reason CANCELLED', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -241,6 +241,24 @@ describe('gRPC transport error normalization', () => {
 
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
+	it('survives a reason whose properties throw when read', async () => {
+		// `abort()` takes anything. Reading one must not throw out of a rejection handler, which would
+		// surface as an unhandled rejection.
+		const controller = new AbortController();
+		const reason = {
+			get message(): string {
+				throw new Error('nope');
+			},
+		};
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(reason), 1)));
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
 	it('codes an abort with a primitive reason CANCELLED', async () => {
 		// `abort('stop')` takes a string, which the transport stringifies into an INTERNAL error.
 		const controller = new AbortController();

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -151,14 +151,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('codes a caller deadline as DEADLINE_EXCEEDED rather than INTERNAL', async () => {
-		const client = clientRespondingWith(
-			() =>
-				new Promise<Response>((_, reject) => {
-					setTimeout(() => {
-						reject(Object.assign(new Error('The operation was aborted'), { name: 'TimeoutError' }));
-					}, 1);
-				}),
-		);
+		const client = makeClient(hangingFetch());
 
 		const error = await captureError(
 			client.ledgerService.getObject({ objectId: '0x1' }, { abort: AbortSignal.timeout(1) })
@@ -173,14 +166,8 @@ describe('gRPC transport error normalization', () => {
 		// `AbortError` reaches the transport's cancellation branch; anything else lands as INTERNAL and
 		// would be retried as a server failure.
 		const controller = new AbortController();
-		const client = clientRespondingWith(
-			() =>
-				new Promise<Response>((_, reject) => {
-					setTimeout(() => {
-						controller.abort(new Error('caller gave up'));
-						reject(new Error('caller gave up'));
-					}, 1);
-				}),
+		const client = makeClient(
+			hangingFetch(() => setTimeout(() => controller.abort(new Error('caller gave up')), 1)),
 		);
 
 		const error = await captureError(
@@ -190,17 +177,56 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
+	it('does not read a fabricated TimeoutError name as a deadline', async () => {
+		// Only `AbortSignal.timeout` — or a deadline this transport imposed — is a deadline. A reason
+		// dressed up to look like one is still a cancellation.
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() =>
+				setTimeout(
+					() => controller.abort(Object.assign(new Error('stop'), { name: 'TimeoutError' })),
+					1,
+				),
+			),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
+	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
+		// Headers resolve before a later failure propagates, so a caller that aborts once it has them
+		// — or simply races a truncated connection — must not have that failure relabelled.
+		const controller = new AbortController();
+		const client = clientRespondingWith(() =>
+			Promise.resolve(
+				new Response(
+					new ReadableStream({
+						start(streamController) {
+							setTimeout(() => streamController.error(new Error('connection reset')), 2);
+						},
+					}),
+					{ status: 200, headers: { 'content-type': 'application/grpc-web+proto' } },
+				),
+			),
+		);
+
+		const call = client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal });
+		await call.headers;
+		controller.abort();
+
+		const error = await captureError(call.response);
+
+		expect(error.message).toBe('connection reset');
+		expect(error.code).toBe('INTERNAL');
+	});
+
 	it('leaves a genuine cancellation coded CANCELLED', async () => {
 		const controller = new AbortController();
-		const client = clientRespondingWith(
-			() =>
-				new Promise<Response>((_, reject) => {
-					setTimeout(() => {
-						controller.abort();
-						reject(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }));
-					}, 1);
-				}),
-		);
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort(), 1)));
 
 		const error = await captureError(
 			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -5,7 +5,7 @@ import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
 
-import { SuiGrpcClient, SuiGrpcWebTransport } from '../../../src/grpc/index.js';
+import { GrpcWebFetchTransport, SuiGrpcClient } from '../../../src/grpc/index.js';
 
 /**
  * A grpc-web response that carries its status in the headers, which is how a fullnode answers a
@@ -36,8 +36,8 @@ function clientRespondingWith(response: Response | (() => Promise<Response>)) {
 }
 
 /**
- * A transport of the caller's own, standing in for one imported straight from
- * `@protobuf-ts/grpcweb-transport`. Whatever it does with errors is its own contract.
+ * A transport of the caller's own, standing in for one built without this package's
+ * `GrpcWebFetchTransport`. Whatever it does with errors is its own contract.
  */
 function transportRejectingWith(error: RpcError): RpcTransport {
 	return {
@@ -219,11 +219,11 @@ describe('a caller-supplied transport', () => {
 		expect(caught.code).toBe('INTERNAL');
 	});
 
-	it('normalizes when it is a SuiGrpcWebTransport the caller built', async () => {
+	it('normalizes when it is a GrpcWebFetchTransport the caller built from this package', async () => {
 		// The path an app takes when it needs interceptors: build the transport itself, from ours.
 		const client = new SuiGrpcClient({
 			network: 'testnet',
-			transport: new SuiGrpcWebTransport({
+			transport: new GrpcWebFetchTransport({
 				baseUrl: 'http://localhost',
 				fetch: (async () => statusResponse(5, 'Object%20not%20found%3A%200x1')) as typeof fetch,
 			}),

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -372,6 +372,50 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('INTERNAL');
 	});
 
+	it('codes an abort that lands while the body is being read', async () => {
+		const controller = new AbortController();
+		const client = clientRespondingWith(() =>
+			Promise.resolve(
+				new Response(
+					new ReadableStream({
+						start(streamController) {
+							setTimeout(() => {
+								controller.abort();
+								streamController.error(controller.signal.reason);
+							}, 2);
+						},
+					}),
+					{ status: 200, headers: { 'content-type': 'application/grpc-web+proto' } },
+				),
+			),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
+	it('does not decode the text of a body that failed mid-read', async () => {
+		const client = clientRespondingWith(() =>
+			Promise.resolve(
+				new Response(
+					new ReadableStream({
+						start(streamController) {
+							setTimeout(() => streamController.error(new Error('read /objects/a%2Fb failed')), 2);
+						},
+					}),
+					{ status: 200, headers: { 'content-type': 'application/grpc-web+proto' } },
+				),
+			),
+		);
+
+		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(error.message).toBe('read /objects/a%2Fb failed');
+	});
+
 	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
 		// Headers resolve before a later failure propagates, so a caller that aborts once it has
 		// them must not have that failure relabelled as a cancellation.

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -189,6 +189,37 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
+	it('codes a deadline as DEADLINE_EXCEEDED when the fetch substitutes its own AbortError', async () => {
+		// node-fetch rejects with a generic AbortError rather than the signal's reason, so the reason's
+		// text is not there to match on.
+		const client = makeClient(
+			((_input: unknown, init: RequestInit) =>
+				new Promise((_, reject) => {
+					init.signal?.addEventListener('abort', () =>
+						reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })),
+					);
+				})) as unknown as typeof globalThis.fetch,
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { timeout: 5 }).response,
+		);
+
+		expect(error.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('codes an abort with a primitive reason CANCELLED', async () => {
+		// `abort('stop')` takes a string, which the transport stringifies into an INTERNAL error.
+		const controller = new AbortController();
+		const client = makeClient(hangingFetch(() => setTimeout(() => controller.abort('stop'), 1)));
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
 	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
 		// Headers resolve before a later failure propagates, so a caller that aborts once it has
 		// them must not have that failure relabelled as a cancellation.
@@ -262,6 +293,16 @@ describe('a caller-supplied transport', () => {
 		await expect(client.core.resolveNameServiceAddress({ name: '@mysten' })).resolves.toEqual({
 			address: null,
 		});
+	});
+
+	it('does not decode a status the transport already decoded', async () => {
+		// The wire form of a message that literally reads `name%20has%20expired`. Decoding it twice
+		// would turn an unrelated failure into a resolved-to-null name.
+		const client = clientRespondingWith(statusResponse(8, 'name%2520has%2520expired'));
+
+		const error = await captureError(client.core.resolveNameServiceAddress({ name: '@mysten' }));
+
+		expect(error.message).toBe('name%20has%20expired');
 	});
 
 	it('normalizes when it is a GrpcWebFetchTransport the caller built from this package', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RpcError } from '@protobuf-ts/runtime-rpc';
+import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
+import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
 
 import { SuiGrpcClient } from '../../../src/grpc/index.js';
@@ -32,6 +33,45 @@ function makeClient(fetch: typeof globalThis.fetch) {
 function clientRespondingWith(response: Response | (() => Promise<Response>)) {
 	return makeClient((async () =>
 		typeof response === 'function' ? response() : response) as typeof globalThis.fetch);
+}
+
+/**
+ * A transport that is not grpc-web — standing in for `@protobuf-ts/grpc-transport`, which decodes
+ * `grpc-message` itself. Rejects every call with the *same* error instance, which is also what makes
+ * it a probe for call-specific state being recorded on a shared error.
+ */
+function transportRejectingWith(error: RpcError): RpcTransport {
+	return {
+		mergeOptions: (options) => options ?? {},
+		unary(method, input, _options) {
+			return new UnaryCall(
+				method,
+				{},
+				input,
+				Promise.reject(error),
+				Promise.reject(error),
+				Promise.reject(error),
+				Promise.reject(error),
+			);
+		},
+		serverStreaming: () => {
+			throw new Error('unused');
+		},
+		clientStreaming: () => {
+			throw new Error('unused');
+		},
+		duplex: () => {
+			throw new Error('unused');
+		},
+	};
+}
+
+/** A timeout signal that has already fired, so a call can be normalized against a settled abort. */
+async function firedTimeoutSignal() {
+	const signal = AbortSignal.timeout(0);
+	await new Promise((resolve) => setTimeout(resolve, 2));
+
+	return signal;
 }
 
 async function captureError(promise: Promise<unknown>) {
@@ -125,6 +165,28 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
 
+	it('codes an abort with a caller-supplied reason CANCELLED, not INTERNAL', async () => {
+		// `AbortController.abort(reason)` takes an arbitrary reason, and fetch rejects with it. Only an
+		// `AbortError` reaches the transport's cancellation branch; anything else lands as INTERNAL and
+		// would be retried as a server failure.
+		const controller = new AbortController();
+		const client = clientRespondingWith(
+			() =>
+				new Promise<Response>((_, reject) => {
+					setTimeout(() => {
+						controller.abort(new Error('caller gave up'));
+						reject(new Error('caller gave up'));
+					}, 1);
+				}),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
 	it('leaves a genuine cancellation coded CANCELLED', async () => {
 		const controller = new AbortController();
 		const client = clientRespondingWith(
@@ -142,5 +204,59 @@ describe('gRPC transport error normalization', () => {
 		);
 
 		expect(error.code).toBe('CANCELLED');
+	});
+});
+
+describe('gRPC transport error normalization on a non-grpc-web transport', () => {
+	it('leaves status text alone, since such a transport has already decoded it', async () => {
+		// `read_mask path: a%20b` is the decoded message: a second decode would collapse it to `a b`.
+		const error = new RpcError('read_mask path: a%20b', 'INVALID_ARGUMENT');
+		const client = new SuiGrpcClient({
+			network: 'testnet',
+			transport: transportRejectingWith(error),
+		});
+
+		const caught = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
+
+		expect(caught.message).toBe('read_mask path: a%20b');
+	});
+
+	it('still codes an aborted call from the signal', async () => {
+		const error = new RpcError('connection closed', 'INTERNAL');
+		const client = new SuiGrpcClient({
+			network: 'testnet',
+			transport: transportRejectingWith(error),
+		});
+
+		const caught = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: await firedTimeoutSignal() })
+				.response,
+		);
+
+		expect(caught.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('codes each call from its own signal when a transport reuses one error instance', async () => {
+		// Recording the mapping on the error would let whichever call normalized first decide the code
+		// every later call observes.
+		const shared = new RpcError('connection closed', 'INTERNAL');
+		const client = new SuiGrpcClient({
+			network: 'testnet',
+			transport: transportRejectingWith(shared),
+		});
+
+		const timedOut = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: await firedTimeoutSignal() })
+				.response,
+		);
+		expect(timedOut.code).toBe('DEADLINE_EXCEEDED');
+
+		const controller = new AbortController();
+		controller.abort();
+		const cancelled = await captureError(
+			client.ledgerService.getObject({ objectId: '0x2' }, { abort: controller.signal }).response,
+		);
+
+		expect(cancelled.code).toBe('CANCELLED');
 	});
 });

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { GrpcWebFetchTransport as UpstreamGrpcWebFetchTransport } from '@protobuf-ts/grpcweb-transport';
 import type { RpcOptions, RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
@@ -254,6 +255,22 @@ describe('a caller-supplied transport', () => {
 
 		expect(caught.message).toBe('Object%20not%20found');
 		expect(caught.code).toBe('INTERNAL');
+	});
+
+	it('still resolves an expired name through an upstream transport', async () => {
+		// Core policy must not depend on which transport the client was given: the node reports an
+		// expired name as RESOURCE_EXHAUSTED with prose, and upstream leaves that prose encoded.
+		const client = new SuiGrpcClient({
+			network: 'mainnet',
+			transport: new UpstreamGrpcWebFetchTransport({
+				baseUrl: 'http://localhost',
+				fetch: (async () => statusResponse(8, 'name%20has%20expired')) as typeof fetch,
+			}),
+		});
+
+		await expect(client.core.resolveNameServiceAddress({ name: '@mysten' })).resolves.toEqual({
+			address: null,
+		});
 	});
 
 	it('normalizes when it is a GrpcWebFetchTransport the caller built from this package', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -5,7 +5,7 @@ import type { RpcTransport } from '@protobuf-ts/runtime-rpc';
 import { RpcError, UnaryCall } from '@protobuf-ts/runtime-rpc';
 import { describe, expect, it } from 'vitest';
 
-import { SuiGrpcClient } from '../../../src/grpc/index.js';
+import { SuiGrpcClient, SuiGrpcWebTransport } from '../../../src/grpc/index.js';
 
 /**
  * A grpc-web response that carries its status in the headers, which is how a fullnode answers a
@@ -36,23 +36,23 @@ function clientRespondingWith(response: Response | (() => Promise<Response>)) {
 }
 
 /**
- * A transport that is not grpc-web — standing in for `@protobuf-ts/grpc-transport`, which decodes
- * `grpc-message` itself. Rejects every call with the *same* error instance, which is also what makes
- * it a probe for call-specific state being recorded on a shared error.
+ * A transport of the caller's own, standing in for one imported straight from
+ * `@protobuf-ts/grpcweb-transport`. Whatever it does with errors is its own contract.
  */
 function transportRejectingWith(error: RpcError): RpcTransport {
 	return {
 		mergeOptions: (options) => options ?? {},
 		unary(method, input, _options) {
-			return new UnaryCall(
-				method,
-				{},
-				input,
-				Promise.reject(error),
-				Promise.reject(error),
-				Promise.reject(error),
-				Promise.reject(error),
-			);
+			// Handled here so the promises a test does not await are not reported as unhandled: nothing
+			// wraps this transport now, so nothing else attaches to them.
+			const rejected = () => {
+				const promise = Promise.reject(error);
+				promise.catch(() => {});
+
+				return promise;
+			};
+
+			return new UnaryCall(method, {}, input, rejected(), rejected(), rejected(), rejected());
 		},
 		serverStreaming: () => {
 			throw new Error('unused');
@@ -64,14 +64,6 @@ function transportRejectingWith(error: RpcError): RpcTransport {
 			throw new Error('unused');
 		},
 	};
-}
-
-/** A timeout signal that has already fired, so a call can be normalized against a settled abort. */
-async function firedTimeoutSignal() {
-	const signal = AbortSignal.timeout(0);
-	await new Promise((resolve) => setTimeout(resolve, 2));
-
-	return signal;
 }
 
 async function captureError(promise: Promise<unknown>) {
@@ -207,56 +199,38 @@ describe('gRPC transport error normalization', () => {
 	});
 });
 
-describe('gRPC transport error normalization on a non-grpc-web transport', () => {
-	it('leaves status text alone, since such a transport has already decoded it', async () => {
-		// `read_mask path: a%20b` is the decoded message: a second decode would collapse it to `a b`.
-		const error = new RpcError('read_mask path: a%20b', 'INVALID_ARGUMENT');
-		const client = new SuiGrpcClient({
-			network: 'testnet',
-			transport: transportRejectingWith(error),
-		});
-
-		const caught = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
-
-		expect(caught.message).toBe('read_mask path: a%20b');
-	});
-
-	it('still codes an aborted call from the signal', async () => {
-		const error = new RpcError('connection closed', 'INTERNAL');
+describe('a caller-supplied transport', () => {
+	it('is used exactly as given, errors and all', async () => {
+		// Upstream's transport leaves `grpc-message` encoded and codes an aborted call INTERNAL. That
+		// is upstream's behaviour to change; the client does not reach into a transport it was handed.
+		const error = new RpcError('Object%20not%20found', 'INTERNAL');
+		const controller = new AbortController();
+		controller.abort();
 		const client = new SuiGrpcClient({
 			network: 'testnet',
 			transport: transportRejectingWith(error),
 		});
 
 		const caught = await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { abort: await firedTimeoutSignal() })
-				.response,
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
 		);
 
-		expect(caught.code).toBe('DEADLINE_EXCEEDED');
+		expect(caught.message).toBe('Object%20not%20found');
+		expect(caught.code).toBe('INTERNAL');
 	});
 
-	it('codes each call from its own signal when a transport reuses one error instance', async () => {
-		// Recording the mapping on the error would let whichever call normalized first decide the code
-		// every later call observes.
-		const shared = new RpcError('connection closed', 'INTERNAL');
+	it('normalizes when it is a SuiGrpcWebTransport the caller built', async () => {
+		// The path an app takes when it needs interceptors: build the transport itself, from ours.
 		const client = new SuiGrpcClient({
 			network: 'testnet',
-			transport: transportRejectingWith(shared),
+			transport: new SuiGrpcWebTransport({
+				baseUrl: 'http://localhost',
+				fetch: (async () => statusResponse(5, 'Object%20not%20found%3A%200x1')) as typeof fetch,
+			}),
 		});
 
-		const timedOut = await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { abort: await firedTimeoutSignal() })
-				.response,
-		);
-		expect(timedOut.code).toBe('DEADLINE_EXCEEDED');
+		const caught = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
 
-		const controller = new AbortController();
-		controller.abort();
-		const cancelled = await captureError(
-			client.ledgerService.getObject({ objectId: '0x2' }, { abort: controller.signal }).response,
-		);
-
-		expect(cancelled.code).toBe('CANCELLED');
+		expect(caught.message).toBe('Object not found: 0x1');
 	});
 });

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -322,16 +322,6 @@ describe('gRPC transport error normalization', () => {
 		expect(error.message).toBe('cancel /objects/a%2Fb');
 	});
 
-	it('does not decode the text of a fetch failure', async () => {
-		// The message is the fetch's own, not `grpc-message`.
-		const client = makeClient((() =>
-			Promise.reject(new Error('request to http://host/a%2Fb failed'))) as typeof globalThis.fetch);
-
-		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
-
-		expect(error.message).toBe('request to http://host/a%2Fb failed');
-	});
-
 	it('does not decode the text of an abort reason', async () => {
 		// The reason's message is local text, not `grpc-message` off the wire.
 		const controller = new AbortController();
@@ -347,33 +337,8 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
-	it('keeps a server status that came with metadata, whatever the abort reason says', async () => {
-		// An error built from an abort carries no metadata, so matching text cannot make this one look
-		// like a cancellation.
-		const controller = new AbortController();
-		const client = makeClient((async () => {
-			controller.abort(new Error('shutdown'));
-
-			return new Response(null, {
-				status: 200,
-				headers: {
-					'content-type': 'application/grpc-web+proto',
-					'grpc-status': '13',
-					'grpc-message': 'shutdown',
-					'x-request-id': 'abc',
-				},
-			});
-		}) as typeof globalThis.fetch);
-
-		const error = await captureError(
-			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
-		);
-
-		expect(error.code).toBe('INTERNAL');
-	});
-
-	it('passes through a body it cannot wrap, as node-fetch returns', async () => {
-		// Upstream reads those through `Symbol.asyncIterator`; calling `getReader` on one would throw.
+	it('leaves the response body alone, whatever shape it is', async () => {
+		// A `node-fetch` body is a node stream, which upstream reads through `Symbol.asyncIterator`.
 		const client = makeClient((async () => ({
 			status: 200,
 			statusText: 'OK',
@@ -386,30 +351,6 @@ describe('gRPC transport error normalization', () => {
 		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
 
 		expect(error.message).not.toContain('getReader');
-	});
-
-	it('answers from a header status without consuming the body', async () => {
-		// The transport never reads the body of a header-carried status, so a body that fails on its
-		// own must not mark the call a local failure and suppress decoding.
-		const client = makeClient((async () => ({
-			status: 200,
-			statusText: 'OK',
-			headers: new Headers({
-				'content-type': 'application/grpc-web+proto',
-				'grpc-status': '5',
-				'grpc-message': 'Object%20not%20found',
-			}),
-			body: new ReadableStream({
-				pull(streamController) {
-					streamController.error(new Error('connection reset'));
-				},
-			}),
-		})) as unknown as typeof globalThis.fetch);
-
-		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
-
-		expect(error.message).toBe('Object not found');
-		expect(error.code).toBe('NOT_FOUND');
 	});
 
 	it('codes an abort that lands while the body is being read', async () => {
@@ -435,52 +376,6 @@ describe('gRPC transport error normalization', () => {
 		);
 
 		expect(error.code).toBe('CANCELLED');
-	});
-
-	it('does not decode the text of a body that failed mid-read', async () => {
-		const client = clientRespondingWith(() =>
-			Promise.resolve(
-				new Response(
-					new ReadableStream({
-						start(streamController) {
-							setTimeout(() => streamController.error(new Error('read /objects/a%2Fb failed')), 2);
-						},
-					}),
-					{ status: 200, headers: { 'content-type': 'application/grpc-web+proto' } },
-				),
-			),
-		);
-
-		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
-
-		expect(error.message).toBe('read /objects/a%2Fb failed');
-	});
-
-	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
-		// Headers resolve before a later failure propagates, so a caller that aborts once it has
-		// them must not have that failure relabelled as a cancellation.
-		const controller = new AbortController();
-		const client = clientRespondingWith(() =>
-			Promise.resolve(
-				new Response(
-					new ReadableStream({
-						start(streamController) {
-							setTimeout(() => streamController.error(new Error('connection reset')), 2);
-						},
-					}),
-					{ status: 200, headers: { 'content-type': 'application/grpc-web+proto' } },
-				),
-			),
-		);
-
-		const call = client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal });
-		await call.headers;
-		controller.abort();
-
-		const error = await captureError(call.response);
-
-		expect(error.message).toBe('connection reset');
-		expect(error.code).toBe('INTERNAL');
 	});
 
 	it('leaves a genuine cancellation coded CANCELLED', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -191,6 +191,23 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
 	});
 
+	it('ignores a reason whose code is a numeric key or a prototype member', async () => {
+		// The enum's reverse mapping and `Object.prototype` both answer `in`; a status name is the one
+		// that maps to a number.
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() =>
+				setTimeout(() => controller.abort(Object.assign(new Error('x'), { code: '0' })), 1),
+			),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('CANCELLED');
+	});
+
 	it('ignores a reason whose code is not a gRPC status', async () => {
 		// A Node system error carries `code`, which must not be mistaken for a status.
 		const controller = new AbortController();
@@ -412,6 +429,22 @@ describe('a caller-supplied transport', () => {
 
 		expect(caught.message).toBe('Object%20not%20found');
 		expect(caught.code).toBe('INTERNAL');
+	});
+
+	it('resolves an expired name reported by another copy of runtime-rpc', async () => {
+		// A duplicate install fails `instanceof RpcError`, but carries the same shape.
+		const foreign = Object.assign(new Error('name has expired'), {
+			code: 'RESOURCE_EXHAUSTED',
+			meta: {},
+		});
+		const client = new SuiGrpcClient({
+			network: 'mainnet',
+			transport: transportRejectingWith(foreign as never),
+		});
+
+		await expect(client.core.resolveNameServiceAddress({ name: '@mysten' })).resolves.toEqual({
+			address: null,
+		});
 	});
 
 	it('still resolves an expired name through an upstream transport', async () => {

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -344,6 +344,22 @@ describe('gRPC transport error normalization', () => {
 		}
 	});
 
+	it('decodes a server status that arrives while the call is aborted', async () => {
+		// The abort takes the code, but the text came off the wire and still has to be readable.
+		const controller = new AbortController();
+		const client = makeClient((async () => {
+			controller.abort();
+
+			return statusResponse(13, 'Object%20not%20found');
+		}) as typeof globalThis.fetch);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.message).toBe('Object not found');
+	});
+
 	it('does not decode the text of an abort reason', async () => {
 		// The reason's message is local text, not `grpc-message` off the wire.
 		const controller = new AbortController();

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -8,10 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import { GrpcWebFetchTransport, SuiGrpcClient } from '../../../src/grpc/index.js';
 
-/**
- * A grpc-web response that carries its status in the headers, which is how a fullnode answers a
- * request it rejected outright. `grpc-message` is percent-encoded, per the protocol.
- */
+/** A grpc-web response carrying its status in the headers, with `grpc-message` percent-encoded. */
 function statusResponse(status: number, message: string) {
 	return new Response(null, {
 		status: 200,
@@ -36,16 +33,12 @@ function clientRespondingWith(response: Response | (() => Promise<Response>)) {
 		typeof response === 'function' ? response() : response) as typeof globalThis.fetch);
 }
 
-/**
- * A transport of the caller's own, standing in for one built without this package's
- * `GrpcWebFetchTransport`. Whatever it does with errors is its own contract.
- */
+/** A transport of the caller's own, built without this package's `GrpcWebFetchTransport`. */
 function transportRejectingWith(error: RpcError): RpcTransport {
 	return {
 		mergeOptions: (options) => options ?? {},
 		unary(method, input, _options) {
-			// Handled here so the promises a test does not await are not reported as unhandled: nothing
-			// wraps this transport now, so nothing else attaches to them.
+			// Handled here so promises a test does not await are not reported as unhandled.
 			const rejected = () => {
 				const promise = Promise.reject(error);
 				promise.catch(() => {});
@@ -67,7 +60,7 @@ function transportRejectingWith(error: RpcError): RpcTransport {
 	};
 }
 
-/** A server that accepts the request and then never answers, until the call's signal aborts. */
+/** A server that accepts the request and never answers, until the call's signal aborts. */
 function hangingFetch(onRequest?: (init: RequestInit) => void): typeof globalThis.fetch {
 	return ((_input: unknown, init: RequestInit) => {
 		onRequest?.(init);
@@ -121,14 +114,14 @@ describe('gRPC transport error normalization', () => {
 			captureError(call.trailers),
 		]);
 
-		// A single decode: `%2520` is a literal `%20` in the message, not a second escape to unwrap.
+		// One decode only: `%2520` is a literal `%20` in the message, not a second escape.
 		expect(fromResponse.message).toBe('invalid read_mask path: a%20b');
 		expect(fromStatus).toBe(fromResponse);
 		expect(fromTrailers).toBe(fromResponse);
 	});
 
 	it('keeps a message that is not percent-encoded verbatim', async () => {
-		// A bare `%` is not a valid escape; decoding would throw and lose the status text entirely.
+		// A bare `%` is not a valid escape, and decoding it would throw.
 		const client = clientRespondingWith(statusResponse(8, 'rate limit: 100% of quota used'));
 
 		const error = await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
@@ -163,9 +156,8 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('codes an abort with a caller-supplied reason CANCELLED, not INTERNAL', async () => {
-		// `AbortController.abort(reason)` takes an arbitrary reason, and fetch rejects with it. Only an
-		// `AbortError` reaches the transport's cancellation branch; anything else lands as INTERNAL and
-		// would be retried as a server failure.
+		// Only an `AbortError` reaches the transport's cancellation branch. Any other reason lands as
+		// INTERNAL, which callers retry as a server failure.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() => setTimeout(() => controller.abort(new Error('caller gave up')), 1)),
@@ -179,8 +171,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('does not read a fabricated TimeoutError name as a deadline', async () => {
-		// Only `AbortSignal.timeout` — or a deadline this transport imposed — is a deadline. A reason
-		// dressed up to look like one is still a cancellation.
+		// Only `AbortSignal.timeout`, or a deadline this transport imposed, counts as a deadline.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() =>
@@ -199,8 +190,8 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
-		// Headers resolve before a later failure propagates, so a caller that aborts once it has them
-		// — or simply races a truncated connection — must not have that failure relabelled.
+		// Headers resolve before a later failure propagates, so a caller that aborts once it has
+		// them must not have that failure relabelled as a cancellation.
 		const controller = new AbortController();
 		const client = clientRespondingWith(() =>
 			Promise.resolve(
@@ -239,8 +230,8 @@ describe('gRPC transport error normalization', () => {
 
 describe('a caller-supplied transport', () => {
 	it('is used exactly as given, errors and all', async () => {
-		// Upstream's transport leaves `grpc-message` encoded and codes an aborted call INTERNAL. That
-		// is upstream's behaviour to change; the client does not reach into a transport it was handed.
+		// Upstream leaves `grpc-message` encoded and codes an aborted call INTERNAL. The client does
+		// not reach into a transport it was handed.
 		const error = new RpcError('Object%20not%20found', 'INTERNAL');
 		const controller = new AbortController();
 		controller.abort();
@@ -258,8 +249,8 @@ describe('a caller-supplied transport', () => {
 	});
 
 	it('still resolves an expired name through an upstream transport', async () => {
-		// Core policy must not depend on which transport the client was given: the node reports an
-		// expired name as RESOURCE_EXHAUSTED with prose, and upstream leaves that prose encoded.
+		// The node reports an expired name as RESOURCE_EXHAUSTED with prose, which upstream leaves
+		// encoded. Whether the name resolves must not depend on the transport.
 		const client = new SuiGrpcClient({
 			network: 'mainnet',
 			transport: new UpstreamGrpcWebFetchTransport({
@@ -274,7 +265,7 @@ describe('a caller-supplied transport', () => {
 	});
 
 	it('normalizes when it is a GrpcWebFetchTransport the caller built from this package', async () => {
-		// The path an app takes when it needs interceptors: build the transport itself, from ours.
+		// What an app does when it needs interceptors: build the transport itself, from ours.
 		const client = new SuiGrpcClient({
 			network: 'testnet',
 			transport: new GrpcWebFetchTransport({
@@ -291,7 +282,7 @@ describe('a caller-supplied transport', () => {
 
 describe('gRPC transport deadlines', () => {
 	it('enforces a timeout the base transport only advertises', async () => {
-		// `grpc-timeout` asks the node to give up; it does nothing when the connection itself stalls.
+		// The header asks the node to give up. It does nothing when the connection stalls.
 		const client = makeClient(hangingFetch());
 
 		const error = await captureError(
@@ -340,8 +331,8 @@ describe('gRPC transport deadlines', () => {
 		expect(first.code).toBe('DEADLINE_EXCEEDED');
 		expect(second.code).toBe('DEADLINE_EXCEEDED');
 
-		// `mergeRpcOptions` hands these very options to a call that passes none of its own, so writing
-		// the composed signal onto them would leave every later call born already aborted.
+		// `mergeRpcOptions` hands these options to a call that passes none of its own, so writing the
+		// composed signal onto them would leave every later call already aborted.
 		const defaults = (transport as unknown as { defaultOptions: RpcOptions }).defaultOptions;
 		expect(defaults.abort).toBeUndefined();
 	});

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -114,7 +114,7 @@ describe('gRPC transport error normalization', () => {
 			captureError(call.trailers),
 		]);
 
-		// One decode only: `%2520` is a literal `%20` in the message, not a second escape.
+		// `%2520` is a literal `%20` in the message, not a second escape.
 		expect(fromResponse.message).toBe('invalid read_mask path: a%20b');
 		expect(fromStatus).toBe(fromResponse);
 		expect(fromTrailers).toBe(fromResponse);
@@ -156,8 +156,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('codes an abort with a caller-supplied reason CANCELLED, not INTERNAL', async () => {
-		// Only an `AbortError` reaches the transport's cancellation branch. Any other reason lands as
-		// INTERNAL, which callers retry as a server failure.
+		// Only an `AbortError` reaches the transport's cancellation branch; the rest land as INTERNAL.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() => setTimeout(() => controller.abort(new Error('caller gave up')), 1)),
@@ -171,9 +170,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('reads a reason named TimeoutError as a deadline, whatever built it', async () => {
-		// The reason is the caller's own data. Requiring a `DOMException` would lose a genuine timeout
-		// from another realm, and a caller naming their reason `TimeoutError` is declaring the same
-		// thing either way.
+		// Requiring a `DOMException` would lose a genuine timeout from another realm.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() =>
@@ -192,8 +189,7 @@ describe('gRPC transport error normalization', () => {
 	});
 
 	it('ignores a reason whose code is a numeric key or a prototype member', async () => {
-		// The enum's reverse mapping and `Object.prototype` both answer `in`; a status name is the one
-		// that maps to a number.
+		// The enum's reverse mapping and `Object.prototype` both answer `in`.
 		const controller = new AbortController();
 		const client = makeClient(
 			hangingFetch(() =>
@@ -392,8 +388,7 @@ describe('gRPC transport error normalization', () => {
 
 describe('a caller-supplied transport', () => {
 	it('is used exactly as given, errors and all', async () => {
-		// Upstream leaves `grpc-message` encoded and codes an aborted call INTERNAL. The client does
-		// not reach into a transport it was handed.
+		// Upstream leaves `grpc-message` encoded; the client does not reach into a transport.
 		const error = new RpcError('Object%20not%20found', 'INTERNAL');
 		const controller = new AbortController();
 		controller.abort();
@@ -427,8 +422,7 @@ describe('a caller-supplied transport', () => {
 	});
 
 	it('still resolves an expired name through an upstream transport', async () => {
-		// The node reports an expired name as RESOURCE_EXHAUSTED with prose, which upstream leaves
-		// encoded. Whether the name resolves must not depend on the transport.
+		// The node reports an expired name as RESOURCE_EXHAUSTED with prose, left encoded upstream.
 		const client = new SuiGrpcClient({
 			network: 'mainnet',
 			transport: new UpstreamGrpcWebFetchTransport({
@@ -443,8 +437,7 @@ describe('a caller-supplied transport', () => {
 	});
 
 	it('honours the decoded marker set by another copy of this package', async () => {
-		// A transport from a duplicate install decodes with the same registered symbol, so its errors
-		// are not decoded again, and their text is not read as a wire form.
+		// The marker is registered globally, so a duplicate install's transport sets the same one.
 		const decoded = new RpcError('name%20has%20expired', 'RESOURCE_EXHAUSTED');
 		Object.defineProperty(decoded, Symbol.for('@mysten/sui/grpc/decoded-status-message'), {
 			value: true,
@@ -492,8 +485,7 @@ describe('gRPC transport call options', () => {
 		await captureError(client.ledgerService.getObject({ objectId: '0x1' }).response);
 		await captureError(client.ledgerService.getObject({ objectId: '0x2' }).response);
 
-		// `mergeRpcOptions` hands these options to a call that passes none of its own, so writing the
-		// observing fetch onto them would install one call's state on every later call.
+		// `mergeRpcOptions` hands these to a call that passes no options of its own.
 		const defaults = (transport as unknown as { defaultOptions: { fetch?: unknown } })
 			.defaultOptions;
 

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -220,6 +220,31 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('CANCELLED');
 	});
 
+	it('keeps a server status that came with metadata, whatever the abort reason says', async () => {
+		// An error built from an abort carries no metadata, so matching text cannot make this one look
+		// like a cancellation.
+		const controller = new AbortController();
+		const client = makeClient((async () => {
+			controller.abort(new Error('shutdown'));
+
+			return new Response(null, {
+				status: 200,
+				headers: {
+					'content-type': 'application/grpc-web+proto',
+					'grpc-status': '13',
+					'grpc-message': 'shutdown',
+					'x-request-id': 'abc',
+				},
+			});
+		}) as typeof globalThis.fetch);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('INTERNAL');
+	});
+
 	it('leaves a server failure that raced an abort with the status the server gave it', async () => {
 		// Headers resolve before a later failure propagates, so a caller that aborts once it has
 		// them must not have that failure relabelled as a cancellation.

--- a/packages/sui/test/unit/grpc/transport-errors.test.ts
+++ b/packages/sui/test/unit/grpc/transport-errors.test.ts
@@ -233,6 +233,45 @@ describe('gRPC transport error normalization', () => {
 		expect(error.code).toBe('INTERNAL');
 	});
 
+	it('keeps a coded reason when the fetch substitutes its own AbortError', async () => {
+		// node-fetch never propagates the reason, so the caller's status has to be carried across.
+		const controller = new AbortController();
+		const client = makeClient(
+			((_input: unknown, init: RequestInit) =>
+				new Promise((_, reject) => {
+					setTimeout(() => controller.abort(new RpcError('gone', 'INTERNAL')), 1);
+					init.signal?.addEventListener('abort', () =>
+						reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })),
+					);
+				})) as unknown as typeof globalThis.fetch,
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('INTERNAL');
+	});
+
+	it('leaves a coded reason carrying metadata alone, text and all', async () => {
+		const controller = new AbortController();
+		const client = makeClient(
+			hangingFetch(() =>
+				setTimeout(
+					() => controller.abort(new RpcError('cancel /objects/a%2Fb', 'INTERNAL', { k: 'v' })),
+					1,
+				),
+			),
+		);
+
+		const error = await captureError(
+			client.ledgerService.getObject({ objectId: '0x1' }, { abort: controller.signal }).response,
+		);
+
+		expect(error.code).toBe('INTERNAL');
+		expect(error.message).toBe('cancel /objects/a%2Fb');
+	});
+
 	it('does not decode the text of an abort reason', async () => {
 		// The reason's message is local text, not `grpc-message` off the wire.
 		const controller = new AbortController();
@@ -384,6 +423,20 @@ describe('gRPC transport deadlines', () => {
 		);
 
 		expect(error.code).toBe('DEADLINE_EXCEEDED');
+	});
+
+	it('leaves a deadline past the timer ceiling to the header', async () => {
+		// `setTimeout` overflows beyond 2^31-1 ms and fires on the next tick, so a 30-day deadline
+		// would end the call immediately.
+		let sent: RequestInit | undefined;
+		const client = makeClient(hangingFetch((init) => (sent = init)));
+		const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+		client.ledgerService.getObject({ objectId: '0x1' }, { timeout: thirtyDaysMs });
+		await new Promise((resolve) => setTimeout(resolve, 5));
+
+		expect(sent?.signal ?? null).toBeNull();
+		expect((sent!.headers as Headers).get('grpc-timeout')).toBe(`${thirtyDaysMs}m`);
 	});
 
 	it('still sends the grpc-timeout header', async () => {


### PR DESCRIPTION
## Description

gRPC status messages reach callers percent-encoded, as `Object%20not%20found:%200x1`, because `grpc-message` is percent-encoded on the wire and protobuf-ts's `GrpcWebFetchTransport` reads the header verbatim ([#739](https://github.com/timostamm/protobuf-ts/pull/739) has been open upstream since December). Every consumer then decodes for itself, and a second decode throws `URIError` on a literal `%`.

`GrpcWebFetchTransport` exported from `@mysten/sui/grpc` is now a subclass of upstream's class of the same name, and `SuiGrpcClient` builds one by default. Same name and constructor, so existing code picks up the fixes unchanged:

- **Status messages are decoded once, at the wire boundary.** `client.core`, the generated service clients, response streams and caller interceptors all see the same text. A message that is not valid percent-encoding is kept as is.
- **An aborted call takes its status from the abort reason** instead of arriving as `INTERNAL` and being retried as a server failure: `DEADLINE_EXCEEDED` for an `AbortSignal.timeout`, the status an `RpcError` reason carries, and `CANCELLED` otherwise. Only `INTERNAL` and `CANCELLED` are rewritten, which are the two codes upstream produces for an abort, so a status the server answered with keeps its own.

Also here:

- `@mysten/sui/grpc` exports `RpcError` and `GrpcStatusCode`, so callers can narrow and code gRPC failures without a `@protobuf-ts/*` dependency.
- `SuiGrpcClient` forwards the rest of `GrpcWebOptions` (`fetch`, `format`, `meta`, `timeout`, `interceptors`, `jsonOptions`, `binaryOptions`) to the transport it builds. These were accepted by the type and dropped. `abort` is not forwarded, since every call carries its own signal.
- `core.ts` loses both of its `decodeURIComponent` calls, including the unguarded one that could replace a simulation failure with a `URIError`.

A transport the caller supplies is used as given. The one exception is `isNameServiceResolutionMiss`, which matches both the decoded and the wire form of the expired-name status, since whether a name resolves is the SDK's decision and should not depend on the transport.

**Deliberately out of scope**, after trying and reverting them during review: enforcing `timeout` as a local deadline, and wrapping the request or response body to prove which failure an abort caused. A failure that arrives while a call is aborted is relabelled as the abort, and a local diagnostic containing a percent escape may be decoded. Both are narrow races confined to display text, and the wrappers that close them broke `node-fetch` bodies and drained subscription streams.

## Test plan

- `test/unit/grpc/transport-errors.test.ts`: 28 cases driven through the real client with a stubbed `fetch`, covering decoding on service clients, `client.core` and server-streaming calls; one decode across `response`/`status`/`trailers`; every abort-reason shape (timeout, bare abort, custom, primitive, coded, foreign-copy, throwing accessors); a caller-supplied transport left untouched; and expired-name resolution through an upstream transport.
- `test/unit/grpc/exports.test.ts` and `test/unit/client/name-service.test.ts`.
- `pnpm --filter @mysten/sui test`: 557 unit tests and the package typecheck. `oxlint`, `prettier` and `validate-docs` clean.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oSGKfQXmagTp7urUiU19w
