### PR TITLE
fix(deepbook-v3): unbreak the release build by scoping the config type-check

### DIFF
--- a/packages/deepbook-v3/package.json
+++ b/packages/deepbook-v3/package.json
@@ -54,13 +54,13 @@
 		"prettier:fix": "prettier -w --ignore-unknown .",
 		"oxlint:check": "oxlint  .",
 		"oxlint:fix": "oxlint --fix",
-		"test": "vitest run",
-		"lint": "pnpm run typecheck:config && pnpm run oxlint:check && pnpm run prettier:check",
+		"test": "pnpm run config:typecheck && vitest run",
+		"lint": "pnpm run oxlint:check && pnpm run prettier:check",
 		"lint:fix": "pnpm run oxlint:fix && pnpm run prettier:fix",
 		"sync-deployment": "tsx scripts/sync-deployment.ts",
 		"sync-deployment:format": "prettier --write src/deployments",
 		"test:e2e": "PREDICT_SDK_TESTNET=1 vitest run test/predict/testnet",
-		"typecheck:config": "tsc --noEmit -p tsconfig.config.json"
+		"config:typecheck": "tsc --noEmit -p tsconfig.config.json"
 	},
 	"dependencies": {
 		"@mysten/bcs": "workspace:^",

--- a/packages/deepbook-v3/package.json
+++ b/packages/deepbook-v3/package.json
@@ -55,11 +55,12 @@
 		"oxlint:check": "oxlint  .",
 		"oxlint:fix": "oxlint --fix",
 		"test": "vitest run",
-		"lint": "pnpm run oxlint:check && pnpm run prettier:check",
+		"lint": "pnpm run typecheck:config && pnpm run oxlint:check && pnpm run prettier:check",
 		"lint:fix": "pnpm run oxlint:fix && pnpm run prettier:fix",
 		"sync-deployment": "tsx scripts/sync-deployment.ts",
 		"sync-deployment:format": "prettier --write src/deployments",
-		"test:e2e": "PREDICT_SDK_TESTNET=1 vitest run test/predict/testnet"
+		"test:e2e": "PREDICT_SDK_TESTNET=1 vitest run test/predict/testnet",
+		"typecheck:config": "tsc --noEmit -p tsconfig.config.json"
 	},
 	"dependencies": {
 		"@mysten/bcs": "workspace:^",

--- a/packages/deepbook-v3/tsconfig.config.json
+++ b/packages/deepbook-v3/tsconfig.config.json
@@ -1,6 +1,6 @@
 {
 	"extends": "../../tsconfig.shared.json",
-	"include": ["src"],
+	"include": ["*.config.ts", "*.config.mts", "scripts"],
 	"compilerOptions": {
 		"noEmit": true
 	}

--- a/packages/deepbook-v3/turbo.json
+++ b/packages/deepbook-v3/turbo.json
@@ -3,6 +3,10 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build", "build:docs", "@mysten/sui#build"]
+		},
+		"test": {
+			"dependsOn": ["^build", "build"],
+			"env": ["PREDICT_SDK_TESTNET"]
 		}
 	}
 }


### PR DESCRIPTION
## Description

`@mysten/deepbook-v3` has not published since **2.0.1** on 2026-08-18. Every release run since 2026-08-26 has failed at the same step, so `2.1.0`–`2.1.3` — the subpath consolidation — is on `main` unpublished. Merging the Version Packages PR has no effect, because the release never reaches the publish step:

```
Install ✅ → Build ❌ → Publish to npm  (skipped)
```

`build` is `tsc --noEmit && tsdown`, and `_release-package.yml` installs with `pnpm install --filter "<pkg>..." --prod`, which drops devDependencies. This package's `tsconfig.json` includes `*.config.ts` and `*.config.mts`, and those files import devDependencies:

| file | imports | available in the release job? |
|---|---|---|
| `sui-codegen.config.ts` | `@mysten/codegen` | no — devDependency, dropped by `--prod` |
| `vitest.config.mts` | `vitest/config` | no — devDependency, dropped by `--prod` |
| `tsdown.config.ts` | `tsdown` | yes — in the sandboxed `tools` list |

So `tsc` fails on two of the three and everything downstream is skipped. The live-testnet smoke gate ran and **passed** on each of those runs — the failure is one step earlier, which is why this presents as a publish or auth problem rather than a build one.

## The fix

Type-checking the config files is worth keeping — it is what stops a codegen config with an undeclared identifier from passing CI green. This keeps the check and moves it off the release path, in the shape the repo already uses.

- `tsconfig.json` returns to `include: ["src"]`, which is what the release build needs and what every other publishable package uses.
- The config files and `scripts/` move to a scoped `tsconfig.config.json`, run by `config:typecheck`. `scripts/` was previously type-checked by nothing, including the generator that writes shipped source.
- `config:typecheck` is invoked from `test`, matching the `test:typecheck` shape that **eight** packages already use (`sui`, `seal`, `hashi`, `pas`, `sponsor`, `wallet-sdk`, `zksend`, `ledgerjs-hw-app-sui`), all of which chain it from their `test` script. `test` already depends on `^build`, so the workspace types resolve; the release job runs `build`, never `test`.

### It also restores this package's test dependencies

While verifying the above I found the `test` task had lost its build dependencies. The root `@mysten/deepbook-v3#test` entry declares only `env`, and a scoped entry **replaces** the base task rather than merging with it — so `dependsOn: ["^build", "build"]` was silently dropped:

```
@mysten/deepbook-v3#test   dependencies: []
@mysten/hashi#test         dependencies: ["@mysten/bcs#build:docs", "@mysten/utils#build", …]
```

This package's tests were not building their workspace dependencies. Re-declared in the package's own `turbo.json`, which takes precedence over the root entry, so no root file changes. `@mysten/walrus#test` and `@mysten/seal#test` re-declare `dependsOn` in their scoped entries for exactly this reason.

**No root files are changed** — the diff is four files, all under `packages/deepbook-v3/`.

## Test plan

Reproduced the CI conditions — `pnpm install --filter "@mysten/deepbook-v3..." --prod --frozen-lockfile`, the workflow's exact sandboxed tool list (`tsdown@0.20.0-beta.1 typescript@5.9.3 @types/node@25.0.8`), then `pnpm --filter "@mysten/deepbook-v3..." --if-present run build`:

- **`main` reproduces the release failure exactly** — `TS2307: Cannot find module '@mysten/codegen'` and `TS2307: Cannot find module 'vitest/config'`.
- **This branch builds clean** under the same conditions.

With `packages/codegen/dist` and `packages/sui/dist` deleted, to mimic a fresh checkout:

- **cold `turbo test`** builds `bcs`, `sui` and `codegen` first, then passes **512/512** — 9 tasks, where before the fix it ran 1 task with no dependencies.
- **the guard still fires**: removing the `bcsOverrides` declaration fails with **TS18004**.
- **`pnpm --filter @mysten/deepbook-v3 lint` passes standalone**, unchanged from every other package — the type-check is not attached to `lint`.

Full package: build clean, 512/512 offline, 17/17 live-testnet, oxlint and prettier clean.

**No changeset** — a build-configuration change with no consumer-visible effect, and adding one would require another Version Packages merge before the pending `2.1.3` can ship. The changesets bot will note its absence; happy to add one if preferred.

## What actually publishes

Packed the artifact this branch would ship (`pnpm pack`, which is what the release runs) and installed it into a clean project:

- **`@mysten/deepbook-v3@2.1.3`**, with all four entry points present in the tarball (`dist/index.mjs`, `dist/account.mjs`, `dist/sessions.mjs`, `dist/predict/index.mjs`) plus `README.md` and `PREDICT.md`.
- `workspace:` refs are rewritten and satisfiable: `@mysten/bcs@^2.1.1` and peer `@mysten/sui@^2.28.0`, both resolving on npm today.
- Installed from the tarball in a fresh project, every entry point imports: root **52** exports, `/account` **11**, `/sessions` **14**, `/predict` **26**, and `getDeployment('testnet')` reports `predict-testnet-8-21`.

Replicating the orchestrator's own logic against `main`, `@mysten/deepbook-v3@2.1.3` is the **only** unpublished package, and there are no pending changesets, so nothing causes it to skip.

## After merge

Once `Turborepo CI` is green on `main`, the Release Orchestrator fires on `workflow_run`, finds `2.1.3` unpublished, and dispatches this package's release. Every other package released successfully through the same reusable workflow on 2026-09-01 — `deepbook-v3` was the only failure — so the publish path itself is known good. `Publish to npm` has not executed for *this* package since 2026-08-18 because the build failure has been masking it, so the first run is worth watching rather than assuming.

## Follow-up

Root `turbo.json` still carries `"@mysten/deepbook-v3#test": { "env": ["PREDICT_SDK_TESTNET"] }`. It is now redundant — the package's own `turbo.json` declares both `env` and `dependsOn` — and removing it would prevent the same override trap next time. Left out here to keep this change free of root files.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoL9A5eMTtoJTvjPr6vcE3
