### PR TITLE
docs(sui): clarify dynamic object field migration

### DIFF
--- a/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
+++ b/packages/docs/content/sui/migrations/sui-2.0/json-rpc-migration.mdx
@@ -130,7 +130,7 @@ use the same replacement under `client.core`.
 | `getBalance`                 | `getBalance`                                                          |
 | `getCoinMetadata`            | `getCoinMetadata`                                                     |
 | `getDynamicFields`           | `listDynamicFields`                                                   |
-| `getDynamicFieldObject`      | `getDynamicField` or `client.core.getDynamicObjectField`              |
+| `getDynamicFieldObject`      | `getDynamicField` or `getDynamicObjectField`, depending on field kind |
 | `getTransactionBlock`        | `getTransaction`                                                      |
 | `multiGetTransactionBlocks`  | Multiple `getTransaction` calls                                       |
 | `executeTransactionBlock`    | `executeTransaction`                                                  |
@@ -143,6 +143,55 @@ use the same replacement under `client.core`.
 | `getMoveFunctionArgTypes`    | No direct equivalent; `getMoveFunction` returns normalized signatures |
 | `resolveNameServiceAddress`  | `resolveNameServiceAddress` (returns `{ address }`)                   |
 | `resolveNameServiceNames`    | No direct equivalent for listing every name assigned to an address    |
+
+The JSON-RPC `getDynamicFieldObject` method returned an object for both field kinds. For a regular
+dynamic field, it returned the `0x2::dynamic_field::Field<Name, Value>` object. For a dynamic object
+field, it derived the wrapper field, extracted its child ID, and returned the referenced child
+object instead of the wrapper.
+
+The replacement APIs expose these operations separately. `getDynamicField` returns a normalized
+field entry and its BCS-encoded value. `getDynamicObjectField` derives the wrapper, extracts the
+child ID, and loads the referenced object. If the field kind is not known in advance, call
+`listDynamicFields` and check whether its `$kind` is `DynamicField` or `DynamicObject`. SDKs can
+call the same methods through `client.core`.
+
+```typescript
+const page = await client.listDynamicFields({ parentId });
+
+for (const field of page.dynamicFields) {
+	if (field.$kind === 'DynamicObject') {
+		const { object } = await client.getDynamicObjectField({
+			parentId,
+			name: field.name,
+			include: { content: true },
+		});
+
+		console.log(object.objectId, object.content);
+	} else {
+		const { dynamicField } = await client.getDynamicField({
+			parentId,
+			name: field.name,
+		});
+
+		console.log(dynamicField.value.type, dynamicField.value.bcs);
+	}
+}
+```
+
+The dynamic object field wrapper remains accessible through `getDynamicField`. Wrap the name type
+explicitly and pass the original name BCS bytes:
+
+```typescript
+const { dynamicField } = await client.getDynamicField({
+	parentId,
+	name: {
+		type: `0x2::dynamic_object_field::Wrapper<${fieldName.type}>`,
+		bcs: fieldName.bcs,
+	},
+});
+
+console.log(dynamicField.fieldId, dynamicField.childId);
+```
 
 `getMoveFunction` exposes normalized parameter signatures, but it does not reproduce the legacy
 `Pure`, `Object`, and object-access classifications from `getMoveFunctionArgTypes`. Likewise,


### PR DESCRIPTION
## Description

Clarify how to migrate legacy `getDynamicFieldObject` calls:

- use `getDynamicField` for regular dynamic fields
- use `getDynamicObjectField` for dynamic object fields
- inspect `$kind` from `listDynamicFields` when the kind is not known in advance
- use the top-level method in application code and `client.core` in reusable SDK code

Adds a complete example that branches on the field kind and calls the matching API. This addresses the documentation ambiguity surfaced by https://github.com/MystenLabs/sui/issues/27894.

## Test plan

- `node scripts/build-docs.ts --all`
- `node scripts/validate-llm-docs.ts`
- `prettier --check content/sui/migrations/sui-2.0/json-rpc-migration.mdx`

All checks pass. The underlying scripts were run directly because the local `pnpm` wrapper reported that `node_modules` was out of sync with `pnpm-lock.yaml`.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.