### PR TITLE
feat(deepbook-v3): re-pin Predict bindings to main and name the collateral USDC (DBU-776)

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,19 @@
+---
+'@mysten/deepbook-v3': minor
+---
+
+Target the `deepbook-predict-testnet` deployment. Every testnet id the SDK ships changes — the
+Predict, account and sessions packages and their shared objects — so `getConfig('testnet')`,
+`getAccountConfig('testnet')`, `getSessionsConfig('testnet')` and `TESTNET_CONFIG` all resolve
+against the new deployment, and `getDeployment('testnet')` reports it by name and source commit.
+Anything pinned to the previous testnet deployment's ids will not find its accounts, positions or
+markets there; they are separate deployments, not an upgrade.
+
+The settlement collateral is renamed upstream from `dusdc::dusdc::DUSDC` to `usdc::usdc::USDC`, so
+one Move module path resolves on both testnet and mainnet and mainnet can link native USDC by
+address alone. `quoteCoinType` carries the new type. The testnet coin keeps the `DUSDC` display
+symbol, which is what distinguishes the mintable test coin from native USDC in wallets and
+explorers — read `quoteCoinType` rather than assuming a symbol or a type.
+
+The exported surface is otherwise unchanged: no symbol is added, removed or re-typed, and the
+renamed Move argument (`min_usdc_out`) is internal to the transaction builders.

--- a/.github/workflows/deepbook-v3-e2e.yml
+++ b/.github/workflows/deepbook-v3-e2e.yml
@@ -1,11 +1,15 @@
 ---
 name: DeepBook live-testnet tests
 
-# The `/predict` and `/sessions` bindings are generated against (and pinned to) a specific
-# deployed package set, so this suite runs against LIVE testnet rather than localnet:
-# localnet publishes deepbookv3 `main`, which has drifted from the deployed surface and
-# is therefore the wrong parity oracle. Kept off the `pull_request` lane so a network
-# blip never fails unrelated PRs; the offline suite (`test`) covers those.
+# This suite runs against LIVE testnet rather than localnet, because it is the deployed
+# surface it is meant to check the SDK against. Kept off the `pull_request` lane so a
+# network blip never fails unrelated PRs; the offline suite (`test`) covers those.
+#
+# EXPECTED RED until the Predict republish: the `/predict` and `/sessions` bindings are
+# now generated against deepbookv3 `main` rather than the deployed package set (see
+# `packages/deepbook-v3/sui-codegen.config.ts`), so they describe a surface live testnet
+# does not serve yet. This goes green again when the republish lands and the deployment
+# manifest is synced.
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/deepbook-v3-e2e.yml
+++ b/.github/workflows/deepbook-v3-e2e.yml
@@ -4,12 +4,6 @@ name: DeepBook live-testnet tests
 # This suite runs against LIVE testnet rather than localnet, because it is the deployed
 # surface it is meant to check the SDK against. Kept off the `pull_request` lane so a
 # network blip never fails unrelated PRs; the offline suite (`test`) covers those.
-#
-# EXPECTED RED until the Predict republish: the `/predict` and `/sessions` bindings are
-# now generated against deepbookv3 `main` rather than the deployed package set (see
-# `packages/deepbook-v3/sui-codegen.config.ts`), so they describe a surface live testnet
-# does not serve yet. This goes green again when the republish lands and the deployment
-# manifest is synced.
 on:
   workflow_dispatch:
   schedule:

--- a/packages/deepbook-v3/CLAUDE.md
+++ b/packages/deepbook-v3/CLAUDE.md
@@ -182,11 +182,20 @@ pnpm --filter @mysten/deepbook-v3 test
 pnpm --filter @mysten/deepbook-v3 test:e2e
 
 # Regenerate bindings, and refresh the deployed ids. Both read the sibling ../deepbookv3
-# checkout, and both want it on the deployment BRANCH (e.g. predict-testnet-8-21) — not on
-# the manifest's sourceCommit, where the manifest does not yet exist.
+# checkout, but they now want DIFFERENT refs, so they are two separate checkouts:
+#
+#   codegen          -> deepbookv3 `main`. Reversed from the old "check out the deployment
+#                       branch" rule: Predict is being republished from main, so main is the
+#                       commit that gets deployed. sui-codegen.config.ts owns this and records
+#                       the exact anchor; move it forward again at deploy time.
+#   sync-deployment  -> the deployment BRANCH (e.g. predict-testnet-8-21), which is the only
+#                       ref carrying the manifest — not the manifest's sourceCommit, where it
+#                       does not yet exist.
 #
 # codegen rewrites EVERY entry in sui-codegen.config.ts from whatever commit that checkout
-# is on, so diff the result: a regeneration meant for one entry rewrites the rest.
+# is on, so diff the result: a regeneration meant for one entry rewrites the rest. In
+# particular it rewrites the @deepbook/* margin bindings, which are deliberately NOT on main
+# — revert those unless you intend to re-pin a live mainnet surface.
 pnpm --filter @mysten/deepbook-v3 codegen
 pnpm --filter @mysten/deepbook-v3 sync-deployment
 ```

--- a/packages/deepbook-v3/CLAUDE.md
+++ b/packages/deepbook-v3/CLAUDE.md
@@ -182,15 +182,10 @@ pnpm --filter @mysten/deepbook-v3 test
 pnpm --filter @mysten/deepbook-v3 test:e2e
 
 # Regenerate bindings, and refresh the deployed ids. Both read the sibling ../deepbookv3
-# checkout, but they now want DIFFERENT refs, so they are two separate checkouts:
-#
-#   codegen          -> deepbookv3 `main`. Reversed from the old "check out the deployment
-#                       branch" rule: Predict is being republished from main, so main is the
-#                       commit that gets deployed. sui-codegen.config.ts owns this and records
-#                       the exact anchor; move it forward again at deploy time.
-#   sync-deployment  -> the deployment BRANCH (e.g. predict-testnet-8-21), which is the only
-#                       ref carrying the manifest — not the manifest's sourceCommit, where it
-#                       does not yet exist.
+# checkout on the deployment BRANCH (currently `deepbook-predict-testnet`) — not the
+# manifest's sourceCommit, where the manifest does not yet exist. That branch's Move sources
+# are identical to `main`, so one checkout serves both; if a future deployment lags main,
+# the deployment is what the bindings must describe.
 #
 # codegen rewrites EVERY entry in sui-codegen.config.ts from whatever commit that checkout
 # is on, so diff the result: a regeneration meant for one entry rewrites the rest. In

--- a/packages/deepbook-v3/PREDICT.md
+++ b/packages/deepbook-v3/PREDICT.md
@@ -32,10 +32,10 @@ const client = new SuiGrpcClient({
 // One-time: create your Predict account (a shared AccountWrapper).
 const createTx = client.predict.tx.createManager();
 
-// Fund it: pulls DUSDC from your address (coin objects and/or address balance).
+// Fund it: pulls USDC from your address (coin objects and/or address balance).
 const depositTx = client.predict.tx.deposit(myAddress, 250); // $250
 
-// Cash out: lands in your DUSDC address balance by default (no coin-object churn).
+// Cash out: lands in your USDC address balance by default (no coin-object churn).
 // Pass { toCoinObject: true } if you need a discrete Coin<T> instead.
 const withdrawTx = client.predict.tx.withdraw(myAddress, 100); // $100
 
@@ -101,7 +101,7 @@ reads use the primitives layer, which returns raw `bigint`s (`accountBalance`, `
 
 | Concept                                     | You pass / receive                                             | On-chain raw                          |
 | ------------------------------------------- | -------------------------------------------------------------- | ------------------------------------- |
-| Amounts (deposit, spend, maxCost, balances) | USD decimal number or string (`12.5`, `"12.5"`)                | ×1e6 (DUSDC)                          |
+| Amounts (deposit, spend, maxCost, balances) | USD decimal number or string (`12.5`, `"12.5"`)                | ×1e6 (USDC)                           |
 | `quantity`                                  | **max payout** in USD; positions pay $1 per contract at expiry | ×1e6, in $0.01 lots                   |
 | `strike`                                    | USD (`105_000`)                                                | ×1e9, must land on the admission grid |
 | `maxProbability`                            | 0..1 (`0.35` = 35¢ per $1 contract)                            | ×1e9                                  |
@@ -236,8 +236,8 @@ stop requiring an SDK release for target resolution.
 - `claimSettled` closes the order in full — the deployed entrypoint takes no quantity.
 - **`withdraw` lands in your address balance by default** (`0x2::coin::send_funds`), not a coin
   object — it merges into the versionless accumulator `deposit` already draws from, so the round
-  trip never accretes stray `Coin<DUSDC>` objects. `read.balance(owner)` reflects the account's
-  internal custody balance; use the client's `getBalance(owner)` for the wallet-side DUSDC total
+  trip never accretes stray `Coin<USDC>` objects. `read.balance(owner)` reflects the account's
+  internal custody balance; use the client's `getBalance(owner)` for the wallet-side USDC total
   (coin objects + address balance). Pass `withdraw(owner, amt, { toCoinObject: true })` for a
   discrete coin (wallets/explorers that only render coin objects, or same-PTB composition).
 

--- a/packages/deepbook-v3/PREDICT.md
+++ b/packages/deepbook-v3/PREDICT.md
@@ -109,6 +109,11 @@ reads use the primitives layer, which returns raw `bigint`s (`accountBalance`, `
 
 `side: "up"` wins if the settlement price is above the strike; `"down"` below.
 
+Trading closes slightly before expiry: the protocol enforces a short pre-expiry no-trade window
+(`no_trade_window_ms` on the live `ProtocolConfig`, 2s on the current testnet deployment), so a mint
+or redeem submitted inside it aborts `ETradeWindowClosed` rather than filling. Treat the last
+seconds of a window as untradeable rather than retrying.
+
 ## Reference-price markets (Polymarket-style windows)
 
 Each market carries an on-chain **reference price** — derived from the exact previous-window oracle

--- a/packages/deepbook-v3/scripts/sync-deployment.ts
+++ b/packages/deepbook-v3/scripts/sync-deployment.ts
@@ -280,7 +280,7 @@ export const ${manifest.network.toUpperCase()}_PREDICT: PredictIds = Object.free
 		oracleRegistry: ${lit(reqId(o, 'oracleRegistry', 'objects'))},
 		accountRegistry: ${lit(reqId(o, 'accountRegistry', 'objects'))},
 	}),
-	quoteCoinType: ${lit(reqType(c, 'dusdc', 'coinTypes'))},
+	quoteCoinType: ${lit(reqType(c, 'usdc', 'coinTypes'))},
 	/**
 	 * \`plp\` is the LP share coin type. It is NOT derivable from \`packages.predict\`: a Move
 	 * type tag keeps the ORIGINAL package id across an upgrade, while \`packages.predict\`

--- a/packages/deepbook-v3/scripts/sync-deployment.ts
+++ b/packages/deepbook-v3/scripts/sync-deployment.ts
@@ -13,16 +13,17 @@
  * Check the sibling checkout out to the DEPLOYMENT BRANCH — not the manifest's own
  * `sourceCommit`. The deploy tooling writes the manifest in a commit that lands *after* the
  * sources it deployed, so the manifest does not exist at `sourceCommit`. For
- * `predict-testnet-8-21` that trailing commit adds only `Published.toml` files and the
- * manifest itself, no Move sources — so the branch tip is also the right ref for
- * `pnpm codegen`, and one checkout serves both.
+ * `deepbook-predict-testnet` that trailing commit adds only `Published.toml` files and the
+ * manifest itself, no Move sources — verified: the branch's predict/account/propbook sources
+ * are byte-identical to the `main` the bindings are pinned to — so the branch tip is also the
+ * right ref for `pnpm codegen`, and one checkout serves both.
  *
  * The emitted file is not prettier-formatted, so follow with `sync-deployment:format`. They
  * are two scripts rather than one `&&` chain because pnpm appends `-- <args>` after the whole
  * chain: `sync-deployment -- --manifest <path>` sent the flag to prettier, which reformatted
  * the manifest in place, while the generator silently used the default path.
  *
- *   git -C ../../../deepbookv3 checkout predict-testnet-8-21
+ *   git -C ../../../deepbookv3 checkout deepbook-predict-testnet
  *   pnpm --filter @mysten/deepbook-v3 sync-deployment
  *   pnpm --filter @mysten/deepbook-v3 sync-deployment -- --manifest /path/to/deployment.testnet.json
  *   pnpm --filter @mysten/deepbook-v3 sync-deployment:format
@@ -32,7 +33,13 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const DEFAULT_MANIFEST = '../../../deepbookv3/packages/predict/deployment/deployment.testnet.json';
-const SUPPORTED_SCHEMA = 6;
+// Bumped 6 -> 8 for the `deepbook-predict-testnet` deployment. Verified every field this
+// script reads still exists and still means the same thing: v8 re-keyed `writers.*` to
+// `oracleDependencies.*` and dropped `writers.keeper.lifecycleCap` (the pool-valuation cap
+// split), but this script consumes none of those — it reads only `packages`, `objects`,
+// `coinTypes`, `underlyings`, `initialConfiguration.units` and `sourceCommit`. The one
+// change that does reach it is the collateral's `coinTypes` key, now `usdc`, read below.
+const SUPPORTED_SCHEMA = 8;
 
 interface Manifest {
 	schemaVersion: number;
@@ -136,7 +143,7 @@ try {
 	throw new Error(
 		`could not read the deployment manifest at ${manifestPath}. ` +
 			'Check the sibling deepbookv3 checkout out to the deployment BRANCH (e.g. ' +
-			"`predict-testnet-8-21`), not to the manifest's sourceCommit — the deploy tooling " +
+			"`deepbook-predict-testnet`), not to the manifest's sourceCommit — the deploy tooling " +
 			'writes the manifest in a later commit, so it does not exist at that commit. ' +
 			'Or pass --manifest with an explicit path.',
 		{ cause },

--- a/packages/deepbook-v3/scripts/sync-deployment.ts
+++ b/packages/deepbook-v3/scripts/sync-deployment.ts
@@ -13,10 +13,10 @@
  * Check the sibling checkout out to the DEPLOYMENT BRANCH — not the manifest's own
  * `sourceCommit`. The deploy tooling writes the manifest in a commit that lands *after* the
  * sources it deployed, so the manifest does not exist at `sourceCommit`. For
- * `deepbook-predict-testnet` that trailing commit adds only `Published.toml` files and the
- * manifest itself, no Move sources — verified: the branch's predict/account/propbook sources
- * are byte-identical to the `main` the bindings are pinned to — so the branch tip is also the
- * right ref for `pnpm codegen`, and one checkout serves both.
+ * `deepbook-predict-testnet` those trailing commits add no Move sources — only publication
+ * metadata, the manifest, and deploy tooling. Verified: the branch's predict/account/propbook
+ * sources are byte-identical to `main`, so the branch tip is also the right ref for
+ * `pnpm codegen`, and one checkout serves both.
  *
  * The emitted file is not prettier-formatted, so follow with `sync-deployment:format`. They
  * are two scripts rather than one `&&` chain because pnpm appends `-- <args>` after the whole

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/builder_code.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/builder_code.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 
 /**
- * Owns deterministic builder referral codes and the DUSDC fees delivered to their
+ * Owns deterministic builder referral codes and the USDC fees delivered to their
  * object addresses through the funds accumulator. Codes are derived per owner and
  * index, and only the immutable owner may withdraw accumulated fees.
  */
@@ -112,7 +112,7 @@ export interface ClaimableBuilderFeesOptions {
 		predictPackageId?: string;
 	};
 }
-/** Return visible DUSDC builder fees for SDK and devInspect reads. */
+/** Return visible USDC builder fees for SDK and devInspect reads. */
 export function claimableBuilderFees(options: ClaimableBuilderFeesOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -137,7 +137,7 @@ export interface ClaimAllBuilderFeesOptions {
 	};
 }
 /**
- * Claims all settled DUSDC builder fees for the immutable owner; an empty
+ * Claims all settled USDC builder fees for the immutable owner; an empty
  * accumulator returns a zero coin.
  */
 export function claimAllBuilderFees(options: ClaimAllBuilderFeesOptions) {

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/config_events.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/config_events.ts
@@ -79,9 +79,9 @@ export const MarketCreated = new MoveStruct({
 		tick_size: U64,
 		/** Coarser raw-price step that new finite mint boundaries must align to. */
 		admission_tick_size: U64,
-		/** DUSDC pool allocation cap snapshotted for this expiry. */
+		/** USDC pool allocation cap snapshotted for this expiry. */
 		max_expiry_allocation: U64,
-		/** Minimum DUSDC cash target snapshotted for this expiry. */
+		/** Minimum USDC cash target snapshotted for this expiry. */
 		initial_expiry_cash: U64,
 		backing_buffer_lambda: U64,
 		base_fee: U64,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/config_events.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/config_events.ts
@@ -50,6 +50,13 @@ export const PlpFeeRatesUpdated = new MoveStruct({
 		onchain_timestamp_ms: U64,
 	},
 });
+export const NoTradeWindowUpdated = new MoveStruct({
+	name: `${$moduleName}::NoTradeWindowUpdated`,
+	fields: {
+		no_trade_window_ms: U64,
+		onchain_timestamp_ms: U64,
+	},
+});
 export const TradingPausedUpdated = new MoveStruct({
 	name: `${$moduleName}::TradingPausedUpdated`,
 	fields: {

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/deps/sui/vec_map.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/deps/sui/vec_map.ts
@@ -1,0 +1,33 @@
+/**************************************************************
+ * THIS FILE IS GENERATED AND SHOULD NOT BE MANUALLY MODIFIED *
+ **************************************************************/
+import { type BcsType, bcs } from '@mysten/sui/bcs';
+import { MoveStruct } from '../../../utils/index.js';
+const $moduleName = '0x2::vec_map';
+/** An entry in the map */
+export function Entry<K extends BcsType<any>, V extends BcsType<any>>(...typeParameters: [K, V]) {
+	return new MoveStruct({
+		name: `${$moduleName}::Entry<${typeParameters[0].name as K['name']}, ${typeParameters[1].name as V['name']}>`,
+		fields: {
+			key: typeParameters[0],
+			value: typeParameters[1],
+		},
+	});
+}
+/**
+ * A map data structure backed by a vector. The map is guaranteed not to contain
+ * duplicate keys, but entries are _not_ sorted by key--entries are included in
+ * insertion order. All operations are O(N) in the size of the map--the intention
+ * of this data structure is only to provide the convenience of programming against
+ * a map API. Large maps should use handwritten parent/child relationships instead.
+ * Maps that need sorted iteration rather than insertion order iteration should
+ * also be handwritten.
+ */
+export function VecMap<K extends BcsType<any>, V extends BcsType<any>>(...typeParameters: [K, V]) {
+	return new MoveStruct({
+		name: `${$moduleName}::VecMap<${typeParameters[0].name as K['name']}, ${typeParameters[1].name as V['name']}>`,
+		fields: {
+			contents: bcs.vector(Entry(typeParameters[0], typeParameters[1])),
+		},
+	});
+}

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/expiry_cash.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/expiry_cash.ts
@@ -3,7 +3,7 @@
  **************************************************************/
 
 /**
- * Expiry-local DUSDC custody and isolated reserve accounting.
+ * Expiry-local USDC custody and isolated reserve accounting.
  *
  * This leaf owns cash balance arithmetic and the inventory-impact escrow used only
  * for live-close rebates. It does not decide payment eligibility, pool allocation,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/expiry_market.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/expiry_market.ts
@@ -19,14 +19,24 @@ import {
 	type RawTransactionArgument,
 	type ConfigValue,
 } from '../utils/index.js';
-import { bcs } from '@mysten/sui/bcs';
 import { U64 } from '../../bcs/integers.js';
+import { bcs } from '@mysten/sui/bcs';
 import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
 import * as expiry_cash from './expiry_cash.js';
 import * as balance from './deps/sui/balance.js';
 import * as strike_exposure from './strike_exposure.js';
 import * as ewma from './ewma.js';
 const $moduleName = '@local-pkg/deepbook_predict::expiry_market';
+export const ValuationStamp = new MoveStruct({
+	name: `${$moduleName}::ValuationStamp`,
+	fields: {
+		flush_seq: U64,
+		/** `cash.balance()` at the snapshot instant. */
+		snapshot_cash: U64,
+		/** `cash.inventory_impact_reserve()` at the snapshot instant. */
+		snapshot_impact_reserve: U64,
+	},
+});
 export const ExpiryMarket = new MoveStruct({
 	name: `${$moduleName}::ExpiryMarket`,
 	fields: {
@@ -34,9 +44,9 @@ export const ExpiryMarket = new MoveStruct({
 		/** Propbook underlying this market was created for. */
 		propbook_underlying_id: bcs.u32(),
 		expiry: U64,
-		/** DUSDC custody and payout backing. */
+		/** USDC custody and payout backing. */
 		cash: expiry_cash.ExpiryCash,
-		/** Sponsor-funded DUSDC available to subsidize this market's taker fees. */
+		/** Sponsor-funded USDC available to subsidize this market's taker fees. */
 		fee_incentive_balance: balance.Balance,
 		/** Exposure lifecycle state for this expiry's strike ticks. */
 		strike_exposure: strike_exposure.StrikeExposure,
@@ -48,6 +58,14 @@ export const ExpiryMarket = new MoveStruct({
 		 * through the registry (ungated kill switch).
 		 */
 		mint_paused: bcs.bool(),
+		/**
+		 * `Some` from the flush's snapshot stage until this market's `value_expiry` (or
+		 * lazily discarded once the stamp goes stale — see `ValuationStamp`). Trading is
+		 * never gated on it and never touches it: the cash rows are captured eagerly here
+		 * at the snapshot instant, and the payout tree captures its own boundary shadows
+		 * as trades first touch each node.
+		 */
+		valuation_stamp: bcs.option(ValuationStamp),
 	},
 });
 export const MintQuote = new MoveStruct({
@@ -224,7 +242,7 @@ export interface CashBalanceOptions {
 		predictPackageId?: string;
 	};
 }
-/** Return expiry DUSDC custody for SDK and devInspect state reads. */
+/** Return expiry USDC custody for SDK and devInspect state reads. */
 export function cashBalance(options: CashBalanceOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -396,7 +414,7 @@ export interface InventoryImpactScaleOptions {
 	};
 }
 /**
- * Return the immutable DUSDC scale of this market's inventory-impact curve for SDK
+ * Return the immutable USDC scale of this market's inventory-impact curve for SDK
  * and devInspect state reads.
  */
 export function inventoryImpactScale(options: InventoryImpactScaleOptions) {
@@ -608,6 +626,45 @@ export function loadLivePricer(options: LoadLivePricerOptions) {
 					...options.arguments,
 					config: options.arguments?.config ?? options.config?.protocolConfig,
 					propbookRegistry: options.arguments?.propbookRegistry ?? options.config?.oracleRegistry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface IsPendingValuationArguments {
+	market: RawTransactionArgument<string>;
+	config?: RawTransactionArgument<string>;
+}
+export interface IsPendingValuationOptions {
+	package?: string;
+	arguments: IsPendingValuationArguments;
+	config?: {
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Return whether this market is snapshotted into the in-flight flush and still
+ * awaiting its `value_expiry`. For SDK, keeper, and devInspect reads. It gates
+ * nothing: settlement and trading both run regardless — the frozen mark is
+ * settlement-invariant, so a stamped market settles the instant it expires. Do not
+ * defer a settlement attempt on this read.
+ */
+export function isPendingValuation(options: IsPendingValuationOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null] satisfies (string | null)[];
+	const parameterNames = ['market', 'config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'expiry_market',
+			function: 'is_pending_valuation',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
 				},
 				argumentsTypes,
 				parameterNames,
@@ -1118,7 +1175,7 @@ export interface MintExactQuantityOptions {
  * withdraw through the loaded account. The position's strike range is the tick
  * pair `(lower_tick, higher_tick]` (`lower_tick = 0` is `-inf`,
  * `higher_tick = pos_inf_tick` is `+inf`); the SDK converts raw strikes to ticks.
- * `max_cost` caps the all-in DUSDC withdrawal, while `max_probability` caps the
+ * `max_cost` caps the all-in USDC withdrawal, while `max_probability` caps the
  * quoted per-contract probability before fees. Callers can pass
  * `std::u64::max_value!()` for either uncapped guard. Returns the minted order ID
  * for future order-scoped flows.
@@ -1193,12 +1250,12 @@ export interface MintExactAmountOptions {
  * must meet `min_quantity`.
  *
  * Fees, builder fees, and EWMA congestion penalties are charged on top of
- * `max_premium`, so `max_cost` — not `max_premium` — bounds the all-in DUSDC
+ * `max_premium`, so `max_cost` — not `max_premium` — bounds the all-in USDC
  * withdrawal (`premium + trader-paid fee + builder_fee + EWMA penalty`).
  * `max_cost` is required: unlike `mint_exact_quantity`'s guards there is no value
  * that disables it, because the budget shape exists to bound spend. The sizing
- * budget is first capped to the account's available DUSDC after settlement; fees
- * still require additional available DUSDC at payment time. Any unspent premium
+ * budget is first capped to the account's available USDC after settlement; fees
+ * still require additional available USDC at payment time. Any unspent premium
  * dust remains in the account because order quantity must be an integer number of
  * `position_lot_size` lots.
  */
@@ -1275,7 +1332,7 @@ export interface RedeemLiveOptions {
  * Two close-side slippage floors, the mirror of mint's `max_probability` /
  * `max_cost` pair; pass `0` to disable either. `min_probability` floors the quoted
  * per-contract range probability (same units as mint's `max_probability`).
- * `min_proceeds` floors the all-in net DUSDC credited to the account
+ * `min_proceeds` floors the all-in net USDC credited to the account
  * (`redeem_amount` minus trading fee, builder fee, and EWMA penalty), the mirror
  * of mint's all-in `max_cost`.
  */
@@ -1440,7 +1497,9 @@ export interface SetReferenceTickOptions {
  * Set this expiry's reference fine-grid tick from the exact previous-window
  * Propbook Pyth observation. The source observation must be inserted into the feed
  * at `reference_tick_source_timestamp_ms` before this call, and the normalized
- * spot is floored to the market's `tick_size`.
+ * spot is floored to the market's `tick_size`. Not gated on the valuation lock:
+ * the reference tick shapes mint admission only, and a mint it admits mid-flush is
+ * invisible to the captured snapshot like any other.
  */
 export function setReferenceTick(options: SetReferenceTickOptions) {
 	const packageAddress =

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/market_manager.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/market_manager.ts
@@ -40,12 +40,12 @@ export const CadenceConfig = new MoveStruct({
 		/** Coarser raw-price step that new finite mint boundaries must align to. */
 		admission_tick_size: U64,
 		/**
-		 * DUSDC pool allocation cap snapshotted into pool accounting for each created
+		 * USDC pool allocation cap snapshotted into pool accounting for each created
 		 * expiry.
 		 */
 		max_expiry_allocation: U64,
 		/**
-		 * Minimum DUSDC cash target snapshotted into pool accounting for each created
+		 * Minimum USDC cash target snapshotted into pool accounting for each created
 		 * expiry.
 		 */
 		initial_expiry_cash: U64,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/order_events.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/order_events.ts
@@ -36,14 +36,14 @@ export const OrderMinted = new MoveStruct({
 		/** 1e9-scaled range probability quoted at entry. */
 		entry_probability: U64,
 		quantity: U64,
-		/** Premium the user paid into LP backing, in DUSDC base units. */
+		/** Premium the user paid into LP backing, in USDC base units. */
 		premium: U64,
 		/** Full trading fee assessed for the mint, including any sponsor-paid subsidy. */
 		trading_fee: U64,
 		/** Portion of `trading_fee` paid from expiry-local fee incentives. */
 		fee_incentive_subsidy: U64,
 		builder_fee: U64,
-		/** EWMA gas-price congestion surcharge assessed for the mint, in DUSDC base units. */
+		/** EWMA gas-price congestion surcharge assessed for the mint, in USDC base units. */
 		penalty_fee: U64,
 		/**
 		 * Portion of the trader-paid trading fee and congestion surcharge delivered to the
@@ -62,8 +62,8 @@ export const OrderMinted = new MoveStruct({
 		onchain_timestamp_ms: U64,
 		/**
 		 * Oracle source timestamps present when this mint was priced: Pyth's canonical
-		 * source time and the Block Scholes batch-envelope times used for freshness. The
-		 * SVI one is also the roll-down anchor. Pyth is `0` only when unusable.
+		 * source time and the Block Scholes per-update source times used for freshness.
+		 * The SVI one is also the roll-down anchor. Pyth is `0` only when unusable.
 		 */
 		pyth_spot_source_timestamp_ms: U64,
 		block_scholes_spot_source_timestamp_ms: U64,
@@ -92,7 +92,7 @@ export const LiveOrderRedeemed = new MoveStruct({
 		redeem_amount: U64,
 		trading_fee: U64,
 		builder_fee: U64,
-		/** EWMA gas-price congestion surcharge retained by the pool, in DUSDC base units. */
+		/** EWMA gas-price congestion surcharge retained by the pool, in USDC base units. */
 		penalty_fee: U64,
 		/** Separate inventory-impact rebate paid from its isolated escrow. */
 		inventory_impact_rebate: U64,
@@ -104,7 +104,7 @@ export const LiveOrderRedeemed = new MoveStruct({
 		onchain_timestamp_ms: U64,
 		/**
 		 * Oracle source timestamps present when this redemption was priced: Pyth's
-		 * canonical source time and the Block Scholes batch-envelope times used for
+		 * canonical source time and the Block Scholes per-update source times used for
 		 * freshness. The SVI one is also the roll-down anchor. Pyth is `0` only when
 		 * unusable.
 		 */

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/plp.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/plp.ts
@@ -5,15 +5,16 @@
 /**
  * PLP token and pool vault.
  *
- * PoolVault owns the PLP treasury cap, idle DUSDC, the protocol reserve,
+ * PoolVault owns the PLP treasury cap, idle USDC, the protocol reserve,
  * sponsor-funded fee incentives, per-expiry cash accounting, and the queued LP
- * supply/withdraw requests. It coordinates the full-pool NAV valuation (a
- * hot-potato aggregation over every active market) and the unified per-market cash
+ * supply/withdraw requests. It coordinates the full-pool NAV valuation — an atomic
+ * oracle snapshot followed by resumable per-market valuation transactions, with
+ * trading live throughout (see `PoolValuation`) — and the unified per-market cash
  * flow (initial funding, live rebalance/sweep, and settled-market sweep with
  * terminal profit materialization). LPs queue supply/withdraw requests routed
- * through a loaded Account; each flush (`finish_flush`) drains them at the frozen
- * pool NAV, minting/burning PLP and delivering fills to each account via the
- * balance accumulator.
+ * through a loaded Account; each flush (`finish_flush`) drains the requests that
+ * predate its snapshot at the frozen pool NAV, minting/burning PLP and delivering
+ * fills to each account via the balance accumulator.
  */
 
 import {
@@ -25,6 +26,8 @@ import {
 import { bcs } from '@mysten/sui/bcs';
 import { U64 } from '../../bcs/integers.js';
 import { type Transaction, type TransactionArgument } from '@mysten/sui/transactions';
+import * as vec_map from './deps/sui/vec_map.js';
+import * as pricing from './pricing.js';
 import * as balance from './deps/sui/balance.js';
 import * as lp_book from './lp_book.js';
 import * as pool_accounting from './pool_accounting.js';
@@ -35,33 +38,93 @@ export const PLP = new MoveStruct({
 		dummy_field: bcs.bool(),
 	},
 });
-export const PoolVault = new MoveStruct({
-	name: `${$moduleName}::PoolVault`,
+export const PoolValuationProof = new MoveStruct({
+	name: `${$moduleName}::PoolValuationProof`,
 	fields: {
-		id: bcs.Address,
-		/**
-		 * Protocol-owned DUSDC excluded from PLP redemption. No package entrypoint
-		 * withdraws this balance.
-		 */
-		protocol_reserve_balance: balance.Balance,
-		/** Sponsor-funded DUSDC reserved for taker fee sponsorship, excluded from PLP NAV. */
-		fee_incentive_reserve: balance.Balance,
-		/** PLP share issuance plus queued supply/withdraw escrow. */
-		lp: lp_book.LpBook,
-		/** Idle DUSDC custody, registered expiries, and per-expiry cash-flow rows. */
-		expiry_accounting: pool_accounting.Ledger,
+		dummy_field: bcs.bool(),
+	},
+});
+export const SnapshotStage = new MoveStruct({
+	name: `${$moduleName}::SnapshotStage`,
+	fields: {
+		dummy_field: bcs.bool(),
 	},
 });
 export const PoolValuation = new MoveStruct({
 	name: `${$moduleName}::PoolValuation`,
 	fields: {
-		pool_vault_id: bcs.Address,
 		/** Active expiry markets snapshotted at start; every one must be valued. */
 		expected_expiry_markets: bcs.vector(bcs.Address),
-		/** Markets valued so far this flow; folded against `expected` at finish. */
+		/** Markets valued so far this flush; folded against `expected` at finish. */
 		valued_expiry_markets: bcs.vector(bcs.Address),
-		/** Running Σ of each valued market's NAV (settled markets contribute 0). */
+		/** Running Σ of each valued market's snapshot NAV (settled markets contribute 0). */
 		total_nav: U64,
+		/**
+		 * Oracle state frozen during the snapshot stage, one entry per expected market.
+		 * Keyed by market id so a `Pricer` can never be applied to the wrong market.
+		 * `none` marks a market that was already settled at snapshot time and therefore
+		 * contributes 0. This map is what makes the valuation stage deterministic: it
+		 * decides both the mark AND the sweep-vs-value branch, so no later transaction's
+		 * clock or oracle state can change a market's contribution.
+		 */
+		frozen_pricers: vec_map.VecMap(bcs.Address, bcs.option(pricing.FrozenPricer)),
+		/**
+		 * Set by `seal_valuation_snapshot`; no market may be valued before it. Nothing may
+		 * be snapshotted after it because sealing consumes the `SnapshotStage`.
+		 */
+		sealed: bcs.bool(),
+		/** Clock time the flush was started, for the stuck-flush deadline. */
+		started_at_ms: U64,
+		/**
+		 * Drain budgets committed at start (the cap owner's choice), bounding how many
+		 * requests each queue processes at finish. Committing them here — not at finish —
+		 * is what lets `finish_flush` run permissionless: a stranger may complete a flush
+		 * but only ever drains at these budgets, so completion can help LPs, never starve
+		 * them by finishing with a zero budget.
+		 */
+		supply_budget: bcs.option(U64),
+		withdraw_budget: bcs.option(U64),
+		/**
+		 * Each LP queue's `next_index` at the snapshot instant: the drain fills only
+		 * requests indexed strictly below these, so nobody can watch the frozen mark form
+		 * and then submit against a price they already know is stale.
+		 */
+		supply_request_cutoff: U64,
+		withdraw_request_cutoff: U64,
+		/**
+		 * Vault-side figures captured by `seal_valuation_snapshot`. With every market's
+		 * cash frozen in its stamp and these frozen here, the mark is a pure function of
+		 * the snapshot instant: no in-window cash move — maintenance, settled sweep,
+		 * market funding, reserve realization — can reach it. Settled members are swept
+		 * during the snapshot stage, so their recoverable cash sits inside
+		 * `frozen_idle_balance`.
+		 */
+		frozen_idle_balance: U64,
+		frozen_profit_basis_credits: U64,
+		frozen_profit_basis_debits: U64,
+		frozen_pending_protocol_profit: U64,
+	},
+});
+export const PoolVault = new MoveStruct({
+	name: `${$moduleName}::PoolVault`,
+	fields: {
+		id: bcs.Address,
+		/**
+		 * Protocol-owned USDC excluded from PLP redemption. No package entrypoint
+		 * withdraws this balance.
+		 */
+		protocol_reserve_balance: balance.Balance,
+		/** Sponsor-funded USDC reserved for taker fee sponsorship, excluded from PLP NAV. */
+		fee_incentive_reserve: balance.Balance,
+		/** PLP share issuance plus queued supply/withdraw escrow. */
+		lp: lp_book.LpBook,
+		/** Idle USDC custody, registered expiries, and per-expiry cash-flow rows. */
+		expiry_accounting: pool_accounting.Ledger,
+		/**
+		 * In-flight full-pool valuation, held across transactions. `Some` exactly while
+		 * the `ProtocolConfig` valuation flag is engaged.
+		 */
+		valuation: bcs.option(PoolValuation),
 	},
 });
 export interface IdArguments {
@@ -107,7 +170,7 @@ export interface IdleBalanceOptions {
 		predictPackageId?: string;
 	};
 }
-/** Return idle DUSDC for SDK and devInspect state reads. */
+/** Return idle USDC for SDK and devInspect state reads. */
 export function idleBalance(options: IdleBalanceOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -139,7 +202,7 @@ export interface ProtocolReserveBalanceOptions {
 		predictPackageId?: string;
 	};
 }
-/** Return protocol-owned DUSDC for SDK and devInspect state reads. */
+/** Return protocol-owned USDC for SDK and devInspect state reads. */
 export function protocolReserveBalance(options: ProtocolReserveBalanceOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -451,7 +514,9 @@ export function pendingProtocolProfit(options: PendingProtocolProfitOptions) {
 export interface StartPoolValuationArguments {
 	config?: RawTransactionArgument<string>;
 	vault?: RawTransactionArgument<string>;
-	lifecycleProof: TransactionArgument;
+	valuationProof: TransactionArgument;
+	supplyBudget: RawTransactionArgument<number | bigint | null>;
+	withdrawBudget: RawTransactionArgument<number | bigint | null>;
 }
 export interface StartPoolValuationOptions {
 	package?: string;
@@ -463,16 +528,25 @@ export interface StartPoolValuationOptions {
 	};
 }
 /**
- * Begin a full-pool valuation using a registry-issued lifecycle proof. The proof
- * grants control over when current oracle state is frozen for queued LP fills.
- * Starting engages the transaction-local valuation lock and snapshots every active
- * expiry that must be included before the queues can drain.
+ * Begin a full-pool valuation using a registry-issued pool-valuation proof. The
+ * proof grants control over when current oracle state is frozen for queued LP
+ * fills. Starting engages the cross-transaction valuation flag, snapshots the
+ * active expiry set and each LP queue's eligibility cutoff, and opens the atomic
+ * snapshot stage: freeze every active market's pricer under the returned
+ * `SnapshotStage`, then seal it in the same transaction.
  */
 export function startPoolValuation(options: StartPoolValuationOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
-	const argumentsTypes = [null, null, null] satisfies (string | null)[];
-	const parameterNames = ['config', 'vault', 'lifecycleProof'];
+	const argumentsTypes = [
+		null,
+		null,
+		null,
+		'0x1::option::Option<u64>',
+		'0x1::option::Option<u64>',
+		'0x2::clock::Clock',
+	] satisfies (string | null)[];
+	const parameterNames = ['config', 'vault', 'valuationProof', 'supplyBudget', 'withdrawBudget'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -489,9 +563,9 @@ export function startPoolValuation(options: StartPoolValuationOptions) {
 			),
 		});
 }
-export interface ValueExpiryArguments {
-	valuation: TransactionArgument;
+export interface SnapshotExpiryPricerArguments {
 	vault?: RawTransactionArgument<string>;
+	Stage: TransactionArgument;
 	market: RawTransactionArgument<string>;
 	config?: RawTransactionArgument<string>;
 	propbookRegistry?: RawTransactionArgument<string>;
@@ -499,9 +573,9 @@ export interface ValueExpiryArguments {
 	bsValues: RawTransactionArgument<string>;
 	bsSvi: RawTransactionArgument<string>;
 }
-export interface ValueExpiryOptions {
+export interface SnapshotExpiryPricerOptions {
 	package?: string;
-	arguments: ValueExpiryArguments;
+	arguments: SnapshotExpiryPricerArguments;
 	config?: {
 		poolVault: ConfigValue;
 		protocolConfig: ConfigValue;
@@ -510,16 +584,28 @@ export interface ValueExpiryOptions {
 	};
 }
 /**
- * Run the per-market cash flow for one snapshotted market, then fold its NAV into
- * the running total. The market must be in the snapshot and not already valued. A
- * settled market is swept (deactivated, cash returned, profit materialized) and
- * contributes 0; a live market is rebalanced to target and valued on its current
- * cash.
+ * Freeze one snapshotted market's oracle state for this flush and stamp the
+ * market, capturing its cash rows and activating its payout-tree snapshot at this
+ * instant.
  *
- * Settlement is a separate PTB step through `expiry_market::try_settle`. An
- * expired unsettled market cannot produce the live pricer required here.
+ * Holding `SnapshotStage` is what admits this call, and that potato cannot leave
+ * the transaction `start_pool_valuation` minted it in — so every `Pricer` here is
+ * loaded at one instant, which is what lets the valuation stage span transactions
+ * without mixing marks (audit L10). This stage reads oracles only — it never walks
+ * a payout tree — so all markets fit one PTB regardless of book size.
+ *
+ * The oracle feeding this stage must have been written in an EARLIER transaction:
+ * `pricing::resolve_live_pricer` refuses a read stamped with the current
+ * transaction digest (RP-24), so a keeper cannot refresh and snapshot in one PTB.
+ *
+ * A market already settled at snapshot time is recorded with no pricer, gets no
+ * stamp (settled flows never touch live NAV), and contributes 0. An
+ * expired-but-unsettled market aborts: it has no well-defined mark, and because
+ * this stage is atomic the abort reverts the whole snapshot transaction, so the
+ * flag is never left engaged. Settle it first, then start the flush; settlement is
+ * never blocked by a flush, so that ordering is always available.
  */
-export function valueExpiry(options: ValueExpiryOptions) {
+export function snapshotExpiryPricer(options: SnapshotExpiryPricerOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
 	const argumentsTypes = [
@@ -534,8 +620,8 @@ export function valueExpiry(options: ValueExpiryOptions) {
 		'0x2::clock::Clock',
 	] satisfies (string | null)[];
 	const parameterNames = [
-		'valuation',
 		'vault',
+		'Stage',
 		'market',
 		'config',
 		'propbookRegistry',
@@ -547,7 +633,7 @@ export function valueExpiry(options: ValueExpiryOptions) {
 		tx.moveCall({
 			package: packageAddress,
 			module: 'plp',
-			function: 'value_expiry',
+			function: 'snapshot_expiry_pricer',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,
@@ -560,16 +646,111 @@ export function valueExpiry(options: ValueExpiryOptions) {
 			),
 		});
 }
+export interface SealValuationSnapshotArguments {
+	vault?: RawTransactionArgument<string>;
+	stage: TransactionArgument;
+	config?: RawTransactionArgument<string>;
+}
+export interface SealValuationSnapshotOptions {
+	package?: string;
+	arguments: SealValuationSnapshotArguments;
+	config?: {
+		poolVault: ConfigValue;
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Close the snapshot stage once every expected market has a frozen pricer, and
+ * freeze the vault-side figures — idle, the profit basis, the pending protocol cut
+ * — completing the snapshot.
+ *
+ * Consuming `SnapshotStage` is the simultaneity proof: the potato dies here, so no
+ * later transaction can add oracle state to this flush, and every market is marked
+ * at the instant the snapshot transaction executed. The vault capture is
+ * consistent with the per-market stamps because `rebalance_expiry_cash` refuses to
+ * run while the stage is open (`ESnapshotStageOpen`), so no idle↔market move can
+ * land between a stamp and this capture. Valuation may then resume across as many
+ * transactions as it needs.
+ */
+export function sealValuationSnapshot(options: SealValuationSnapshotOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, null] satisfies (string | null)[];
+	const parameterNames = ['vault', 'stage', 'config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'plp',
+			function: 'seal_valuation_snapshot',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					vault: options.arguments?.vault ?? options.config?.poolVault,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface ValueExpiryArguments {
+	vault?: RawTransactionArgument<string>;
+	market: RawTransactionArgument<string>;
+	config?: RawTransactionArgument<string>;
+}
+export interface ValueExpiryOptions {
+	package?: string;
+	arguments: ValueExpiryArguments;
+	config?: {
+		poolVault: ConfigValue;
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Fold one snapshotted market's SNAPSHOT-INSTANT NAV into the running total. A
+ * market frozen as settled is swept and contributes 0; one frozen with a pricer is
+ * valued via `expiry_market::snapshot_nav` over its captured cash and tree
+ * shadows, then has its stamp cleared (releasing the tree snapshot), so later
+ * trades and the next flush start clean.
+ *
+ * The resumable stage: any transaction after the seal, one market per transaction
+ * (`constants::max_payout_tree_nodes`), reading no oracle and no clock.
+ * MEASUREMENT-ONLY for every member — settled members were swept during the
+ * snapshot stage and every frozen figure was captured there, so this call moves no
+ * cash and `rebalance_expiry_cash` runs at any time. A market that expired
+ * mid-window is valued at its frozen pre-expiry mark; its settlement does not wait
+ * for this call, because settlement is never blocked by a flush.
+ */
+export function valueExpiry(options: ValueExpiryOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, null] satisfies (string | null)[];
+	const parameterNames = ['vault', 'market', 'config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'plp',
+			function: 'value_expiry',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					vault: options.arguments?.vault ?? options.config?.poolVault,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
 export interface FinishFlushArguments {
-	valuation: TransactionArgument;
 	vault?: RawTransactionArgument<string>;
 	config?: RawTransactionArgument<string>;
-	supplyBudget: RawTransactionArgument<number | bigint | null>;
-	withdrawBudget: RawTransactionArgument<number | bigint | null>;
 }
 export interface FinishFlushOptions {
 	package?: string;
-	arguments: FinishFlushArguments;
+	arguments?: FinishFlushArguments;
 	config?: {
 		poolVault: ConfigValue;
 		protocolConfig: ConfigValue;
@@ -580,9 +761,12 @@ export interface FinishFlushOptions {
  * Finish a full-pool valuation and run the LP flush: prove every snapshotted
  * market was valued exactly once, price the pool NAV, then drain the
  * supply/withdraw queues at that frozen mark (mint PLP for supplies, burn PLP and
- * pay DUSDC for withdrawals), release the valuation lock, consume the potato, and
- * return the LP-attributable pool-wide DUSDC NAV (idle + Σ active NAV, net of the
- * pending-protocol-profit exclusion priced from the aggregate profit basis).
+ * pay USDC for withdrawals), release the valuation flag, retire the in-flight
+ * valuation, and return the LP-attributable pool-wide USDC NAV (frozen idle + Σ
+ * active NAV, net of the pending-protocol-profit exclusion priced from the frozen
+ * profit basis — every term as of the snapshot instant). Each drain fills only
+ * requests submitted before the flush's snapshot instant (the recorded queue
+ * cutoffs); younger requests wait for the next mark.
  *
  * `supply_budget` and `withdraw_budget` bound how many requests each queue may
  * process this flush (`None` = unbounded). Fills — whole or partial — and
@@ -606,14 +790,8 @@ export interface FinishFlushOptions {
 export function finishFlush(options: FinishFlushOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
-	const argumentsTypes = [
-		null,
-		null,
-		null,
-		'0x1::option::Option<u64>',
-		'0x1::option::Option<u64>',
-	] satisfies (string | null)[];
-	const parameterNames = ['valuation', 'vault', 'config', 'supplyBudget', 'withdrawBudget'];
+	const argumentsTypes = [null, null, '0x2::clock::Clock'] satisfies (string | null)[];
+	const parameterNames = ['vault', 'config'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -655,8 +833,12 @@ export interface RebalanceExpiryCashOptions {
  * due. An expired unsettled market is a no-op until that transition succeeds. Mint
  * asserts backing but never pulls pool cash, so this is what makes a market
  * mintable. The market must already be registered to this vault
- * (`registry::create_and_share_expiry_market`). Blocked while a full-pool
- * valuation is in progress.
+ * (`registry::create_and_share_expiry_market`). Runs at any time, including while
+ * a flush is in flight — every figure the mark reads was frozen at the snapshot
+ * instant, so no move here can reach it. The one refusal is the still-open
+ * snapshot stage (start → seal, a single transaction): a cross-move landing
+ * between a market's stamp and the seal's vault capture would skew the frozen
+ * figures, so it is structurally rejected rather than corrected for.
  */
 export function rebalanceExpiryCash(options: RebalanceExpiryCashOptions) {
 	const packageAddress =
@@ -694,9 +876,9 @@ export interface SponsorFeeIncentivesOptions {
 	};
 }
 /**
- * Sponsor taker fee incentives with DUSDC. Anyone may contribute; the payment
- * joins a pool-level reserve that is excluded from PLP NAV and later allocated to
- * expiry markets by the normal rebalance flow.
+ * Sponsor taker fee incentives with USDC. Anyone may contribute; the payment joins
+ * a pool-level reserve that is excluded from PLP NAV and later allocated to expiry
+ * markets by the normal rebalance flow.
  */
 export function sponsorFeeIncentives(options: SponsorFeeIncentivesOptions) {
 	const packageAddress =
@@ -735,9 +917,9 @@ export interface LockCapitalOptions {
 	};
 }
 /**
- * Bootstrap the pool exactly once: permanently lock `payment` DUSDC of minimum
+ * Bootstrap the pool exactly once: permanently lock `payment` USDC of minimum
  * liquidity. Mints matching PLP (1:1) into the book's locked balance — never
- * withdrawable, so the caller receives no shares — and joins the DUSDC into idle.
+ * withdrawable, so the caller receives no shares — and joins the USDC into idle.
  * This keeps `total_supply > 0` while the vault exists and gives rounding dust a
  * non-withdrawable PLP holder. Requires root authority and zero existing supply.
  * Supply, withdrawal, and flush flows remain disabled until the locked liquidity
@@ -782,10 +964,10 @@ export interface RequestSupplyOptions {
 	};
 }
 /**
- * Queue a supply request: pull `amount` DUSDC from account custody into queue
+ * Queue a supply request: pull `amount` USDC from account custody into queue
  * escrow, recording the account's receive address as the fill recipient. The pull
- * auto-settles any flush-delivered DUSDC first. The flush charges the protocol's
- * supply fee — zero by default — on the DUSDC it takes in and prices shares on the
+ * auto-settles any flush-delivered USDC first. The flush charges the protocol's
+ * supply fee — zero by default — on the USDC it takes in and prices shares on the
  * remainder, so `min_plp_out` is measured after that fee. The account receives
  * minted PLP only at a mark that mints at least `min_plp_out` for the whole
  * `amount` — a **price floor**, not a promise of that many shares: if the pool cap
@@ -832,7 +1014,7 @@ export interface RequestWithdrawArguments {
 	auth: TransactionArgument;
 	config?: RawTransactionArgument<string>;
 	amount: RawTransactionArgument<number | bigint>;
-	minDusdcOut: RawTransactionArgument<number | bigint>;
+	minUsdcOut: RawTransactionArgument<number | bigint>;
 }
 export interface RequestWithdrawOptions {
 	package?: string;
@@ -847,15 +1029,15 @@ export interface RequestWithdrawOptions {
  * Queue a withdraw request: pull `amount` PLP shares from account custody into
  * queue escrow, recording the account's receive address as the fill recipient. The
  * pull auto-settles any flush-delivered PLP first. The flush withholds the
- * protocol's withdraw fee from the marked payout, so `min_dusdc_out` is measured
+ * protocol's withdraw fee from the marked payout, so `min_usdc_out` is measured
  * after the fee. The account is paid only at a mark that quotes at least
- * `min_dusdc_out` for the whole `amount` — a **price floor**, not a promise of
- * that much DUSDC: if idle liquidity covers only part of the payout, only the
- * shares idle affords are burned, the fill is proportionally smaller at the same
- * price, and the remainder stays queued with its limit rescaled. At the shipped
- * attempt count of one, a flush whose mark quotes less cancels and refunds the
- * request there and then; a higher configured count lets it rest and retry that
- * many flushes first. Returns the queue index used to cancel before the flush.
+ * `min_usdc_out` for the whole `amount` — a **price floor**, not a promise of that
+ * much USDC: if idle liquidity covers only part of the payout, only the shares
+ * idle affords are burned, the fill is proportionally smaller at the same price,
+ * and the remainder stays queued with its limit rescaled. At the shipped attempt
+ * count of one, a flush whose mark quotes less cancels and refunds the request
+ * there and then; a higher configured count lets it rest and retry that many
+ * flushes first. Returns the queue index used to cancel before the flush.
  */
 export function requestWithdraw(options: RequestWithdrawOptions) {
 	const packageAddress =
@@ -870,7 +1052,7 @@ export function requestWithdraw(options: RequestWithdrawOptions) {
 		'0x2::accumulator::AccumulatorRoot',
 		'0x2::clock::Clock',
 	] satisfies (string | null)[];
-	const parameterNames = ['vault', 'wrapper', 'auth', 'config', 'amount', 'minDusdcOut'];
+	const parameterNames = ['vault', 'wrapper', 'auth', 'config', 'amount', 'minUsdcOut'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
@@ -904,8 +1086,8 @@ export interface CancelSupplyRequestOptions {
 	};
 }
 /**
- * Cancel a still-pending supply request, refunding its escrowed DUSDC straight
- * into the requesting account. `account` must be the request's recorded recipient.
+ * Cancel a still-pending supply request, refunding its escrowed USDC straight into
+ * the requesting account. `account` must be the request's recorded recipient.
  */
 export function cancelSupplyRequest(options: CancelSupplyRequestOptions) {
 	const packageAddress =

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/pool_accounting.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/pool_accounting.ts
@@ -5,13 +5,13 @@
 /**
  * Pool-owned expiry registration and cash-flow accounting.
  *
- * This module owns pool idle DUSDC custody, the durable set of expiries registered
- * to a pool, the active expiry index used for valuation, DUSDC sent from the main
- * pool into each expiry, DUSDC received back from each expiry, snapshotted
- * lifetime fee-incentive caps and allocations, terminal cash watermarks, and
- * per-expiry cap checks. It does not classify expiry-local liabilities or apply
- * PLP reserve policy; PoolVault uses the aggregate profit basis to price PLP and
- * decide protocol reserve transfers.
+ * This module owns pool idle USDC custody, the durable set of expiries registered
+ * to a pool, the active expiry index used for valuation, USDC sent from the main
+ * pool into each expiry, USDC received back from each expiry, snapshotted lifetime
+ * fee-incentive caps and allocations, terminal cash watermarks, and per-expiry cap
+ * checks. It does not classify expiry-local liabilities or apply PLP reserve
+ * policy; PoolVault uses the aggregate profit basis to price PLP and decide
+ * protocol reserve transfers.
  */
 
 import { MoveStruct } from '../utils/index.js';
@@ -30,7 +30,7 @@ export const ActiveExpiry = new MoveStruct({
 export const Ledger = new MoveStruct({
 	name: `${$moduleName}::Ledger`,
 	fields: {
-		/** Idle LP-owned DUSDC available for withdrawals and expiry funding. */
+		/** Idle LP-owned USDC available for withdrawals and expiry funding. */
 		idle_balance: balance.Balance,
 		/** Expiry markets that still contribute active pool valuation/risk. */
 		active_expiry_markets: bcs.vector(ActiveExpiry),
@@ -39,9 +39,9 @@ export const Ledger = new MoveStruct({
 		 * pool.
 		 */
 		registered_expiries: table.Table,
-		/** Pricing debit basis: DUSDC sent to expiries plus materialized terminal profit. */
+		/** Pricing debit basis: USDC sent to expiries plus materialized terminal profit. */
 		profit_basis_debits: U64,
-		/** Pricing credit basis: all DUSDC received back from expiries. */
+		/** Pricing credit basis: all USDC received back from expiries. */
 		profit_basis_credits: U64,
 		/**
 		 * Aggregate terminal losses that later terminal profits must recover first; losses
@@ -59,13 +59,13 @@ export const Ledger = new MoveStruct({
 export const RegisteredExpiry = new MoveStruct({
 	name: `${$moduleName}::RegisteredExpiry`,
 	fields: {
-		/** DUSDC pool allocation cap snapshotted when this expiry was created. */
+		/** USDC pool allocation cap snapshotted when this expiry was created. */
 		max_expiry_allocation: U64,
-		/** Minimum DUSDC cash target snapshotted when this expiry was created. */
+		/** Minimum USDC cash target snapshotted when this expiry was created. */
 		initial_expiry_cash: U64,
-		/** DUSDC sent from the main pool into this expiry. */
+		/** USDC sent from the main pool into this expiry. */
 		sent_to_expiry: U64,
-		/** DUSDC returned from this expiry to the main pool. */
+		/** USDC returned from this expiry to the main pool. */
 		received_from_expiry: U64,
 		/** Absolute lifetime fee-incentive cap snapshotted when this expiry was registered. */
 		fee_incentive_lifetime_cap: U64,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/pool_valuation_cap.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/pool_valuation_cap.ts
@@ -3,17 +3,18 @@
  **************************************************************/
 
 /**
- * Defines revocable authority for market creation without granting pool-valuation,
- * oracle-write, or root-admin power. `Registry` owns the allowlist and the
- * creation entrypoint this capability gates.
+ * Defines revocable authority to start the full-pool valuation (the flush) without
+ * granting market-creation, oracle-write, or root-admin power. `Registry` owns the
+ * allowlist and issues the transaction-local proof `plp::start_pool_valuation`
+ * consumes.
  */
 
 import { MoveStruct, normalizeMoveArguments, type RawTransactionArgument } from '../utils/index.js';
 import { bcs } from '@mysten/sui/bcs';
 import { type Transaction } from '@mysten/sui/transactions';
-const $moduleName = '@local-pkg/deepbook_predict::market_lifecycle_cap';
-export const MarketLifecycleCap = new MoveStruct({
-	name: `${$moduleName}::MarketLifecycleCap`,
+const $moduleName = '@local-pkg/deepbook_predict::pool_valuation_cap';
+export const PoolValuationCap = new MoveStruct({
+	name: `${$moduleName}::PoolValuationCap`,
 	fields: {
 		id: bcs.Address,
 	},
@@ -37,7 +38,7 @@ export function id(options: IdOptions) {
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
-			module: 'market_lifecycle_cap',
+			module: 'pool_valuation_cap',
 			function: 'id',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
 		});
@@ -52,7 +53,7 @@ export interface DestroyOptions {
 		predictPackageId?: string;
 	};
 }
-/** Destroy a `MarketLifecycleCap` the holder no longer needs. */
+/** Destroy a `PoolValuationCap` the holder no longer needs. */
 export function destroy(options: DestroyOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -61,7 +62,7 @@ export function destroy(options: DestroyOptions) {
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
-			module: 'market_lifecycle_cap',
+			module: 'pool_valuation_cap',
 			function: 'destroy',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
 		});

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/predict_account.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/predict_account.ts
@@ -7,7 +7,7 @@
  * (the `account` package).
  *
  * This is Predict's account-local state: open positions and sticky builder-code
- * attribution. DUSDC/PLP custody lives in `Account`. The `PredictApp` witness
+ * attribution. USDC/PLP custody lives in `Account`. The `PredictApp` witness
  * namespaces this slot, so only Predict writes it.
  *
  * Position mutations are package-internal. Builder-code configuration accepts an

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/pricing.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/pricing.ts
@@ -32,6 +32,18 @@ export const PricingSVI = new MoveStruct({
 		sigma: U64,
 	},
 });
+export const FrozenPricer = new MoveStruct({
+	name: `${$moduleName}::FrozenPricer`,
+	fields: {
+		expiry_market_id: bcs.Address,
+		forward: U64,
+		svi: PricingSVI,
+		pyth_spot_source_timestamp_ms: U64,
+		block_scholes_spot_source_timestamp_ms: U64,
+		block_scholes_forward_source_timestamp_ms: U64,
+		block_scholes_svi_source_timestamp_ms: U64,
+	},
+});
 export const Pricer = new MoveStruct({
 	name: `${$moduleName}::Pricer`,
 	fields: {
@@ -42,10 +54,10 @@ export const Pricer = new MoveStruct({
 		/**
 		 * Timestamps of the oracle observations this snapshot validated, as trade events
 		 * report them — each observation's own economic clock. Pyth carries its source
-		 * timestamp (`0` only when no usable normalized observation exists); the Block
-		 * Scholes reads carry their batch envelope time (`source_timestamp_ms`), the clock
-		 * freshness gated and the SVI roll-down anchored on. The provider's calibration
-		 * (model) times stay on the stored observations and their ingestion events.
+		 * timestamp (`0` only when no usable normalized observation exists); Block Scholes
+		 * spot and forward carry the provider `value_timestamp`, and SVI carries the
+		 * provider `svi_timestamp`. Those timestamps are the clocks freshness gates and
+		 * SVI roll-down use.
 		 */
 		pyth_spot_source_timestamp_ms: U64,
 		block_scholes_spot_source_timestamp_ms: U64,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/protocol_config.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/protocol_config.ts
@@ -6,8 +6,10 @@
  * Protocol-wide configuration and flow gates for Predict.
  *
  * This shared object owns the admin-tunable config structs, the trading pause
- * gate, the protocol-wide emergency freeze, and the transaction-local full-pool
- * valuation lock. Flow modules decide which gates apply before they mutate expiry,
+ * gate, the protocol-wide emergency freeze, and the full-pool valuation in-flight
+ * state (flag + flush ordinal, held across the transactions a flush spans;
+ * keeper/config flows gate on it, trading flows read it only to discard stale
+ * stamps lazily). Flow modules decide which gates apply before they mutate expiry,
  * oracle, pool, or account state.
  */
 
@@ -41,7 +43,7 @@ export const ProtocolConfig = new MoveStruct({
 		referral_fee_rate: U64,
 		/**
 		 * Fee charged on an executed PLP supply fill, in FLOAT_SCALING, deducted from the
-		 * DUSDC taken in before shares are priced. Ships at zero — a deposit dilutes the
+		 * USDC taken in before shares are priced. Ships at zero — a deposit dilutes the
 		 * pool's risk per dollar rather than concentrating it, so it is not taxed; the
 		 * knob exists to keep that reversible.
 		 */
@@ -66,6 +68,15 @@ export const ProtocolConfig = new MoveStruct({
 		 * the pool is uncapped until an operator sets a figure (RP-23).
 		 */
 		max_lp_pool_value: U64,
+		/**
+		 * Hard staleness bound: `finish_flush` refuses to complete a flush in flight
+		 * longer than this, so no LP request fills at a mark older than the window; past
+		 * it the operator starts a fresh flush (which discards the stale one). A stalled
+		 * flush blocks only LP queue fills and the flush-set markets' settlement — trading
+		 * continues — so this also bounds LP-fill latency and is tuned alongside flush
+		 * cadence (RP-29).
+		 */
+		max_valuation_window_ms: U64,
 		strike_exposure_template_config: strike_exposure_config.StrikeExposureConfig,
 		ewma_config: ewma_config.EwmaConfig,
 		/**
@@ -88,10 +99,30 @@ export const ProtocolConfig = new MoveStruct({
 		 */
 		frozen: bcs.bool(),
 		/**
-		 * Transaction-local lock held while a full-pool valuation is assembled, so no
-		 * NAV-changing op can interleave between per-market value steps in the PTB.
+		 * True for the whole duration of a full-pool valuation, across every transaction
+		 * it spans. Keeper cash flows, market lifecycle, and config mutations gate on it;
+		 * trading flows do NOT — they read it (with `flush_seq`) only to discard a stale
+		 * valuation stamp lazily; a pending market's snapshot state is captured, never
+		 * recorded per trade (see `plp`).
 		 */
 		valuation_in_progress: bcs.bool(),
+		/**
+		 * True ONLY while the atomic snapshot stage is open — set by `begin_snapshot` at
+		 * `start_pool_valuation` and cleared by `end_snapshot` at
+		 * `seal_valuation_snapshot`. Both live in one PTB (the `SnapshotStage` hot potato
+		 * forces it), so this can never be observed across transactions: it blocks only a
+		 * trade the keeper composes INTO its own snapshot PTB, where a mid-stamp cash move
+		 * would skew the figures the seal freezes. The resumable valuation stage after the
+		 * seal leaves it false, so trading stays live.
+		 */
+		snapshot_in_progress: bcs.bool(),
+		/**
+		 * Monotonic flush ordinal, bumped by `begin_valuation`. A market's valuation stamp
+		 * names the flush that made it; a stamp whose ordinal is not the current one — or
+		 * held while no valuation is in flight — is stale and is lazily discarded by the
+		 * next trade, so aborting a flush never has to visit its stamped markets.
+		 */
+		flush_seq: U64,
 	},
 });
 export interface IdArguments {
@@ -183,6 +214,43 @@ export function frozen(options: FrozenOptions) {
 			package: packageAddress,
 			module: 'protocol_config',
 			function: 'frozen',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface ValuationInProgressArguments {
+	config?: RawTransactionArgument<string>;
+}
+export interface ValuationInProgressOptions {
+	package?: string;
+	arguments?: ValuationInProgressArguments;
+	config?: {
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Return whether a full-pool valuation is in flight, for SDK and devInspect reads.
+ * The flush spans transactions, so "in flight" is an observable state: a keeper
+ * reads it to notice a flush it must finish or discard, and an integrator reads it
+ * to explain a gated keeper/config transaction. Trading is not gated on it.
+ */
+export function valuationInProgress(options: ValuationInProgressOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null] satisfies (string | null)[];
+	const parameterNames = ['config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'protocol_config',
+			function: 'valuation_in_progress',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,
@@ -680,6 +748,47 @@ export function setLpRequestLimitFlushAttempts(options: SetLpRequestLimitFlushAt
 			package: packageAddress,
 			module: 'protocol_config',
 			function: 'set_lp_request_limit_flush_attempts',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface SetMaxValuationWindowMsArguments {
+	config?: RawTransactionArgument<string>;
+	AdminCap: RawTransactionArgument<string>;
+	windowMs: RawTransactionArgument<number | bigint>;
+}
+export interface SetMaxValuationWindowMsOptions {
+	package?: string;
+	arguments: SetMaxValuationWindowMsArguments;
+	config?: {
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Set how long a started full-pool valuation may stay in flight before anyone may
+ * discard it. A stalled flush costs LP-fill latency (and settlement latency for
+ * its own market set), not a trading pause, so this is an operator liveness knob:
+ * too short and a legitimate long flush can be discarded from under the keeper,
+ * too long and an abandoned one delays queued LP fills for that duration. See
+ * RP-29.
+ */
+export function setMaxValuationWindowMs(options: SetMaxValuationWindowMsOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, 'u64'] satisfies (string | null)[];
+	const parameterNames = ['config', 'AdminCap', 'windowMs'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'protocol_config',
+			function: 'set_max_valuation_window_ms',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/protocol_config.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/protocol_config.ts
@@ -64,8 +64,8 @@ export const ProtocolConfig = new MoveStruct({
 		lp_request_limit_flush_attempts: U64,
 		/**
 		 * Ceiling on LP-attributable pool value that queued supplies may raise the pool
-		 * to, enforced at the flush against the frozen mark. Defaults to `u64::MAX`, so
-		 * the pool is uncapped until an operator sets a figure (RP-23).
+		 * to, enforced at the flush against the frozen mark. Defaults to 500,000 USDC
+		 * (RP-23).
 		 */
 		max_lp_pool_value: U64,
 		/**
@@ -77,6 +77,12 @@ export const ProtocolConfig = new MoveStruct({
 		 * cadence (RP-29).
 		 */
 		max_valuation_window_ms: U64,
+		/**
+		 * Window before a market's expiry in which live quotes, mints, and live redeems
+		 * abort. Read live at trade time rather than snapshotted per market, so it can be
+		 * widened on markets already trading. `0` disables.
+		 */
+		no_trade_window_ms: U64,
 		strike_exposure_template_config: strike_exposure_config.StrikeExposureConfig,
 		ewma_config: ewma_config.EwmaConfig,
 		/**
@@ -283,6 +289,43 @@ export function referralFeeRate(options: ReferralFeeRateOptions) {
 			package: packageAddress,
 			module: 'protocol_config',
 			function: 'referral_fee_rate',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface NoTradeWindowMsArguments {
+	config?: RawTransactionArgument<string>;
+}
+export interface NoTradeWindowMsOptions {
+	package?: string;
+	arguments?: NoTradeWindowMsArguments;
+	config?: {
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Window before expiry in which live quotes, mints, and live redeems abort.
+ * `public` for SDK and devInspect reads: a client that cannot see this value can
+ * only learn the window closed by decoding `ETradeWindowClosed` from a failed
+ * quote.
+ */
+export function noTradeWindowMs(options: NoTradeWindowMsOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null] satisfies (string | null)[];
+	const parameterNames = ['config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'protocol_config',
+			function: 'no_trade_window_ms',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,
@@ -901,6 +944,49 @@ export function setEwmaEnabled(options: SetEwmaEnabledOptions) {
 			package: packageAddress,
 			module: 'protocol_config',
 			function: 'set_ewma_enabled',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface SetNoTradeWindowMsArguments {
+	config?: RawTransactionArgument<string>;
+	AdminCap: RawTransactionArgument<string>;
+	value: RawTransactionArgument<number | bigint>;
+}
+export interface SetNoTradeWindowMsOptions {
+	package?: string;
+	arguments: SetNoTradeWindowMsArguments;
+	config?: {
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Set the window before expiry in which live quotes, mints, and live redeems
+ * abort. `0` disables the block. Read live at trade time, so a change applies to
+ * markets already trading and stays available as an incident control.
+ *
+ * Deliberately not gated on `assert_not_valuation_in_progress`, matching
+ * `set_trading_paused`: a stalled flush must not be able to trap a safety control.
+ * Nothing in the flush reads this value, so a mid-valuation change cannot skew a
+ * frozen mark.
+ */
+export function setNoTradeWindowMs(options: SetNoTradeWindowMsOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, 'u64', '0x2::clock::Clock'] satisfies (string | null)[];
+	const parameterNames = ['config', 'AdminCap', 'value'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'protocol_config',
+			function: 'set_no_trade_window_ms',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/registry.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/registry.ts
@@ -38,11 +38,15 @@ export const Registry = new MoveStruct({
 		 */
 		allowed_pause_caps: vec_set.VecSet(bcs.Address),
 		/**
-		 * IDs of `MarketLifecycleCap` objects currently authorized for privileged
-		 * lifecycle entries such as market creation and full-pool valuation. Admin mints
-		 * into this set and revokes from it.
+		 * IDs of `MarketLifecycleCap` objects currently authorized to create expiry
+		 * markets. Admin mints into this set and revokes from it.
 		 */
 		allowed_lifecycle_caps: vec_set.VecSet(bcs.Address),
+		/**
+		 * IDs of `PoolValuationCap` objects currently authorized to start the full-pool
+		 * valuation. Admin mints into this set and revokes from it.
+		 */
+		allowed_pool_valuation_caps: vec_set.VecSet(bcs.Address),
 	},
 });
 export interface IdArguments {
@@ -269,10 +273,7 @@ export interface MintLifecycleCapOptions {
 		predictPackageId?: string;
 	};
 }
-/**
- * Mint a version-gated `MarketLifecycleCap` with market-creation and valuation
- * authority.
- */
+/** Mint a version-gated `MarketLifecycleCap` with market-creation authority. */
 export function mintLifecycleCap(options: MintLifecycleCapOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
@@ -328,33 +329,106 @@ export function revokeLifecycleCap(options: RevokeLifecycleCapOptions) {
 			),
 		});
 }
-export interface GenerateLifecycleProofArguments {
+export interface MintPoolValuationCapArguments {
 	registry?: RawTransactionArgument<string>;
-	lifecycleCap: RawTransactionArgument<string>;
+	AdminCap: RawTransactionArgument<string>;
+	config?: RawTransactionArgument<string>;
 }
-export interface GenerateLifecycleProofOptions {
+export interface MintPoolValuationCapOptions {
 	package?: string;
-	arguments: GenerateLifecycleProofArguments;
+	arguments: MintPoolValuationCapArguments;
+	config?: {
+		registry: ConfigValue;
+		protocolConfig: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/**
+ * Mint a version-gated `PoolValuationCap` with authority to start the full-pool
+ * valuation.
+ */
+export function mintPoolValuationCap(options: MintPoolValuationCapOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, null] satisfies (string | null)[];
+	const parameterNames = ['registry', 'AdminCap', 'config'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'registry',
+			function: 'mint_pool_valuation_cap',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.registry,
+					config: options.arguments?.config ?? options.config?.protocolConfig,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface RevokePoolValuationCapArguments {
+	registry?: RawTransactionArgument<string>;
+	AdminCap: RawTransactionArgument<string>;
+	poolValuationCapId: RawTransactionArgument<string>;
+}
+export interface RevokePoolValuationCapOptions {
+	package?: string;
+	arguments: RevokePoolValuationCapArguments;
+	config?: {
+		registry: ConfigValue;
+		predictPackageId?: string;
+	};
+}
+/** Revoke a `PoolValuationCap` by ID without applying the version gate. */
+export function revokePoolValuationCap(options: RevokePoolValuationCapOptions) {
+	const packageAddress =
+		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
+	const argumentsTypes = [null, null, '0x2::object::ID'] satisfies (string | null)[];
+	const parameterNames = ['registry', 'AdminCap', 'poolValuationCapId'];
+	return (tx: Transaction) =>
+		tx.moveCall({
+			package: packageAddress,
+			module: 'registry',
+			function: 'revoke_pool_valuation_cap',
+			arguments: normalizeMoveArguments(
+				{
+					...options.arguments,
+					registry: options.arguments?.registry ?? options.config?.registry,
+				},
+				argumentsTypes,
+				parameterNames,
+			),
+		});
+}
+export interface GeneratePoolValuationProofArguments {
+	registry?: RawTransactionArgument<string>;
+	poolValuationCap: RawTransactionArgument<string>;
+}
+export interface GeneratePoolValuationProofOptions {
+	package?: string;
+	arguments: GeneratePoolValuationProofArguments;
 	config?: {
 		registry: ConfigValue;
 		predictPackageId?: string;
 	};
 }
 /**
- * Generate a transaction-local proof that `lifecycle_cap` is currently
- * allowlisted. Consumers take the proof by value so a revoked lifecycle cap cannot
- * authorize cross-module lifecycle actions.
+ * Generate a transaction-local proof that `pool_valuation_cap` is currently
+ * allowlisted. `plp::start_pool_valuation` takes the proof by value so a revoked
+ * cap cannot start a valuation.
  */
-export function generateLifecycleProof(options: GenerateLifecycleProofOptions) {
+export function generatePoolValuationProof(options: GeneratePoolValuationProofOptions) {
 	const packageAddress =
 		options.package ?? options.config?.predictPackageId ?? '@local-pkg/deepbook_predict';
 	const argumentsTypes = [null, null] satisfies (string | null)[];
-	const parameterNames = ['registry', 'lifecycleCap'];
+	const parameterNames = ['registry', 'poolValuationCap'];
 	return (tx: Transaction) =>
 		tx.moveCall({
 			package: packageAddress,
 			module: 'registry',
-			function: 'generate_lifecycle_proof',
+			function: 'generate_pool_valuation_proof',
 			arguments: normalizeMoveArguments(
 				{
 					...options.arguments,

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/strike_exposure.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/strike_exposure.ts
@@ -36,7 +36,7 @@ export const StrikeExposure = new MoveStruct({
 		/** Snapshotted exposure and fee policy for this expiry. */
 		config: strike_exposure_config.StrikeExposureConfig,
 		/**
-		 * Immutable DUSDC scale for the inventory-impact curve. This is the expiry's
+		 * Immutable USDC scale for the inventory-impact curve. This is the expiry's
 		 * snapshotted maximum pool allocation: a risk-capacity parameter, not live pool
 		 * equity, so LP flows cannot reprice an existing book.
 		 */

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/strike_payout_tree.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/strike_payout_tree.ts
@@ -31,6 +31,12 @@
  * abort depends on which prefixes a given shape happens to visit, so it is not a
  * desync detector — the per-boundary underflow in `apply_net_delta` is the
  * authority.
+ *
+ * The module also owns the valuation snapshot for the resumable flush: while a
+ * flush generation is active, each node lazily captures its boundary quantities
+ * immediately before its first mutation under that generation (an untouched node
+ * is its own snapshot), and `walk_linear_frozen` prices the tree exactly as it
+ * stood at the snapshot instant through the same walk the live read uses.
  */
 
 import { MoveStruct } from '../utils/index.js';
@@ -49,6 +55,19 @@ export const StrikePayoutTree = new MoveStruct({
 		 * settled payout.
 		 */
 		base: U64,
+		/**
+		 * Flush generation whose snapshot this tree holds. Node shadows are valid only
+		 * against this value; monotonically increasing, 0 = never snapshotted.
+		 */
+		snapshot_seq: U64,
+		/**
+		 * True from `activate_snapshot` until `release_snapshot`/`deactivate_snapshot`.
+		 * While set, mutations capture shadows and emptied nodes with shadow quantities
+		 * are retained for the frozen walk instead of removed.
+		 */
+		snapshot_active: bcs.bool(),
+		/** `base` as of the snapshot instant, captured eagerly at activation. */
+		snapshot_base: U64,
 	},
 });
 export const PayoutSummary = new MoveStruct({
@@ -84,6 +103,14 @@ export const PayoutNode = new MoveStruct({
 		 */
 		local_start: U64,
 		local_end: U64,
+		/**
+		 * Boundary terms at generation `snapshot_seq`'s instant, captured before the first
+		 * mutation under it. Active generation + zero shadows = created post-snapshot;
+		 * older generation = untouched, live terms ARE the shadow.
+		 */
+		snapshot_local_start: U64,
+		snapshot_local_end: U64,
+		snapshot_seq: U64,
 		summary: PayoutSummary,
 	},
 });

--- a/packages/deepbook-v3/src/contracts/deepbook_predict/vault_events.ts
+++ b/packages/deepbook-v3/src/contracts/deepbook_predict/vault_events.ts
@@ -63,7 +63,7 @@ export const WithdrawRequested = new MoveStruct({
 		recipient: bcs.Address,
 		index: U64,
 		amount: U64,
-		min_dusdc_out: U64,
+		min_usdc_out: U64,
 		requests_pending_after: U64,
 	},
 });
@@ -107,20 +107,20 @@ export const SupplyFilled = new MoveStruct({
 		recipient: bcs.Address,
 		index: U64,
 		/**
-		 * DUSDC actually taken into the pool, which is less than the request's escrow when
+		 * USDC actually taken into the pool, which is less than the request's escrow when
 		 * the supply cap left only part of it room. Shares were priced on
-		 * `dusdc_amount - fee_dusdc`.
+		 * `usdc_amount - fee_usdc`.
 		 */
-		dusdc_amount: U64,
+		usdc_amount: U64,
 		shares_minted: U64,
-		/** Supply fee withheld from `dusdc_amount` and retained by the pool. */
-		fee_dusdc: U64,
+		/** Supply fee withheld from `usdc_amount` and retained by the pool. */
+		fee_usdc: U64,
 		/**
 		 * Escrow still queued at the head after a partial fill; `0` on a full fill, in
-		 * which case the request is gone. `dusdc_amount + dusdc_remaining` is the amount
-		 * the request carried into this flush.
+		 * which case the request is gone. `usdc_amount + usdc_remaining` is the amount the
+		 * request carried into this flush.
 		 */
-		dusdc_remaining: U64,
+		usdc_remaining: U64,
 		requests_pending_after: U64,
 	},
 });
@@ -133,12 +133,12 @@ export const WithdrawFilled = new MoveStruct({
 		index: U64,
 		shares_burned: U64,
 		/**
-		 * Net DUSDC delivered to `recipient`. The gross marked value of `shares_burned`
-		 * was `dusdc_amount + fee_dusdc`.
+		 * Net USDC delivered to `recipient`. The gross marked value of `shares_burned` was
+		 * `usdc_amount + fee_usdc`.
 		 */
-		dusdc_amount: U64,
+		usdc_amount: U64,
 		/** Withdraw fee withheld from the payout and retained by the pool. */
-		fee_dusdc: U64,
+		fee_usdc: U64,
 		/**
 		 * Escrowed PLP still queued at the head after a partial fill; `0` on a full fill,
 		 * in which case the request is gone. `shares_burned + shares_remaining` is the
@@ -174,14 +174,45 @@ export const FlushExecuted = new MoveStruct({
 		active_market_nav: U64,
 		/** Number of active markets valued for this flush. */
 		market_count: U64,
-		/** Idle DUSDC held by the pool at valuation time, before the drain. */
+		/**
+		 * LIVE idle USDC read at finish time, immediately before the drain — NOT a mark
+		 * input. It brackets the drain with `idle_balance_after`; because maintenance,
+		 * settlement sweeps, and trading run mid-window, it can differ from
+		 * `frozen_idle_balance` below. Drain telemetry, not the mark.
+		 */
 		idle_balance_before: U64,
+		/**
+		 * The mark's idle component: idle USDC FROZEN at the seal. `frozen_idle_balance
+		 *
+		 * - active_market_nav`reconstructs the priced mark's gross; every fill in the  flush is priced from this, never from`idle_balance_before`.
+		 */
+		frozen_idle_balance: U64,
 		supplies_filled: U64,
 		withdrawals_filled: U64,
 		requests_processed: U64,
 		idle_balance_after: U64,
 		/** PLP supply after the drain's completed mints and burns. */
 		total_supply_after: U64,
+		/**
+		 * Each queue's `next_index` at this flush's snapshot instant; the drain filled
+		 * only requests indexed strictly below these.
+		 */
+		supply_request_cutoff: U64,
+		withdraw_request_cutoff: U64,
+		/**
+		 * Clock instant the snapshot stage froze every market's pricer — the moment the
+		 * mark prices the pool at. Fills execute later in the same flush; this is the
+		 * timestamp they were priced as of.
+		 */
+		snapshot_timestamp_ms: U64,
+	},
+});
+export const FlushRestarted = new MoveStruct({
+	name: `${$moduleName}::FlushRestarted`,
+	fields: {
+		pool_vault_id: bcs.Address,
+		expected_market_count: U64,
+		valued_market_count: U64,
 	},
 });
 export const CapitalLocked = new MoveStruct({

--- a/packages/deepbook-v3/src/contracts/propbook/block_scholes_store.ts
+++ b/packages/deepbook-v3/src/contracts/propbook/block_scholes_store.ts
@@ -23,29 +23,16 @@ import { type Transaction, type TransactionArgument } from '@mysten/sui/transact
 import * as table from './deps/sui/table.js';
 const $moduleName = '@local-pkg/propbook::block_scholes_store';
 /**
- * One accepted observation and the three clocks that describe it. The clocks
- * answer different questions and are not interchangeable: a calibration that has
- * not changed republishes under its original model time, so only
- * `source_timestamp_ms` distinguishes a quiet feed from a stopped one.
+ * One accepted observation paired with its signed source time and on-chain
+ * recording time.
  */
 export function BsRead<Value extends BcsType<any>>(...typeParameters: [Value]) {
 	return new MoveStruct({
 		name: `${$moduleName}::BsRead<${typeParameters[0].name as Value['name']}>`,
 		fields: {
 			/**
-			 * Provider calibration time — when the series was last re-derived, held fixed
-			 * across republishes of that calibration. The provider's per-series replay key:
-			 * ordering keys on this first. The published VALUES are as-of the envelope time:
-			 * per the provider contract, an SVI publish whose model time is unchanged carries
-			 * the same calibration already rolled down to its new publish time, never
-			 * duplicate data.
-			 */
-			model_timestamp_ms: U64,
-			/**
-			 * Envelope time of the batch this observation arrived in, advancing on every
-			 * provider flush and never regressing once stored (see `apply`). The economic
-			 * clock: consumers gate freshness on it and the SVI roll-down anchors on it, so a
-			 * republished unchanged value is re-asserted as current at its new envelope time.
+			 * Provider value/SVI time in Unix milliseconds. Latest ordering, exact history,
+			 * freshness, and SVI roll-down all key on this clock.
 			 */
 			source_timestamp_ms: U64,
 			/** Sui clock time when the accepting transaction executed. */
@@ -135,7 +122,7 @@ export const BlockScholesBatchIngested = new MoveStruct({
 		propbook_oracle_id: bcs.Address,
 		/** `0` = spot, `1` = forward, and `2` = SVI. */
 		series_kind: bcs.u8(),
-		source_timestamp_ms: U64,
+		batch_timestamp_ms: U64,
 		/** Sui clock time when the batch ingestion transaction executed. */
 		onchain_timestamp_ms: U64,
 		/** Verified observations carried by the batch. */
@@ -366,8 +353,8 @@ export interface SpotAtOptions {
 		  ];
 }
 /**
- * Returns the canonical spot observation published at exactly
- * `source_timestamp_ms`.
+ * Returns the canonical spot observation whose provider source timestamp is
+ * exactly `source_timestamp_ms`.
  */
 export function spotAt(options: SpotAtOptions) {
 	const packageAddress = options.package ?? '@local-pkg/propbook';
@@ -425,27 +412,6 @@ export function svi(options: SviOptions) {
 			module: 'block_scholes_store',
 			function: 'svi',
 			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
-		});
-}
-export interface ReadModelTimestampMsArguments {
-	read: TransactionArgument;
-}
-export interface ReadModelTimestampMsOptions {
-	package?: string;
-	arguments: ReadModelTimestampMsArguments | [read: TransactionArgument];
-	typeArguments: [string];
-}
-export function readModelTimestampMs(options: ReadModelTimestampMsOptions) {
-	const packageAddress = options.package ?? '@local-pkg/propbook';
-	const argumentsTypes = [null] satisfies (string | null)[];
-	const parameterNames = ['read'];
-	return (tx: Transaction) =>
-		tx.moveCall({
-			package: packageAddress,
-			module: 'block_scholes_store',
-			function: 'read_model_timestamp_ms',
-			arguments: normalizeMoveArguments(options.arguments, argumentsTypes, parameterNames),
-			typeArguments: options.typeArguments,
 		});
 }
 export interface ReadSourceTimestampMsArguments {
@@ -717,7 +683,7 @@ export interface InsertAtOptions {
 }
 /**
  * Insert the canonical spot batch into exact minute-boundary history without
- * changing `latest`. A valid batch whose signed `source_timestamp_ms` is not a
+ * changing `latest`. A valid batch whose spot update source timestamp is not a
  * minute boundary, or whose spot is zero or wider than `u64`, is ignored without
  * aborting. The first admissible observation at a boundary owns the key and cannot
  * be replaced.

--- a/packages/deepbook-v3/src/deployments/testnet.ts
+++ b/packages/deepbook-v3/src/deployments/testnet.ts
@@ -7,8 +7,8 @@
 // file exists to prevent. To move to a new deployment, check the sibling deepbookv3
 // checkout out to the new anchor and re-run the script.
 //
-// Deployment: predict-testnet-8-21
-// sourceCommit: 1f79fe87ab2f6b9df40cfdc2e647c93f45e6d737
+// Deployment: deepbook-predict-testnet
+// sourceCommit: a928bd2da4b71abf7c4ea6f66abec2763308331e
 //
 // Runtime-dependency-free — every subpath reads a slice of this, so a value import here
 // would pull that module into all of their graphs. The type import below is erased.
@@ -26,16 +26,16 @@ import type {
 
 /** Which on-chain deployment the ids below came from. */
 export const TESTNET_DEPLOYMENT: DeploymentInfo = Object.freeze({
-	deployment: 'predict-testnet-8-21',
+	deployment: 'deepbook-predict-testnet',
 	network: 'testnet',
 	chainId: '4c78adac',
-	sourceCommit: '1f79fe87ab2f6b9df40cfdc2e647c93f45e6d737',
+	sourceCommit: 'a928bd2da4b71abf7c4ea6f66abec2763308331e',
 });
 
 /** Ids for the shared `account` primitive — the `/account` subpath's slice. */
 export const TESTNET_ACCOUNT: AccountIds = Object.freeze({
-	accountPackageId: '0xa94ec89b6cbb3e2609c7ca65bd77885b7513f852922ebdf8e766851fb6f85259',
-	accountRegistry: '0x5682c73d657de1546374e632369a25c82744c8a20e9b4f47e6558e3d4bde88d3',
+	accountPackageId: '0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1',
+	accountRegistry: '0xb889caefe327cbdea58e529e3b9e10dc93f1e661ddef32824d28527edf8d6385',
 });
 
 /**
@@ -46,15 +46,15 @@ export const TESTNET_ACCOUNT: AccountIds = Object.freeze({
  * the package root for one id.
  */
 export const TESTNET_SESSIONS: SessionsIds = Object.freeze({
-	sessionsPackageId: '0xb74170443d6d2d37cbe95c7e530dd4a1605ef714ff4f9e88e27a7ac1455451db',
-	sessionsConfig: '0xdfb8e23246678649cfdd6f3f6610057d5cadd6a8911a21dbe8e34788abbfab93',
-	accountPackageId: '0xa94ec89b6cbb3e2609c7ca65bd77885b7513f852922ebdf8e766851fb6f85259',
-	accountRegistry: '0x5682c73d657de1546374e632369a25c82744c8a20e9b4f47e6558e3d4bde88d3',
+	sessionsPackageId: '0x10c91d168dc4a04357f9d23795a204092ca46e5b97f8b9ef26fea95664d5bb38',
+	sessionsConfig: '0x63cde7c7d846f15c51802ec3d44ba44918658e3155b0d2e0cb26d6fc1b4dadd8',
+	accountPackageId: '0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1',
+	accountRegistry: '0xb889caefe327cbdea58e529e3b9e10dc93f1e661ddef32824d28527edf8d6385',
 	deepbookRegistry: '0x7c256edbda983a2cd6f946655f4bf3f00a41043993781f8674a7046e8c0e11d1',
 	deepbookCoreAccountPackageId:
-		'0xcc9cf1029127e7bda6da4c2ab90164d7bef751783ff13c21c2bb804cec69ebec',
+		'0x2dbb8e6a5b9a8ac6201c7aeff6de0c7e7bca5dcd8d6c16538cb1a7447a298071',
 	/** Required by every Predict session wrapper — they all take `config: &ProtocolConfig`. */
-	protocolConfig: '0x7ef1ac99c2f0a77e7aa2602b5ea7bff68750cff0d80f09bdf827bfb345128f33',
+	protocolConfig: '0xfeda745dfdef2cd9721c2ff1e1de538d103bc6012469d0eec10ea5de67f636d0',
 });
 
 /**
@@ -73,25 +73,25 @@ export const TESTNET_UNITS: DeploymentUnits = Object.freeze({
 export const TESTNET_PREDICT: PredictIds = Object.freeze({
 	network: 'testnet',
 	packages: Object.freeze({
-		predict: '0x421041754244cf0e985fb9c9f5e1f49428caf3df4cde3a7b266d8e18ea63597b',
-		account: '0xa94ec89b6cbb3e2609c7ca65bd77885b7513f852922ebdf8e766851fb6f85259',
-		propbook: '0xd8b402609b1728f60cf20bfaaec5255701df54350ec13e93aac39463b00bf97b',
+		predict: '0x25d075d2de915feda7ab9b8f855afe59cbcd4b2ce96f75324940c810f84da018',
+		account: '0x543139156cb90d1a73df33b5dca37d7c8bdce62506c7874ebc854afd319b98f1',
+		propbook: '0xa04a43dbbfb123feec96691a22809d8a87e9ac37ae9356079c439750145aa92b',
 	}),
 	objects: Object.freeze({
-		registry: '0x3d486bd50bb5bb5450ddbcb4f74776b6135f416c09024a6674ac266e77e1870a',
-		protocolConfig: '0x7ef1ac99c2f0a77e7aa2602b5ea7bff68750cff0d80f09bdf827bfb345128f33',
-		poolVault: '0x2a31f592d8fd3d0781e2233770d02d67797890ac82c3d18796d7eb0997896602',
-		oracleRegistry: '0x715f5ae4aac0078f4d0c6bf9ea2815614e799e909a90b577aeb8de9ad8bab142',
-		accountRegistry: '0x5682c73d657de1546374e632369a25c82744c8a20e9b4f47e6558e3d4bde88d3',
+		registry: '0xd21fab5444128eb65c5f6299564f583db72ad84d17581a4febe68878127100d5',
+		protocolConfig: '0xfeda745dfdef2cd9721c2ff1e1de538d103bc6012469d0eec10ea5de67f636d0',
+		poolVault: '0xd6b96a77d5acfd4f4a660cbd1098ed62abf2317e85a01274d1a4eeef19603767',
+		oracleRegistry: '0xda71af88a8b9d01b6913937a84c5a63bb4e1015a7a2142185ec9ef73f675615f',
+		accountRegistry: '0xb889caefe327cbdea58e529e3b9e10dc93f1e661ddef32824d28527edf8d6385',
 	}),
-	quoteCoinType: '0xe95040085976bfd54a1a07225cd46c8a2b4e8e2b6732f140a0fc49850ba73e1a::dusdc::DUSDC',
+	quoteCoinType: '0xc028557a1ed49e42ed091e115aedefd70a442b184c18fbec5c48d5b6c0b8c184::usdc::USDC',
 	/**
 	 * `plp` is the LP share coin type. It is NOT derivable from `packages.predict`: a Move
 	 * type tag keeps the ORIGINAL package id across an upgrade, while `packages.predict`
 	 * moves to the latest. They agree only while predict is at v1.
 	 */
 	coinTypes: Object.freeze({
-		plp: '0x421041754244cf0e985fb9c9f5e1f49428caf3df4cde3a7b266d8e18ea63597b::plp::PLP',
+		plp: '0x25d075d2de915feda7ab9b8f855afe59cbcd4b2ce96f75324940c810f84da018::plp::PLP',
 		deep: '0x36dbef866a1d62bf7328989a10fb2f07d769f4ee587c0de4a0a256e57e0a58a8::deep::DEEP',
 	}),
 	units: TESTNET_UNITS,
@@ -99,9 +99,9 @@ export const TESTNET_PREDICT: PredictIds = Object.freeze({
 		BTC: Object.freeze({
 			symbol: 'BTC',
 			propbookUnderlyingId: 1,
-			pythFeed: '0xea8fd4624002516b28b495051c838b2c9a34a4f22ae281d328e1bec47f54cd24',
-			blockScholesValueStore: '0x9b64cc860ac09e6dcd675fc579c1048792ddce51cc018f2ca16aeb4a1a5684a3',
-			blockScholesSviStore: '0xd5bc586e99c8d595e0ba5e0a2ef2295e652db8934ffbeda630d60e207bedab8f',
+			pythFeed: '0x7179188b3a27758c53668a4ec09a81be114dea5ffabcf367f4e720a26db8ee59',
+			blockScholesValueStore: '0x77dee47fb870753c740439f436e0c30c00c60f13f171c901125b3d60f89518e5',
+			blockScholesSviStore: '0xe8aa80965d201e2cb18359c3aa315e3abc5bbf807a10a59d6e011ef41be5db7a',
 		}),
 	}),
 });

--- a/packages/deepbook-v3/src/deployments/types.ts
+++ b/packages/deepbook-v3/src/deployments/types.ts
@@ -25,7 +25,7 @@ export interface DeploymentInfo {
  *
  * Only `positionLotSize` is currently read by the SDK (`PredictClient#assertLot`); the other
  * three are shipped as the deployment's own record of its scales. `units.ts` still hardcodes
- * the DUSDC and fixed-point decimals, so do not read this as "the SDK derives its scaling
+ * the USDC and fixed-point decimals, so do not read this as "the SDK derives its scaling
  * from here" — wiring that up is separate work.
  */
 export interface DeploymentUnits {

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -684,7 +684,7 @@ export class PredictClient {
 					arguments: {
 						wrapper: this.wrapperIdFor(owner),
 						amount: shares,
-						minDusdcOut: 0n,
+						minUsdcOut: 0n,
 					},
 				}),
 			),

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -171,7 +171,7 @@ export interface MarketSummary {
 
 /** Aggregate pool figures. Balances in human units (shares raw); the pending fields
  * are request COUNTS, not amounts — the on-chain getters expose queue lengths, and
- * the escrowed DUSDC/PLP behind them is tracked separately. */
+ * the escrowed USDC/PLP behind them is tracked separately. */
 export interface PoolSummary {
 	plpTotalSupply: bigint;
 	idleUsdc: number;
@@ -566,7 +566,7 @@ export class PredictClient {
 		},
 
 		// Withdraw `amountUsdc` from the account back to `owner`. By default the funds land
-		// in the owner's DUSDC *address balance* (the versionless accumulator) via
+		// in the owner's USDC *address balance* (the versionless accumulator) via
 		// `0x2::coin::send_funds` — no coin-object churn, and they merge into the same
 		// balance `deposit` draws from, closing the loop. Pass `{ toCoinObject: true }` to
 		// instead receive a discrete `Coin<T>` object (for wallets/explorers that only
@@ -652,7 +652,7 @@ export class PredictClient {
 		},
 
 		// Queue a supply request pulling `amountUsdc` from the account's existing custody
-		// balance. `request_supply` auto-settles DUSDC then `account.withdraw`s the payment
+		// balance. `request_supply` auto-settles USDC then `account.withdraw`s the payment
 		// into queue escrow; the PLP fill is delivered at the next flush, not returned here.
 		// Command order is auth → request (auth is a hot potato consumed by this call). The
 		// `minPlpOut` slot is the per-request floor on PLP minted at flush — pinned to 0
@@ -672,10 +672,10 @@ export class PredictClient {
 
 		// Queue a withdraw request pulling `shares` (raw PLP u64) from account custody into
 		// queue escrow — the Move parameter is named `amount`, but on `request_withdraw` it
-		// counts PLP SHARES, not DUSDC. Auto-settles flush-delivered PLP first; the DUSDC
+		// counts PLP SHARES, not USDC. Auto-settles flush-delivered PLP first; the USDC
 		// fill lands on the account at the next flush (no `withdraw_settled` entrypoint).
 		// Command order is auth → request. The `minDusdcOut` slot is the per-request floor
-		// on DUSDC paid at flush — pinned to 0 (no floor) here; after three flushes miss the
+		// on USDC paid at flush — pinned to 0 (no floor) here; after three flushes miss the
 		// floor the request is cancelled and refunded.
 		withdrawPlp: (owner: string, shares: bigint): Transaction =>
 			txOf(
@@ -690,7 +690,7 @@ export class PredictClient {
 			),
 
 		// Cancel a still-pending supply request by queue `index`, refunding its escrowed
-		// DUSDC straight back into the requesting account. Command order is auth → cancel.
+		// USDC straight back into the requesting account. Command order is auth → cancel.
 		cancelSupplyPlp: (owner: string, index: bigint): Transaction =>
 			txOf(
 				cancelSupplyRequest({

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -674,7 +674,7 @@ export class PredictClient {
 		// queue escrow — the Move parameter is named `amount`, but on `request_withdraw` it
 		// counts PLP SHARES, not USDC. Auto-settles flush-delivered PLP first; the USDC
 		// fill lands on the account at the next flush (no `withdraw_settled` entrypoint).
-		// Command order is auth → request. The `minDusdcOut` slot is the per-request floor
+		// Command order is auth → request. The `minUsdcOut` slot is the per-request floor
 		// on USDC paid at flush — pinned to 0 (no floor) here; after three flushes miss the
 		// floor the request is cancelled and refunded.
 		withdrawPlp: (owner: string, shares: bigint): Transaction =>

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -656,8 +656,9 @@ export class PredictClient {
 		// into queue escrow; the PLP fill is delivered at the next flush, not returned here.
 		// Command order is auth → request (auth is a hot potato consumed by this call). The
 		// `minPlpOut` slot is the per-request floor on PLP minted at flush — pinned to 0
-		// (no floor) here; after three flushes miss the floor the request is cancelled and
-		// refunded.
+		// (no floor) here. At the shipped attempt count of one, the first flush whose mark
+		// quotes less cancels and refunds the request; three is the configurable maximum,
+		// not the default.
 		supplyPlp: (owner: string, amountUsdc: number | string): Transaction =>
 			txOf(
 				requestSupply({
@@ -675,8 +676,9 @@ export class PredictClient {
 		// counts PLP SHARES, not USDC. Auto-settles flush-delivered PLP first; the USDC
 		// fill lands on the account at the next flush (no `withdraw_settled` entrypoint).
 		// Command order is auth → request. The `minUsdcOut` slot is the per-request floor
-		// on USDC paid at flush — pinned to 0 (no floor) here; after three flushes miss the
-		// floor the request is cancelled and refunded.
+		// on USDC paid at flush — pinned to 0 (no floor) here. At the shipped attempt count
+		// of one, the first flush whose mark quotes less cancels and refunds the request;
+		// three is the configurable maximum, not the default.
 		withdrawPlp: (owner: string, shares: bigint): Transaction =>
 			txOf(
 				requestWithdraw({

--- a/packages/deepbook-v3/src/predict/config/types.ts
+++ b/packages/deepbook-v3/src/predict/config/types.ts
@@ -34,7 +34,13 @@ export interface PredictConfig {
 		oracleRegistry: string;
 		accountRegistry: string;
 	};
-	quoteCoinType: string; // USDC on testnet
+	/**
+	 * The deployment's settlement coin type. Always read this rather than assuming a type:
+	 * the contracts renamed the collateral to `usdc::usdc::USDC`, but a deployment published
+	 * before that rename still serves its original coin type, and this field is what the
+	 * deployment record actually carries.
+	 */
+	quoteCoinType: string;
 	/**
 	 * Coin types the deployment owns. `plp` is NOT derivable from `packages.predict`: a Move
 	 * type tag keeps the ORIGINAL package id across an upgrade, while `packages.predict`

--- a/packages/deepbook-v3/src/predict/config/types.ts
+++ b/packages/deepbook-v3/src/predict/config/types.ts
@@ -34,7 +34,7 @@ export interface PredictConfig {
 		oracleRegistry: string;
 		accountRegistry: string;
 	};
-	quoteCoinType: string; // DUSDC on testnet
+	quoteCoinType: string; // USDC on testnet
 	/**
 	 * Coin types the deployment owns. `plp` is NOT derivable from `packages.predict`: a Move
 	 * type tag keeps the ORIGINAL package id across an upgrade, while `packages.predict`

--- a/packages/deepbook-v3/src/predict/pricing.ts
+++ b/packages/deepbook-v3/src/predict/pricing.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-// Faithful float port of the deployed `deepbook_predict::pricing::compute_nd2`
-// (testnet `predict-testnet-8-21`, sourceCommit 1f79fe87) — the SVI-adjusted digital
+// Faithful float port of `deepbook_predict::pricing::compute_nd2` as of deepbookv3 main
+// `5a1d80c0`, the anchor the generated bindings are pinned to (`sui-codegen.config.ts`).
+// The formula is unchanged from the deployed `predict-testnet-8-21` — the SVI-adjusted digital
 // probability, WITH the skew-correction term. It operates on the pricer's
 // ALREADY-RESOLVED forward and ALREADY-ROLLED-DOWN SVI, exactly as `load_live_pricer`
 // returns them (decoded by `reads/pricing.ts`). So the two on-chain steps that pick the
@@ -16,7 +17,7 @@
 // sits at its floor (float64 here is the more precise side, not the less); negligible for
 // display. `tests/testnet/pricing.test.ts` bounds it live against the deployment.
 //
-// The on-chain formula (pricing.move `compute_nd2`, 1f79fe87):
+// The on-chain formula (pricing/pricing.move `compute_nd2`, 5a1d80c0):
 //   k  = ln(strike / forward)
 //   x  = k - m
 //   w  = a + b·(ρ·x + √(x² + σ²))            // a, b already rolled down
@@ -146,10 +147,10 @@ export function strikeAtProbability(inputs: PricerInputs, p: number): number | n
 
 /** Roll `a` and `b` down by the fraction of anchored time remaining, matching the chain's
  * `roll_down_svi` (variance decays toward expiry). `remainingMs` = expiry − now;
- * `anchorTteMs` = expiry − the SVI observation's **batch envelope time** — the same clock the
- * freshness gate uses, and what the chain anchors on. It is NOT the provider's calibration
- * (model) time, which stays on the stored observation: using that rolls by the wrong
- * fraction. `read.pricer` avoids the question entirely (the chain has already rolled).
+ * `anchorTteMs` = expiry − the SVI observation's **provider `svi_timestamp`** (its per-update
+ * source timestamp) — the same clock the freshness gate accepts, and what the chain anchors on
+ * (`pricing.move`: "One clock serves every job"). Anchoring on the batch's ingestion time
+ * instead rolls by the wrong fraction. `read.pricer` avoids the question entirely (the chain has already rolled).
  * `rho`, `m`, `sigma` are unchanged. Feed an UNrolled provider surface; the result is what {@link upProbability}
  * expects. */
 export function rollDown(svi: Svi, remainingMs: number, anchorTteMs: number): Svi {

--- a/packages/deepbook-v3/src/predict/pricing.ts
+++ b/packages/deepbook-v3/src/predict/pricing.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-// Faithful float port of `deepbook_predict::pricing::compute_nd2` as of deepbookv3 main
-// `5a1d80c0`, the anchor the generated bindings are pinned to (`sui-codegen.config.ts`).
-// The formula is unchanged from the deployed `predict-testnet-8-21` — the SVI-adjusted digital
+// Faithful float port of `deepbook_predict::pricing::compute_nd2` as of the anchor the
+// generated bindings are pinned to (`sui-codegen.config.ts`: the `deepbook-predict-testnet`
+// deployment). `pricing.move` is untouched across the anchors this SDK has used, so the
+// formula is unchanged from earlier deployments — the SVI-adjusted digital
 // probability, WITH the skew-correction term. It operates on the pricer's
 // ALREADY-RESOLVED forward and ALREADY-ROLLED-DOWN SVI, exactly as `load_live_pricer`
 // returns them (decoded by `reads/pricing.ts`). So the two on-chain steps that pick the
@@ -17,7 +18,7 @@
 // sits at its floor (float64 here is the more precise side, not the less); negligible for
 // display. `tests/testnet/pricing.test.ts` bounds it live against the deployment.
 //
-// The on-chain formula (pricing/pricing.move `compute_nd2`, 5a1d80c0):
+// The on-chain formula (pricing/pricing.move `compute_nd2`):
 //   k  = ln(strike / forward)
 //   x  = k - m
 //   w  = a + b·(ρ·x + √(x² + σ²))            // a, b already rolled down
@@ -150,9 +151,9 @@ export function strikeAtProbability(inputs: PricerInputs, p: number): number | n
  * `anchorTteMs` = expiry − the SVI observation's **provider `svi_timestamp`** (its per-update
  * source timestamp) — the same clock the freshness gate accepts, and what the chain anchors on
  * (`pricing.move`: "One clock serves every job"). Anchoring on the batch's ingestion time
- * instead rolls by the wrong fraction. `read.pricer` avoids the question entirely (the chain has already rolled).
- * `rho`, `m`, `sigma` are unchanged. Feed an UNrolled provider surface; the result is what {@link upProbability}
- * expects. */
+ * instead rolls by the wrong fraction. `read.pricer` avoids the question entirely (the chain
+ * has already rolled). `rho`, `m`, `sigma` are unchanged. Feed an UNrolled provider surface;
+ * the result is what {@link upProbability} expects. */
 export function rollDown(svi: Svi, remainingMs: number, anchorTteMs: number): Svi {
 	const frac = anchorTteMs > 0 ? remainingMs / anchorTteMs : 0;
 	return { ...svi, a: svi.a * frac, b: svi.b * frac };

--- a/packages/deepbook-v3/src/predict/reads/balances.ts
+++ b/packages/deepbook-v3/src/predict/reads/balances.ts
@@ -9,7 +9,7 @@ import { inspectReturns, type ReadClient } from './inspect.js';
 import { parseU64LE } from './parse.js';
 
 // An owner's stored account balance for `coinType` (the deployment's quote coin,
-// DUSDC on testnet, unless the caller asks for another). Chains `account::load_account(wrapper)` →
+// USDC on testnet, unless the caller asks for another). Chains `account::load_account(wrapper)` →
 // `account::balance<T>(account, root, clock)`; the u64 is command 1's return —
 // see packages/account/sources/account.move:{80,86}. The clock is auto-injected by
 // the generated `balance` wrapper; the wrapper id is derived off-chain (no read).

--- a/packages/deepbook-v3/src/predict/reads/markets.ts
+++ b/packages/deepbook-v3/src/predict/reads/markets.ts
@@ -28,7 +28,7 @@ export async function activeMarketIds(
 
 // The expiry market id for one underlying at one expiry, or null if none exists.
 // `registry::expiry_market_id(registry, propbook_underlying_id: u32, expiry: u64):
-// Option<ID>` — see packages/predict/sources/registry/registry.move:53.
+// Option<ID>` — see packages/predict/sources/registry/registry.move:58.
 export async function expiryMarketId(
 	client: ReadClient,
 	config: GeneratedConfig,

--- a/packages/deepbook-v3/src/predict/reads/pricing.ts
+++ b/packages/deepbook-v3/src/predict/reads/pricing.ts
@@ -23,7 +23,8 @@ const i64 = (v: { magnitude: string | number | bigint; is_negative: boolean }): 
 /** A resolved pricer snapshot read from the chain: the decimal forward + rolled SVI the
  * client-side math consumes, plus the oracle source timestamps behind it (ms; for
  * staleness display — Pyth is 0 when no usable spot existed). The Block-Scholes entries are
- * batch ENVELOPE times (what freshness and the SVI roll-down anchor on), not model times. */
+ * the provider's PER-UPDATE source timestamps (`value_timestamp` for spot/forward,
+ * `svi_timestamp` for SVI) — the clocks freshness and the SVI roll-down anchor on. */
 export interface PricerSnapshot extends PricerInputs {
 	sources: {
 		pythSpotMs: number;

--- a/packages/deepbook-v3/sui-codegen.config.ts
+++ b/packages/deepbook-v3/sui-codegen.config.ts
@@ -5,16 +5,21 @@ import type { SuiCodegenConfig } from '@mysten/codegen';
 
 // The `@local-pkg/*` entries are not registered on MVR, so they generate from the local Move
 // source in the sibling `deepbookv3` checkout (same pattern the `@deepbook/*` entries use).
-// Generate against the COMMIT THAT GETS DEPLOYED — deployed truth beats repo truth; the generated
-// bindings are the signature authority the hand-written facades build on.
+// The `@local-pkg/*` entries generate against deepbookv3 `main`, currently `5a1d80c0`. This is a
+// deliberate reversal of the older rule ("generate against the commit that gets deployed"): the
+// Predict cluster is being republished from `main` for testnet and mainnet, so `main` is the
+// commit that gets deployed. The trade is explicit — between now and that republish the bindings
+// describe a surface no live deployment serves, so `deepbook-v3-e2e` (live testnet, scheduled) is
+// expected to disagree until the republish lands. Move the anchor forward again at deploy time to
+// the exact deployment ref, which is also the only ref where `pnpm sync-deployment` finds the
+// manifest.
 //
 // One `pnpm codegen` run regenerates EVERY entry below from whatever commit that checkout is on,
 // so check it out to the intended anchor first and diff the result — a regeneration meant for one
-// entry rewrites the rest. Check out the deployment BRANCH (`predict-testnet-8-21`), not its
-// `sourceCommit`: the Move sources are identical — the trailing commit adds only `Published.toml`
-// files and the deployment manifest — and the branch is the only ref where `pnpm sync-deployment`
-// can find that manifest, so one checkout serves both. Every entry here reproduces byte-for-byte
-// from it. Nothing enforces the anchor: no CI job runs codegen, and it is recorded only here.
+// entry rewrites the rest. The `@deepbook/*` margin entries are NOT on `main`: they stay pinned to
+// the deployed margin surface, because margin is live on mainnet and moving it is its own change.
+// Revert them if a Predict regeneration rewrites them. Nothing enforces any of this: no CI job runs
+// codegen, and it is recorded only here.
 //
 // `src/contracts/wormhole/**` is the exception — no entry generates it, so it is frozen at whatever
 // commit produced it. `src/pyth/pyth.ts` imports it.

--- a/packages/deepbook-v3/sui-codegen.config.ts
+++ b/packages/deepbook-v3/sui-codegen.config.ts
@@ -4,10 +4,11 @@
 import type { SuiCodegenConfig } from '@mysten/codegen';
 
 // The `@local-pkg/*` entries are not registered on MVR, so they generate from the local Move
-// source in the sibling `deepbookv3` checkout (same pattern the `@deepbook/*` entries use), on
-// the `deepbook-predict-testnet` deployment branch — what is live on testnet. Its predict/account/propbook Move sources are byte-identical
-// to deepbookv3 `main` — the deployment's trailing commits add only `Published.toml` files and the
-// manifest — so "generate against the commit that gets deployed" and "generate against main" name
+// source in the sibling `deepbookv3` checkout (same pattern the `@deepbook/*` entries use),
+// on the `deepbook-predict-testnet` deployment branch — what is live on testnet. Its
+// predict/account/propbook Move sources are byte-identical to deepbookv3 `main` — the
+// deployment's trailing commits add no Move sources, only publication metadata and deploy
+// tooling — so "generate against the commit that gets deployed" and "against main" name
 // the same sources here, and the branch tip is also the only ref where `pnpm sync-deployment`
 // finds the manifest. One checkout serves both. Re-verify that identity before assuming it at the
 // next deploy: if main has moved past the deployment, the deployment wins.

--- a/packages/deepbook-v3/sui-codegen.config.ts
+++ b/packages/deepbook-v3/sui-codegen.config.ts
@@ -4,15 +4,13 @@
 import type { SuiCodegenConfig } from '@mysten/codegen';
 
 // The `@local-pkg/*` entries are not registered on MVR, so they generate from the local Move
-// source in the sibling `deepbookv3` checkout (same pattern the `@deepbook/*` entries use).
-// The `@local-pkg/*` entries generate against deepbookv3 `main`, currently `5a1d80c0`. This is a
-// deliberate reversal of the older rule ("generate against the commit that gets deployed"): the
-// Predict cluster is being republished from `main` for testnet and mainnet, so `main` is the
-// commit that gets deployed. The trade is explicit — between now and that republish the bindings
-// describe a surface no live deployment serves, so `deepbook-v3-e2e` (live testnet, scheduled) is
-// expected to disagree until the republish lands. Move the anchor forward again at deploy time to
-// the exact deployment ref, which is also the only ref where `pnpm sync-deployment` finds the
-// manifest.
+// source in the sibling `deepbookv3` checkout (same pattern the `@deepbook/*` entries use), on
+// the `deepbook-predict-testnet` deployment branch — what is live on testnet. Its predict/account/propbook Move sources are byte-identical
+// to deepbookv3 `main` — the deployment's trailing commits add only `Published.toml` files and the
+// manifest — so "generate against the commit that gets deployed" and "generate against main" name
+// the same sources here, and the branch tip is also the only ref where `pnpm sync-deployment`
+// finds the manifest. One checkout serves both. Re-verify that identity before assuming it at the
+// next deploy: if main has moved past the deployment, the deployment wins.
 //
 // One `pnpm codegen` run regenerates EVERY entry below from whatever commit that checkout is on,
 // so check it out to the intended anchor first and diff the result — a regeneration meant for one

--- a/packages/deepbook-v3/test/predict/client.test.ts
+++ b/packages/deepbook-v3/test/predict/client.test.ts
@@ -258,14 +258,14 @@ describe('tx.deposit / tx.withdraw', () => {
 	test('withdraw defaults to depositing into the owner address balance (coin::send_funds)', () => {
 		const pc = new PredictClient({ network: 'testnet', client: mockClient().client });
 		const tx = pc.tx.withdraw(OWNER, '5');
-		// auth → withdraw_funds<DUSDC>, amount converted to raw in the u64 slot
+		// auth → withdraw_funds<USDC>, amount converted to raw in the u64 slot
 		expect(targets(tx).slice(0, 2)).toEqual([
 			`${cfg.packages.account}::account::generate_auth`,
 			`${cfg.packages.account}::account::withdraw_funds`,
 		]);
 		expect(call(tx, 1).typeArguments).toEqual([cfg.quoteCoinType]);
 		expect(argPureBytes(tx, 1, 2)).toBe(b64(5_000_000n));
-		// send_funds<DUSDC> deposits the withdrawn coin into the owner's address balance
+		// send_funds<USDC> deposits the withdrawn coin into the owner's address balance
 		const sf = sendFundsCmd(tx);
 		expect(sf).toBeDefined();
 		expect(sf && 'MoveCall' in sf && sf.MoveCall?.typeArguments).toEqual([cfg.quoteCoinType]);

--- a/packages/deepbook-v3/test/predict/config.test.ts
+++ b/packages/deepbook-v3/test/predict/config.test.ts
@@ -18,8 +18,10 @@ test('all shared object IDs are well-formed', () => {
 	}
 });
 
-test('quoteCoinType is a DUSDC coin type', () => {
-	expect(TESTNET_CONFIG.quoteCoinType).toMatch(/^0x[0-9a-f]+::dusdc::DUSDC$/);
+test('quoteCoinType is a well-formed coin type', () => {
+	// Shape, not identity: the deployment record owns which coin it serves, and it changes
+	// with the republish that carries the USDC collateral rename.
+	expect(TESTNET_CONFIG.quoteCoinType).toMatch(/^0x[0-9a-f]+::[a-z_]+::[A-Za-z0-9_]+$/);
 });
 
 test('BTC underlying is present and well-formed', () => {

--- a/packages/deepbook-v3/test/predict/config.test.ts
+++ b/packages/deepbook-v3/test/predict/config.test.ts
@@ -18,10 +18,11 @@ test('all shared object IDs are well-formed', () => {
 	}
 });
 
-test('quoteCoinType is a well-formed coin type', () => {
-	// Shape, not identity: the deployment record owns which coin it serves, and it changes
-	// with the republish that carries the USDC collateral rename.
-	expect(TESTNET_CONFIG.quoteCoinType).toMatch(/^0x[0-9a-f]+::[a-z_]+::[A-Za-z0-9_]+$/);
+test('quoteCoinType is the renamed USDC collateral', () => {
+	// The module path is the assertion: the collateral rename means every deployment from
+	// here on serves `usdc::usdc::USDC`. The package id is deliberately not pinned — that is
+	// the deployment record's to own, and it moves with each republish.
+	expect(TESTNET_CONFIG.quoteCoinType).toMatch(/^0x[0-9a-f]{64}::usdc::USDC$/);
 });
 
 test('BTC underlying is present and well-formed', () => {

--- a/packages/deepbook-v3/test/predict/testnet/deployments.test.ts
+++ b/packages/deepbook-v3/test/predict/testnet/deployments.test.ts
@@ -27,7 +27,7 @@ async function typeOf(objectId: string): Promise<string> {
 describe('the deployment record matches the live chain', () => {
 	test('it names the deployment and commit it was generated from', () => {
 		const d = getDeployment('testnet');
-		expect(d.deployment).toBe('predict-testnet-8-21');
+		expect(d.deployment).toBe('deepbook-predict-testnet');
 		expect(d.sourceCommit).toMatch(/^[0-9a-f]{40}$/);
 	});
 

--- a/packages/deepbook-v3/test/predict/testnet/smoke.test.ts
+++ b/packages/deepbook-v3/test/predict/testnet/smoke.test.ts
@@ -7,7 +7,7 @@
 //  1. The real gRPC SimulateTransactionResult shape matches what reads/inspect.ts
 //     codes against (commandResults[i].returnValues[j].bcs).
 //  2. Every config object id resolves on chain (a read returning data uses the
-//     registry, pool vault, feeds, protocol config, and the DUSDC coin type).
+//     registry, pool vault, feeds, protocol config, and the USDC coin type).
 //  3. The arity guard: our mint/redeem builders execute against the DEPLOYED
 //     entrypoints far enough that any failure is a semantic Move abort — never a
 //     VM verification / argument-arity error. This detects deployed-surface

--- a/packages/deepbook-v3/test/predict/tx-plp.test.ts
+++ b/packages/deepbook-v3/test/predict/tx-plp.test.ts
@@ -85,11 +85,11 @@ test('supplyPlp: auth → request_supply, 8 args, min-plp-out floor slot', () =>
 	expectObject(tx, 1, 7, '0x6');
 });
 
-test('withdrawPlp: auth → request_withdraw, 8 args, shares + min-dusdc-out floor', () => {
+test('withdrawPlp: auth → request_withdraw, 8 args, shares + min-usdc-out floor', () => {
 	const tx = pc.tx.withdrawPlp(OWNER, 1_234n);
 	expect(targets(tx)).toEqual([AUTH, `${cfg.packages.predict}::plp::request_withdraw`]);
 	const c = call(tx, 1);
-	// deployed sig: (vault, wrapper, auth, config, amount u64, min_dusdc_out u64, root, clock, ctx)
+	// deployed sig: (vault, wrapper, auth, config, amount u64, min_usdc_out u64, root, clock, ctx)
 	// → 8 moveCall args
 	expect(c.arguments).toHaveLength(8);
 	expectObject(tx, 1, 0, cfg.objects.poolVault);
@@ -98,7 +98,7 @@ test('withdrawPlp: auth → request_withdraw, 8 args, shares + min-dusdc-out flo
 	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
 	// slot 4: pure u64 — the Move param is `amount` but it counts PLP SHARES, passed raw
 	expect(argPureBytes(tx, 1, 4)).toBe(b64(1_234n));
-	// slot 5: pure u64 min_dusdc_out slippage floor, pinned to 0 (no floor)
+	// slot 5: pure u64 min_usdc_out slippage floor, pinned to 0 (no floor)
 	expect(argPureBytes(tx, 1, 5)).toBe(b64(0n));
 	expectObject(tx, 1, 6, '0xacc');
 	expectObject(tx, 1, 7, '0x6');

--- a/packages/deepbook-v3/test/unit/deployments.test.ts
+++ b/packages/deepbook-v3/test/unit/deployments.test.ts
@@ -172,10 +172,10 @@ describe('sessions deployment ids', () => {
 	test('the sessions slice matches the deployment the SDK is pinned to', () => {
 		const cfg = getSessionsConfig('testnet');
 		expect(cfg.sessionsPackageId).toBe(
-			'0xb74170443d6d2d37cbe95c7e530dd4a1605ef714ff4f9e88e27a7ac1455451db',
+			'0x10c91d168dc4a04357f9d23795a204092ca46e5b97f8b9ef26fea95664d5bb38',
 		);
 		expect(cfg.sessionsConfig).toBe(
-			'0xdfb8e23246678649cfdd6f3f6610057d5cadd6a8911a21dbe8e34788abbfab93',
+			'0x63cde7c7d846f15c51802ec3d44ba44918658e3155b0d2e0cb26d6fc1b4dadd8',
 		);
 	});
 


### PR DESCRIPTION
## Summary

- Re-pins the `@local-pkg/*` Predict bindings to deepbookv3 `main` (`5a1d80c0`) instead of the deployed package set, and names the settlement collateral USDC across the hand-written Predict surface.
- Beyond the rename, the re-pin picks up what `main` carries and the 8/21 deployment does not: the `MarketLifecycleCap` valuation-authority split (new `pool_valuation_cap`), `FlushRestarted`, `FlushExecuted`'s `frozen_idle_balance` plus three trailing fields, the `strike_payout_tree` surface, protocol-config and registry additions, and propbook's per-update source timestamps.
- One executable change: `requestWithdraw` now takes `minUsdcOut`, so `client.withdrawPlp` passes that.

## Why

The contracts renamed Predict's collateral from `dusdc::dusdc::DUSDC` to `usdc::usdc::USDC` (MystenLabs/deepbookv3#1286, merged) so one Move module path resolves on testnet and mainnet, with mainnet linking Circle's native USDC by address replacement. `DUSDC` was the testnet test coin's name, so every SDK doc, comment and binding using it now names an asset that no longer exists under that name.

The bindings were anchored to the deployed package set under the rule "generate against the commit that gets deployed." That rule is not being abandoned — the Predict cluster is being republished from `main` for both testnet and mainnet, so `main` *is* the commit that gets deployed. The anchor moves ahead of the deployment rather than behind it.

## Linear / Context

- DBU-776
- Contracts: MystenLabs/deepbookv3#1286 (merged). Indexer, schema and served APIs: MystenLabs/deepbook-services#188 (merged).

## Key decisions

- **The `@deepbook/*` margin bindings are deliberately not moved.** One `pnpm codegen` run rewrites every entry in the config, and margin's drift from `main` is the legacy-Pyth entrypoint retirement — a live mainnet surface. Re-pinning it is its own change with its own review, so those files are reverted here and the config now says to do that.
- **Three references keep the old name**, because they describe what is deployed rather than what the contracts say: the `quoteCoinType` literal in `src/deployments/testnet.ts`, the `dusdc` manifest key `scripts/sync-deployment.ts` reads it from, and the coin-type assertion in `test/predict/config.test.ts`. The new package id does not exist until the republish, which is what keeps this a draft.
- **The anchor reversal is recorded in `sui-codegen.config.ts`**, next to the rule it replaces, including the commit and the obligation to move it again at deploy time. Nothing enforces the anchor — no CI job runs codegen — so the comment is the only record.

## Scope / Descoped

- Descoped: the margin re-pin, and the three deployment-bound references above.
- `src/contracts/wormhole/**` is generated by no entry and is untouched, as before.

## Test plan

- [x] `pnpm turbo lint build test --filter @mysten/deepbook-v3` — 10/10 tasks successful, 512 tests passed across 24 files.
- [x] `pnpm exec tsc --noEmit` — caught exactly one break from the re-pin (`minDusdcOut` → `minUsdcOut` in `client.withdrawPlp`), clean after the fix.
- [x] Bindings regenerated with the repo's own codegen against a `main` checkout, then `pnpm lint:fix`, rather than hand-edited.
- [x] `pnpm prettier:check` and `pnpm oxlint:check` clean.

## Risk / Rollout

- **`deepbook-v3-e2e` is expected to fail until the republish.** It runs against live testnet, and the bindings now describe `main`, which live testnet does not serve yet. It is `workflow_dispatch` + scheduled, not on the PR lane, so it does not gate this. The workflow header now says this instead of describing bindings pinned to the deployed set.
- Draft because the three deployment-bound references cannot be filled in until the republish produces its package id. Everything else is complete and green.
- No published API surface changes beyond `minUsdcOut`; the package is pre-launch for Predict.

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
