### PR TITLE
ci(hashi): pin the Sui binary instead of installing the newest release

### DIFF
--- a/.github/workflows/hashi-ci.yml
+++ b/.github/workflows/hashi-ci.yml
@@ -79,12 +79,30 @@ jobs:
           # makes the relationship unambiguous in cache hit/miss logs.
           shared-key: hashi-${{ env.HASHI_PIN }}
 
+      # Pinned rather than calling hashi's `install-sui.sh`, which installs whatever
+      # the newest `testnet-*` release happens to be. That floated us onto
+      # testnet-v1.79.0 on 2026-09-02 and broke every run since: the pinned hashi
+      # revision cannot deserialize a value it introduced, failing localnet bootstrap
+      # with `invalid value: integer 3, expected variant index 0 <= i < 3`. Nothing in
+      # this repo changed — the last green run (2026-09-01) installed testnet-v1.78.1
+      # and the first red one installed testnet-v1.79.0.
+      #
+      # Same reasoning as the pinned bitcoind below: a floating dependency must not be
+      # able to change what these tests run against with no PR, and it can't be
+      # checksum-verified. Bump this in step with HASHI_PIN — a hashi revision that
+      # understands a newer Sui is what unpins it.
       - name: Install Sui binary
-        # install-sui.sh queries the GitHub releases API with GITHUB_TOKEN
-        # (set -u, so it must be set) — mirrors the env in hashi's own ci.yml.
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: bash hashi/.github/scripts/install-sui.sh
+          SUI_VERSION: 'testnet-v1.78.1'
+          SUI_SHA256: '892bb34c3719b7609baed451dec4d6110254791f69315e7b63fe51804822027e'
+        run: |
+          echo "Installing Sui binary ${SUI_VERSION}..."
+          wget -q "https://sui-releases.s3-accelerate.amazonaws.com/${SUI_VERSION}/sui"
+          echo "${SUI_SHA256}  sui" | sha256sum -c -
+          sudo chmod +x sui
+          sudo mv sui /usr/local/bin/
+          sui --version
+          echo "SUI_BINARY=/usr/local/bin/sui" >> "$GITHUB_ENV"
 
       # Mirrors the "Install Bitcoin Core" step in
       # hashi/.github/workflows/ci.yml, but pinned rather than tracking the


### PR DESCRIPTION
## Summary

- Pins the Sui binary the `Localnet Integration` job installs to `testnet-v1.78.1`, verified by sha256, instead of calling hashi's `install-sui.sh`, which installs whatever the newest `testnet-*` release happens to be.

## Why

`Localnet Integration` has failed on **every** run since 2026-09-02 — `main` included — so the job has been giving no signal for a week.

Nothing in this repo changed. `install-sui.sh` queries the GitHub releases API and takes the newest `testnet-*` tag. On 2026-09-02 that became `testnet-v1.79.0`, and the pinned hashi revision (`HASHI_PIN cd2b81f9`) cannot deserialize a value it introduced. Localnet bootstrap dies before any test runs:

```
Error: Conversion error due to input issue: invalid value: integer `3`, expected variant index 0 <= i < 3
```

The evidence is a clean A/B across the same repo state:

| Run | Sui installed | Result |
| --- | --- | --- |
| 2026-09-01, `main` | `testnet-v1.78.1` | success |
| 2026-09-02, `main` | `testnet-v1.79.0` | failure |
| 2026-09-09, `main` + every PR | `testnet-v1.79.0` | failure |

The only ts-sdks commit in that window was `Version Packages (#1241)`, which touches `pnpm-lock.yaml` — that is what *triggered* the workflow (it is in the path filter), not what broke it. No change to `packages/hashi/**` or to this workflow.

## Key decisions

- **Pin rather than bump `HASHI_PIN`.** Moving the hashi pin is the real long-term fix, but `HASHI_PIN` must match the revision the committed bindings in `packages/hashi/src/contracts` were generated from, so bumping it means regenerating those bindings — a larger change that should not ride along with a CI repair.
- **Pin with a checksum.** This mirrors the reasoning the bitcoind step immediately below already documents: *"an unpinned bitcoind would let a new Bitcoin Core release change what these tests run against with no PR, and a floating version can't be checksum-verified."* Sui was the remaining floating input in the same job.
- **Inline the install rather than parameterize the upstream script.** `install-sui.sh` lives in the hashi repo and takes no version override, so pinning from here means doing the three lines it does. It sets `SUI_BINARY` in `GITHUB_ENV` exactly as before, so later steps are unchanged.

## Scope / Descoped

- Does not bump `HASHI_PIN` or regenerate the hashi bindings.
- Does not change any test, package, or dependency — one workflow step.
- Leaves `install-sui.sh` untouched upstream; other consumers of it are unaffected.

## Test plan

- [x] Root-caused by diffing the installed Sui version across the last green and first red runs of the same workflow on `main` — the only variable that changed.
- [x] Confirmed no ts-sdks change to `packages/hashi/**` or `.github/workflows/hashi-ci.yml` in that window.
- [x] `testnet-v1.78.1` artifact confirmed still downloadable (HTTP 200) and its sha256 computed from the downloaded binary: `892bb34c3719b7609baed451dec4d6110254791f69315e7b63fe51804822027e`.
- [x] Workflow YAML parses, and the step still exports `SUI_BINARY=/usr/local/bin/sui` for downstream steps.
- [ ] **The real check is this PR's own `Localnet Integration` run** — it exercises the changed step end to end. It is red on every other branch right now, so a green run here is the proof.

## Risk / Rollout

- Scoped to one CI step; no package, test, or dependency changes.
- The pin will go stale: when hashi moves to a revision that understands newer Sui, `HASHI_PIN` and this version bump together and the pin can be relaxed. The comment says so at the point of change.
- If `testnet-v1.78.1` is ever pulled from the release bucket the step fails loudly on the checksum or the download, rather than silently running something else — which is the improvement over the floating install.

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
