### PR TITLE
feat(deepbook-predict): let supplyPlp and withdrawPlp set a price floor (DBU-807)

### DIFF
--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -1,0 +1,8 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Predict: let `supplyPlp` and `withdrawPlp` set a price floor. Both hard-pinned the request's
+floor to 0, so the SDK could only ever queue an LP request that accepts whatever mark the next
+pool flush quotes. They now take an optional third argument — `{ minPlpOut }` (raw `bigint`
+shares) and `{ minUsdcOut }` (USD decimals) — defaulting to the previous no-floor behaviour.

--- a/.changeset/eighty-pugs-shave.md
+++ b/.changeset/eighty-pugs-shave.md
@@ -1,5 +1,5 @@
 ---
-'@mysten/deepbook-v3': patch
+'@mysten/deepbook-v3': minor
 ---
 
 Predict: let `supplyPlp` and `withdrawPlp` set a price floor. Both hard-pinned the request's

--- a/packages/deepbook-v3/PREDICT.md
+++ b/packages/deepbook-v3/PREDICT.md
@@ -238,6 +238,13 @@ stop requiring an SDK release for target resolution.
   as the cheap validator.
 - PLP supply/withdraw are queued and fill at the next pool flush; cancels take the queue `index` —
   get it from `decode.plpRequest(result).index`.
+- **Both take an optional price floor**, and default to none:
+  `supplyPlp(owner, amount, { minPlpOut })` (raw `bigint` shares) and
+  `withdrawPlp(owner, shares, { minUsdcOut })` (USD decimals). Each floors the flush's MARK for the
+  whole request rather than naming a quantity — a flush quoting less declines instead of filling
+  smaller. What a miss costs is the deployment's `lp_request_limit_flush_attempts`: at the shipped
+  count of one, the first flush below the floor cancels the request and refunds it, so re-queueing
+  is a fresh transaction. Leave the floor off and the request takes whatever mark the flush quotes.
 - `claimSettled` closes the order in full — the deployed entrypoint takes no quantity.
 - **`withdraw` lands in your address balance by default** (`0x2::coin::send_funds`), not a coin
   object — it merges into the versionless accumulator `deposit` already draws from, so the round

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -135,6 +135,29 @@ export interface CloseOptions {
 	quantity: number;
 }
 
+/** Options for `supplyPlp`. */
+export interface PlpSupplyOptions {
+	/**
+	 * Floor on the PLP minted for the whole request, as raw `bigint` shares — PLP is raw
+	 * everywhere in this SDK. It is a floor on the MARK, not a share count: a flush quoting
+	 * less does not fill smaller, it declines. Omitted → `0n`, no floor.
+	 *
+	 * How a miss is handled is the deployment's `lp_request_limit_flush_attempts`: at the
+	 * shipped count of one the first flush below the floor cancels and refunds the request.
+	 */
+	minPlpOut?: bigint;
+}
+
+/** Options for `withdrawPlp`. */
+export interface PlpWithdrawOptions {
+	/**
+	 * Floor on the USDC paid for the whole request, in USD decimals like every other amount
+	 * here. A floor on the MARK, not an amount: a flush quoting less declines rather than
+	 * paying out smaller. Omitted → no floor. Measured after the protocol's withdraw fee.
+	 */
+	minUsdcOut?: number | string;
+}
+
 /** One tradeable market as returned by read.markets(). */
 export interface ActiveMarket {
 	id: string;
@@ -655,18 +678,22 @@ export class PredictClient {
 		// balance. `request_supply` auto-settles USDC then `account.withdraw`s the payment
 		// into queue escrow; the PLP fill is delivered at the next flush, not returned here.
 		// Command order is auth → request (auth is a hot potato consumed by this call). The
-		// `minPlpOut` slot is the per-request floor on PLP minted at flush — pinned to 0
-		// (no floor) here. At the shipped attempt count of one, the first flush whose mark
-		// quotes less cancels and refunds the request; three is the configurable maximum,
-		// not the default.
-		supplyPlp: (owner: string, amountUsdc: number | string): Transaction =>
+		// `minPlpOut` slot is the per-request floor on PLP minted at flush — `options.minPlpOut`
+		// when given, otherwise 0 (no floor). At the shipped attempt count of one, the first
+		// flush whose mark quotes less cancels and refunds the request; three is the
+		// configurable maximum, not the default.
+		supplyPlp: (
+			owner: string,
+			amountUsdc: number | string,
+			options: PlpSupplyOptions = {},
+		): Transaction =>
 			txOf(
 				requestSupply({
 					config: this.#config,
 					arguments: {
 						wrapper: this.wrapperIdFor(owner),
 						amount: usdcToRaw(amountUsdc),
-						minPlpOut: 0n,
+						minPlpOut: options.minPlpOut ?? 0n,
 					},
 				}),
 			),
@@ -676,17 +703,18 @@ export class PredictClient {
 		// counts PLP SHARES, not USDC. Auto-settles flush-delivered PLP first; the USDC
 		// fill lands on the account at the next flush (no `withdraw_settled` entrypoint).
 		// Command order is auth → request. The `minUsdcOut` slot is the per-request floor
-		// on USDC paid at flush — pinned to 0 (no floor) here. At the shipped attempt count
-		// of one, the first flush whose mark quotes less cancels and refunds the request;
-		// three is the configurable maximum, not the default.
-		withdrawPlp: (owner: string, shares: bigint): Transaction =>
+		// on USDC paid at flush — `options.minUsdcOut` when given, otherwise 0 (no floor).
+		// At the shipped attempt count of one, the first flush whose mark quotes less
+		// cancels and refunds the request; three is the configurable maximum, not the
+		// default.
+		withdrawPlp: (owner: string, shares: bigint, options: PlpWithdrawOptions = {}): Transaction =>
 			txOf(
 				requestWithdraw({
 					config: this.#config,
 					arguments: {
 						wrapper: this.wrapperIdFor(owner),
 						amount: shares,
-						minUsdcOut: 0n,
+						minUsdcOut: options.minUsdcOut === undefined ? 0n : usdcToRaw(options.minUsdcOut),
 					},
 				}),
 			),

--- a/packages/deepbook-v3/src/predict/index.ts
+++ b/packages/deepbook-v3/src/predict/index.ts
@@ -16,6 +16,8 @@ export type {
 	MintAmountOptions,
 	MintOptions,
 	MintQuote,
+	PlpSupplyOptions,
+	PlpWithdrawOptions,
 	PoolSummary,
 	RedeemQuote,
 } from './client.js';

--- a/packages/deepbook-v3/test/predict/tx-plp.test.ts
+++ b/packages/deepbook-v3/test/predict/tx-plp.test.ts
@@ -78,11 +78,23 @@ test('supplyPlp: auth → request_supply, 8 args, min-plp-out floor slot', () =>
 	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
 	// slot 4: pure u64 amount — 5 USDC → 5_000_000 raw
 	expect(argPureBytes(tx, 1, 4)).toBe(b64(5_000_000n));
-	// slot 5: pure u64 min_plp_out slippage floor, pinned to 0 (no floor)
+	// slot 5: pure u64 min_plp_out slippage floor, 0 when no floor is supplied
 	expect(argPureBytes(tx, 1, 5)).toBe(b64(0n));
 	// slot 6: root = 0xacc, slot 7: clock = 0x6
 	expectObject(tx, 1, 6, '0xacc');
 	expectObject(tx, 1, 7, '0x6');
+});
+
+test('supplyPlp: minPlpOut reaches the floor slot as raw shares, amount untouched', () => {
+	const tx = pc.tx.supplyPlp(OWNER, 5, { minPlpOut: 4_900_000n });
+	// The floor is raw PLP shares, so it is NOT scaled the way the USDC amount is.
+	expect(argPureBytes(tx, 1, 4)).toBe(b64(5_000_000n));
+	expect(argPureBytes(tx, 1, 5)).toBe(b64(4_900_000n));
+});
+
+test('supplyPlp: a zero minPlpOut is passed through, not treated as absent', () => {
+	const tx = pc.tx.supplyPlp(OWNER, 5, { minPlpOut: 0n });
+	expect(argPureBytes(tx, 1, 5)).toBe(b64(0n));
 });
 
 test('withdrawPlp: auth → request_withdraw, 8 args, shares + min-usdc-out floor', () => {
@@ -98,10 +110,17 @@ test('withdrawPlp: auth → request_withdraw, 8 args, shares + min-usdc-out floo
 	expectObject(tx, 1, 3, cfg.objects.protocolConfig);
 	// slot 4: pure u64 — the Move param is `amount` but it counts PLP SHARES, passed raw
 	expect(argPureBytes(tx, 1, 4)).toBe(b64(1_234n));
-	// slot 5: pure u64 min_usdc_out slippage floor, pinned to 0 (no floor)
+	// slot 5: pure u64 min_usdc_out slippage floor, 0 when no floor is supplied
 	expect(argPureBytes(tx, 1, 5)).toBe(b64(0n));
 	expectObject(tx, 1, 6, '0xacc');
 	expectObject(tx, 1, 7, '0x6');
+});
+
+test('withdrawPlp: minUsdcOut is scaled to raw USDC, shares stay raw', () => {
+	const tx = pc.tx.withdrawPlp(OWNER, 1_234n, { minUsdcOut: 1.2 });
+	// shares are raw, the floor is USD decimals — the two slots scale differently.
+	expect(argPureBytes(tx, 1, 4)).toBe(b64(1_234n));
+	expect(argPureBytes(tx, 1, 5)).toBe(b64(1_200_000n));
 });
 
 test('cancelSupplyPlp: auth → cancel_supply_request, 7 args, index in u64 slot', () => {


### PR DESCRIPTION
## Description

`supplyPlp` and `withdrawPlp` hard-pinned the request's price floor to `0n`, so the SDK could only ever queue an LP request that accepts whatever mark the next pool flush quotes. The Move entrypoints (`plp::request_supply` / `plp::request_withdraw`) have carried `min_plp_out` / `min_usdc_out` all along — the facade just never surfaced them, and there was no way to reach them short of composing the PTB by hand against the generated bindings.

That pin matters more than it looks. The floor is a floor on the **mark**, not a quantity: a flush quoting less does not fill smaller, it declines. And how a miss is handled is the deployment's `lp_request_limit_flush_attempts` — at the shipped count of one, the first flush below the floor cancels the request and refunds it. With the floor pinned to zero, a caller supplying into a pool has no slippage control at all.

Both methods now take an optional third argument:

```ts
client.predict.tx.supplyPlp(owner, 100_000, { minPlpOut: 99_000_000_000n });
client.predict.tx.withdrawPlp(owner, shares, { minUsdcOut: 98_500 });
```

Unit conventions follow what the SDK already does rather than inventing a third: `minPlpOut` is **raw `bigint` shares**, matching `withdrawPlp`'s existing `shares` parameter and `plpBalance`; `minUsdcOut` is **USD decimals**, matching every other amount. Both default to the previous no-floor behaviour, so no existing call site changes and no existing test needed updating.

Also exports the two option types (`PlpSupplyOptions`, `PlpWithdrawOptions`) and documents the floors in `PREDICT.md`.

The changeset is marked `patch` since this is purely additive; happy to bump it to `minor` if you would rather signal the new API surface.

## Test plan

- `pnpm turbo run test build --filter @mysten/deepbook-v3` — 24 test files pass, build clean.
- Three new cases in `test/predict/tx-plp.test.ts`, asserting on the serialized PTB argument slots:
  - `minPlpOut` reaches slot 5 as raw shares while the USDC `amount` in slot 4 stays scaled — the two slots scale differently, which is the easy thing to get wrong.
  - An explicit `minPlpOut: 0n` is passed through rather than being swallowed as "absent" (guards the `??` against a future `||`).
  - `minUsdcOut` is scaled to raw USDC while `shares` stays raw.
- Negative control: mutating the expected floor by one unit failed exactly the new assertion, confirming the tests bind to real behaviour rather than passing vacuously.
- `prettier -c` and `oxlint` clean on the touched files.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
