### PR TITLE
fix(slush-wallet): preserve per-account signing capabilities

### DIFF
--- a/.changeset/slush-account-capabilities.md
+++ b/.changeset/slush-account-capabilities.md
@@ -4,3 +4,5 @@
 ---
 
 Preserve per-account signing features in web wallet sessions. Slush now honors an explicit empty or restricted feature list, while older sessions without the field retain their existing capabilities.
+
+Enforce signed account capabilities during wallet-side request verification, advertise only implemented features, and refresh account capabilities when another tab replaces the hosted session.

--- a/.changeset/slush-account-capabilities.md
+++ b/.changeset/slush-account-capabilities.md
@@ -1,0 +1,6 @@
+---
+'@mysten/window-wallet-core': minor
+'@mysten/slush-wallet': patch
+---
+
+Preserve per-account signing features in web wallet sessions. Slush now honors an explicit empty or restricted feature list, while older sessions without the field retain their existing capabilities.

--- a/.changeset/slush-account-capabilities.md
+++ b/.changeset/slush-account-capabilities.md
@@ -1,8 +1,10 @@
 ---
 '@mysten/window-wallet-core': minor
-'@mysten/slush-wallet': patch
+'@mysten/slush-wallet': minor
 ---
 
 Preserve per-account signing features in web wallet sessions. Slush now honors an explicit empty or restricted feature list, while older sessions without the field retain their existing capabilities.
 
 Enforce signed account capabilities during wallet-side request verification, advertise only implemented features, and refresh account capabilities when another tab replaces the hosted session.
+
+Dispose cross-tab session listeners when unregistering the wallet. Directly constructed wallets can release their listener with `dispose()`.

--- a/packages/slush-wallet/package.json
+++ b/packages/slush-wallet/package.json
@@ -22,6 +22,7 @@
 		"experimental"
 	],
 	"scripts": {
+		"test": "vitest run",
 		"clean": "rm -rf tsconfig.tsbuildinfo ./dist",
 		"build": "rm -rf dist && tsc --noEmit && tsdown",
 		"build:docs": "node ../docs/scripts/build-docs.ts",

--- a/packages/slush-wallet/src/wallet/index.test.ts
+++ b/packages/slush-wallet/src/wallet/index.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, expect, it, vi } from 'vitest';
+import { SlushWallet } from './index.js';
+
+function session(features?: string[]) {
+	const payload = {
+		exp: 9999999999,
+		iat: 1,
+		iss: 'wallet',
+		aud: 'dapp',
+		payload: {
+			accounts: [
+				{ address: '0xx', publicKey: 'AQID', ...(features === undefined ? {} : { features }) },
+			],
+		},
+	};
+	return `e30.${btoa(JSON.stringify(payload)).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')}.signature`;
+}
+function wallet(features?: string[]) {
+	vi.stubGlobal('localStorage', { getItem: () => session(features) });
+	return new SlushWallet({
+		name: 'test',
+		metadata: { id: 'slush', walletName: 'Slush', icon: 'data:image/png;base64,', enabled: true },
+	});
+}
+afterEach(() => vi.unstubAllGlobals());
+it('preserves an explicitly unheld account through JWT decoding and wallet account construction', () => {
+	const [account] = wallet([]).accounts;
+	expect(account.features).toEqual([]);
+	expect(account.publicKey).toEqual(new Uint8Array([1, 2, 3]));
+});
+it('preserves the advertised feature subset', () => {
+	expect(wallet(['sui:signPersonalMessage']).accounts[0].features).toEqual([
+		'sui:signPersonalMessage',
+	]);
+});
+it('keeps existing sessions compatible when no feature field was supplied', () => {
+	expect(wallet().accounts[0].features).toContain('sui:signTransaction');
+});

--- a/packages/slush-wallet/src/wallet/index.test.ts
+++ b/packages/slush-wallet/src/wallet/index.test.ts
@@ -38,3 +38,32 @@ it('preserves the advertised feature subset', () => {
 it('keeps existing sessions compatible when no feature field was supplied', () => {
 	expect(wallet().accounts[0].features).toContain('sui:signTransaction');
 });
+
+it('only advertises features implemented by the wallet', () => {
+	const instance = wallet(['sui:signAndExecuteTransactionBlock', 'sui:signTransaction']);
+	expect(instance.accounts[0].features.every((feature) => feature in instance.features)).toBe(true);
+});
+
+it('refreshes accounts when another tab replaces or clears the session', () => {
+	let stored: string | null = session(['sui:signTransaction']);
+	const browser = new EventTarget();
+	vi.stubGlobal('window', browser);
+	vi.stubGlobal('localStorage', { getItem: () => stored });
+	const instance = new SlushWallet({
+		name: 'test',
+		metadata: { id: 'slush', walletName: 'Slush', icon: 'data:image/png;base64,', enabled: true },
+	});
+	const change = vi.fn();
+	instance.features['standard:events'].on('change', change);
+	stored = session([]);
+	browser.dispatchEvent(
+		Object.assign(new Event('storage'), { key: 'slush:session', storageArea: localStorage }),
+	);
+	expect(instance.accounts[0].features).toEqual([]);
+	expect(change).toHaveBeenCalledTimes(1);
+	stored = null;
+	browser.dispatchEvent(
+		Object.assign(new Event('storage'), { key: null, storageArea: localStorage }),
+	);
+	expect(instance.accounts).toEqual([]);
+});

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -109,6 +109,7 @@ export class SlushWallet implements Wallet {
 	#walletName: string;
 	#icon: WalletIcon;
 	#name: string;
+	#removeStorageListener: (() => void) | null = null;
 
 	get name() {
 		return this.#walletName;
@@ -191,15 +192,24 @@ export class SlushWallet implements Wallet {
 		this.#walletName = metadata.walletName;
 		this.#icon = metadata.icon as WalletIcon;
 		if (typeof window !== 'undefined') {
-			window.addEventListener('storage', (event) => {
+			const target = window;
+			const onStorage = (event: StorageEvent) => {
 				if (
 					event.storageArea !== localStorage ||
 					(event.key !== SLUSH_SESSION_KEY && event.key !== null)
 				)
 					return;
 				this.#setAccounts(this.#getPreviouslyAuthorizedAccounts());
-			});
+			};
+			target.addEventListener('storage', onStorage);
+			this.#removeStorageListener = () => target.removeEventListener('storage', onStorage);
 		}
+	}
+
+	/** Stop observing cross-tab session changes. Registered wallets dispose on unregister. */
+	dispose() {
+		this.#removeStorageListener?.();
+		this.#removeStorageListener = null;
 	}
 
 	#signTransactionBlock: SuiSignTransactionBlockMethod = async ({
@@ -359,17 +369,7 @@ export function registerSlushWallet(
 ) {
 	const wallets = getWallets();
 
-	let unregister: (() => void) | null = null;
-
-	// listen for wallet registration
-	wallets.on('register', (wallet) => {
-		if (wallet.id === SUI_WALLET_EXTENSION_ID) {
-			unregister?.();
-		}
-	});
-
-	const extension = wallets.get().find((wallet) => wallet.id === SUI_WALLET_EXTENSION_ID);
-	if (extension) {
+	if (wallets.get().some((wallet) => wallet.id === SUI_WALLET_EXTENSION_ID)) {
 		return;
 	}
 
@@ -378,13 +378,27 @@ export function registerSlushWallet(
 		origin,
 		metadata: FALLBACK_METADATA,
 	});
-	unregister = wallets.register(slushWalletInstance);
+	const unregisterWallet = wallets.register(slushWalletInstance);
+	let unregistered = false;
+	const unregister = () => {
+		if (unregistered) return;
+		unregistered = true;
+		slushWalletInstance.dispose();
+		stopRegistrationListener();
+		unregisterWallet();
+	};
+	const stopRegistrationListener = wallets.on('register', (wallet) => {
+		if (wallet.id === SUI_WALLET_EXTENSION_ID) unregister();
+	});
+	// Another registration listener may have installed the extension synchronously.
+	if (wallets.get().some((wallet) => wallet.id === SUI_WALLET_EXTENSION_ID)) unregister();
 
 	fetchMetadata(metadataApiUrl)
 		.then((metadata) => {
+			if (unregistered) return;
 			if (!metadata.enabled) {
 				console.log('Slush wallet is not currently enabled.');
-				unregister?.();
+				unregister();
 				return;
 			}
 			slushWalletInstance.updateMetadata(metadata);

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -83,7 +83,6 @@ const walletAccountFeatures = [
 	'sui:signAndExecuteTransaction',
 	'sui:signPersonalMessage',
 	'sui:signTransactionBlock',
-	'sui:signAndExecuteTransactionBlock',
 ] as const;
 
 function getAccountsFromSession(session: string) {
@@ -191,6 +190,16 @@ export class SlushWallet implements Wallet {
 		this.#name = name;
 		this.#walletName = metadata.walletName;
 		this.#icon = metadata.icon as WalletIcon;
+		if (typeof window !== 'undefined') {
+			window.addEventListener('storage', (event) => {
+				if (
+					event.storageArea !== localStorage ||
+					(event.key !== SLUSH_SESSION_KEY && event.key !== null)
+				)
+					return;
+				this.#setAccounts(this.#getPreviouslyAuthorizedAccounts());
+			});
+		}
 	}
 
 	#signTransactionBlock: SuiSignTransactionBlockMethod = async ({

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -92,7 +92,10 @@ function getAccountsFromSession(session: string) {
 		return new ReadonlyWalletAccount({
 			address: account.address,
 			chains: SUI_CHAINS,
-			features: walletAccountFeatures,
+			// Older wallet sessions omit capabilities; an explicit empty list is watch-only.
+			features: account.features
+				? walletAccountFeatures.filter((feature) => account.features?.includes(feature))
+				: walletAccountFeatures,
 			publicKey: fromBase64(account.publicKey),
 		});
 	});

--- a/packages/slush-wallet/src/wallet/registration.test.ts
+++ b/packages/slush-wallet/src/wallet/registration.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const registry = vi.hoisted(() => ({ get: vi.fn(), register: vi.fn(), on: vi.fn() }));
+vi.mock('@mysten/wallet-standard', async (original) => ({
+	...(await original<typeof import('@mysten/wallet-standard')>()),
+	getWallets: () => registry,
+}));
+
+import { registerSlushWallet, SlushWallet } from './index.js';
+
+const metadata = {
+	id: 'slush',
+	walletName: 'Slush',
+	icon: 'data:image/png;base64,',
+	enabled: true,
+};
+const extension = { id: 'com.mystenlabs.suiwallet' };
+let browser: EventTarget;
+let registered: (wallet: typeof extension) => void;
+let finishMetadata: (value: Response) => void;
+const unregisterWallet = vi.fn();
+const stopRegistration = vi.fn();
+const readSession = vi.fn(() => null);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	browser = new EventTarget();
+	vi.stubGlobal('window', browser);
+	vi.stubGlobal('localStorage', { getItem: readSession });
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(
+			() =>
+				new Promise<Response>((resolve) => {
+					finishMetadata = resolve;
+				}),
+		),
+	);
+	registry.get.mockReturnValue([]);
+	registry.register.mockReturnValue(unregisterWallet);
+	registry.on.mockImplementation((_event, handler) => {
+		registered = handler;
+		return stopRegistration;
+	});
+});
+afterEach(() => vi.unstubAllGlobals());
+
+function storageChanged() {
+	browser.dispatchEvent(
+		Object.assign(new Event('storage'), { key: 'slush:session', storageArea: localStorage }),
+	);
+}
+
+it.each(['explicit', 'extension', 'disabled metadata'] as const)(
+	'releases listeners when registration ends via %s',
+	async (reason) => {
+		const result = registerSlushWallet('test')!;
+		const changed = vi.fn();
+		result.wallet.features['standard:events'].on('change', changed);
+		storageChanged();
+		expect(changed).toHaveBeenCalledTimes(1);
+		changed.mockClear();
+		if (reason === 'explicit') result.unregister();
+		else if (reason === 'extension') registered(extension);
+		else {
+			finishMetadata(new Response(JSON.stringify({ ...metadata, enabled: false })));
+			await vi.waitFor(() => expect(unregisterWallet).toHaveBeenCalledTimes(1));
+		}
+		result.unregister();
+		readSession.mockClear();
+		storageChanged();
+		expect(readSession).not.toHaveBeenCalled();
+		expect(changed).not.toHaveBeenCalled();
+		expect(unregisterWallet).toHaveBeenCalledTimes(1);
+		expect(stopRegistration).toHaveBeenCalledTimes(1);
+	},
+);
+
+it('does not subscribe when an extension is already registered', () => {
+	registry.get.mockReturnValue([extension]);
+	expect(registerSlushWallet('test')).toBeUndefined();
+	expect(registry.on).not.toHaveBeenCalled();
+});
+
+it('does not update a retired wallet when metadata arrives late', async () => {
+	const result = registerSlushWallet('test')!;
+	const update = vi.spyOn(result.wallet, 'updateMetadata');
+	const json = vi.fn().mockResolvedValue(metadata);
+	result.unregister();
+	finishMetadata({ ok: true, json } as unknown as Response);
+	await vi.waitFor(() => expect(json).toHaveBeenCalledTimes(1));
+	expect(update).not.toHaveBeenCalled();
+});
+
+it('lets directly constructed wallets release their storage listener idempotently', () => {
+	const wallet = new SlushWallet({ name: 'test', metadata });
+	wallet.dispose();
+	wallet.dispose();
+	readSession.mockClear();
+	storageChanged();
+	expect(readSession).not.toHaveBeenCalled();
+});

--- a/packages/slush-wallet/src/wallet/session-verification.test.ts
+++ b/packages/slush-wallet/src/wallet/session-verification.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, expect, it, vi } from 'vitest';
+import { createJwtSession, WalletPostMessageChannel } from '@mysten/window-wallet-core';
+
+const key = new Uint8Array(32).fill(1);
+afterEach(() => vi.unstubAllGlobals());
+async function request(
+	type: 'sign-transaction' | 'sign-and-execute-transaction' | 'sign-personal-message',
+	features?: string[],
+) {
+	vi.stubGlobal('window', { opener: {} });
+	const session = await createJwtSession(
+		{ accounts: [{ address: '0xx', publicKey: 'AQID', features }] },
+		{ secretKey: key, expirationTime: '1h', issuer: 'wallet', audience: 'https://dapp.example' },
+	);
+	return WalletPostMessageChannel.fromPayload({
+		version: '1',
+		requestId: '00000000-0000-4000-8000-000000000001',
+		appUrl: 'https://dapp.example',
+		appName: 'dapp',
+		payload: {
+			type,
+			transaction: '{}',
+			message: 'AQID',
+			address: '0xx',
+			chain: 'sui:devnet',
+			session,
+		},
+	});
+}
+it.each(['sign-transaction', 'sign-and-execute-transaction', 'sign-personal-message'] as const)(
+	'rejects direct %s requests excluded by the signed session',
+	async (type) => {
+		await expect((await request(type, [])).verifyJwtSession(key)).rejects.toThrow('not authorized');
+	},
+);
+it('allows the explicitly included request and legacy sessions', async () => {
+	await expect(
+		(await request('sign-personal-message', ['sui:signPersonalMessage'])).verifyJwtSession(key),
+	).resolves.toBeTruthy();
+	await expect((await request('sign-transaction')).verifyJwtSession(key)).resolves.toBeTruthy();
+});
+
+it('does not widen a restricted session to a different request type', async () => {
+	await expect(
+		(await request('sign-transaction', ['sui:signPersonalMessage'])).verifyJwtSession(key),
+	).rejects.toThrow('not authorized');
+	await expect(
+		(await request('sign-transaction', ['sui:signTransactionBlock'])).verifyJwtSession(key),
+	).resolves.toBeTruthy();
+});

--- a/packages/slush-wallet/vitest.config.mts
+++ b/packages/slush-wallet/vitest.config.mts
@@ -3,4 +3,11 @@
 
 import { defineConfig } from 'vitest/config';
 
-export default defineConfig({});
+export default defineConfig({
+	resolve: {
+		alias: {
+			'@mysten/window-wallet-core': new URL('../window-wallet-core/src/index.ts', import.meta.url)
+				.pathname,
+		},
+	},
+});

--- a/packages/window-wallet-core/src/jwt-session/index.ts
+++ b/packages/window-wallet-core/src/jwt-session/index.ts
@@ -8,6 +8,7 @@ const AccountSchema = v.object({
 	address: v.string(),
 	publicKey: v.string(),
 	label: v.optional(v.string()),
+	features: v.optional(v.array(v.string())),
 });
 
 const JwtSessionSchema = v.object({

--- a/packages/window-wallet-core/src/web-wallet-channel/wallet-post-message-channel.ts
+++ b/packages/window-wallet-core/src/web-wallet-channel/wallet-post-message-channel.ts
@@ -58,6 +58,18 @@ export class WalletPostMessageChannel {
 			throw new Error('Requested account not found in session');
 		}
 
+		const requiredFeatures = {
+			'sign-transaction': ['sui:signTransaction', 'sui:signTransactionBlock'],
+			'sign-and-execute-transaction': ['sui:signAndExecuteTransaction'],
+			'sign-personal-message': ['sui:signPersonalMessage'],
+		}[this.#request.payload.type];
+		if (
+			addressInSession.features !== undefined &&
+			!requiredFeatures.some((feature) => addressInSession.features!.includes(feature))
+		) {
+			throw new Error('Requested operation not authorized by session');
+		}
+
 		return session;
 	}
 


### PR DESCRIPTION
## Description

Slush web sessions now preserve optional per-account signing features. Explicit empty or restricted lists are honored, while older sessions without the field retain their existing capabilities. Wallet-side request verification enforces signed capabilities, and advertised features are limited to those implemented by the adapter.

Cross-tab session changes refresh wallet accounts. Unregistering removes the storage and wallet-registration listeners, is idempotent, and ignores late metadata results. The same cleanup applies when the extension replaces the adapter or metadata disables it. Directly constructed wallets can release their storage listener with `dispose()`; the changeset marks that API addition as a minor release.

This is the SDK counterpart of MystenLabs/slush#4346. Hosted rollout still requires package releases and dApp adoption; no packages have been published.

## Test plan

- [x] 16 tests across three suites, including signed-JWT capability enforcement and cross-tab account updates.
- [x] Teardown regressions cover explicit unregister, extension replacement, disabled metadata, an existing extension, late metadata, and direct idempotent disposal. They fail against the previous implementation and pass with the fix.
- [x] Slush wallet typecheck and package build.
- [x] Targeted Oxlint and Prettier checks; git diff check.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
