### PR TITLE
docs(deepbook-v3): document both Predict deployments and correct PREDICT.md (DBU-477)

### DIFF
--- a/.changeset/deepbook-v3-predict-docs-both-networks.md
+++ b/.changeset/deepbook-v3-predict-docs-both-networks.md
@@ -1,0 +1,11 @@
+---
+'@mysten/deepbook-v3': patch
+---
+
+Predict docs: document both recorded deployments. `PREDICT.md` and the README now describe the
+`deepbook-predict-mainnet` and `deepbook-predict-testnet` records that `getConfig`, `getDeployment`,
+`getUnits`, `getAccountConfig`, and `getSessionsConfig` resolve, the quote coin per network (Circle
+native USDC on mainnet, a mintable test coin that displays as DUSDC on testnet, read from
+`quoteCoinType`), the `side: 'range'` descriptor arm, which decoders have plural forms, what is
+exported for PTB composition, that `read.markets()` returns live-and-not-yet-settled markets, and
+the `supplyPlp` / `withdrawPlp` floor options as shipped. Documentation only; no runtime change.

--- a/packages/deepbook-v3/PREDICT.md
+++ b/packages/deepbook-v3/PREDICT.md
@@ -1,8 +1,8 @@
 # DeepBook Predict (`@mysten/deepbook-v3/predict`)
 
-TypeScript SDK for DeepBook Predict — binary markets on Sui. Builds ready-to-sign transactions and
-reads on-chain state through your Sui client. The SDK never signs and never touches keys: every
-`tx.*` method returns a `Transaction` for your wallet (dapp-kit) or signer to execute.
+TypeScript SDK for DeepBook Predict — binary and range markets on Sui. Builds ready-to-sign
+transactions and reads on-chain state through your Sui client. The SDK never signs and never touches
+keys: every `tx.*` method returns a `Transaction` for your wallet (dapp-kit) or signer to execute.
 
 ## Install
 
@@ -12,8 +12,10 @@ npm i @mysten/deepbook-v3 @mysten/sui
 
 `@mysten/sui` is a peer dependency.
 
-> Predict is deployed on **testnet** only. `getConfig('mainnet')` throws until a mainnet deployment
-> exists.
+> Two deployments are recorded, **testnet** and **mainnet**: `predict({ network })` and
+> `getConfig(network)` resolve either, and any other network throws. They settle in different coins
+> that share one Move module path — read `quoteCoinType` from the config rather than assuming a
+> symbol or a type. See [Networks & deployments](#networks--deployments).
 
 ## Quickstart
 
@@ -32,16 +34,22 @@ const client = new SuiGrpcClient({
 // One-time: create your Predict account (a shared AccountWrapper).
 const createTx = client.predict.tx.createManager();
 
-// Fund it: pulls USDC from your address (coin objects and/or address balance).
+// Fund it: pulls the deployment's quote coin (`client.predict.cfg.quoteCoinType`) from your
+// address (coin objects and/or address balance).
 const depositTx = client.predict.tx.deposit(myAddress, 250); // $250
 
-// Cash out: lands in your USDC address balance by default (no coin-object churn).
+// Cash out: lands in your quote-coin address balance by default (no coin-object churn).
 // Pass { toCoinObject: true } if you need a discrete Coin<T> instead.
 const withdrawTx = client.predict.tx.withdraw(myAddress, 100); // $100
 
-// Pick a live market. Expiries are absolute timestamps, so never hardcode one.
+// Pick a market. `read.markets()` lists ACTIVE markets — live and not yet settled — which
+// includes a market past its expiry that nobody has settled yet; quoting against one aborts.
+// Expiries are absolute timestamps, so never hardcode one: filter on `expiryMs`, leaving
+// room to quote, sign and land (and clear the pre-expiry no-trade window).
 const markets = await client.predict.read.markets();
-const expiryMs = markets[0].expiryMs;
+// -> [{ id, expiryMs, tickSize, admissionTickSize, mintPaused, referencePrice }, ...]
+const tradeable = markets.filter((m) => Number(m.expiryMs) > Date.now() + 30_000 && !m.mintPaused);
+const expiryMs = tradeable[0].expiryMs;
 
 // Describe the position once and reuse it — quoting and minting take the same descriptor.
 const desc = { underlying: 'BTC', expiryMs, strike: 'reference', side: 'up' } as const;
@@ -73,14 +81,10 @@ receipt.entryProbability; // your fill price (0..1 per $1 payout)
 receipt.premium; // exact cost breakdown
 receipt.fees;
 
-// Read: tradeable markets and pool state.
-const markets = await client.predict.read.markets();
-// -> [{ id, expiryMs, tickSize, admissionTickSize, mintPaused, referencePrice }, ...]
-const market = await client.predict.read.market({
-	underlying: 'BTC',
-	expiryMs: markets[0].expiryMs,
-});
+// Read: one market's live state (+ NAV) and the pool.
+const market = await client.predict.read.market({ underlying: 'BTC', expiryMs });
 console.log(market?.nav, market?.tickSize, market?.mintPaused);
+const pool = await client.predict.read.pool();
 ```
 
 ## ⚠ Slippage defaults are UNCAPPED
@@ -89,30 +93,41 @@ console.log(market?.nav, market?.tickSize, market?.mintPaused);
 **uncapped** — if the price moves between your quote and execution, the position can cost up to your
 full account balance. **Call `read.quoteMint` and pass its `cost` (plus your buffer) as `maxCost`.**
 The same applies to `redeem`: the deployed `redeem_live` DOES take `min_probability` /
-`min_proceeds` floors, but the facade does not surface them yet and always sends `0` (uncapped).
-`read.quoteRedeem` first, close fast — or drive `redeemLive` from the tx layer to set the floors.
+`min_proceeds` floors, but the facade's `tx.redeem` does not surface them and always sends `0`
+(uncapped). `read.quoteRedeem` first, close fast. The floors are reachable through `/sessions`:
+`SessionsContract.redeemLive` takes `minProbability` / `minProceeds` (raw units —
+`probabilityToRaw`, `usdcToRaw`) plus a `pricer` from `loadLivePricer`, and is signed by a session
+key the owner has authorized (see the README's `/sessions` section).
 
 ## Units
 
 Everything human-facing is decimal; everything on-chain is scaled integers. The facade converts
 **inputs** exactly (string/bigint math — no floats on the money path in). Read outputs typed
-`number` are display values: above 2^53 raw they lose low-digit precision — for accounting-exact
-reads use the primitives layer, which returns raw `bigint`s (`accountBalance`, `poolStats`, …).
+`number` are display values: above 2^53 raw they lose low-digit precision — quotes and receipts
+carry a `raw` block of `bigint`s alongside, and `plpBalance` / `pool().plpTotalSupply` are raw
+`bigint` already.
+
+Amounts are in the deployment's quote coin — `getConfig(network).quoteCoinType`: Circle native USDC
+on mainnet, a mintable 6-decimal test coin on testnet. Both are `…::usdc::USDC`, so only the package
+address tells them apart; read the type, never assume a symbol.
 
 | Concept                                     | You pass / receive                                             | On-chain raw                          |
 | ------------------------------------------- | -------------------------------------------------------------- | ------------------------------------- |
-| Amounts (deposit, spend, maxCost, balances) | USD decimal number or string (`12.5`, `"12.5"`)                | ×1e6 (USDC)                           |
+| Amounts (deposit, spend, maxCost, balances) | USD decimal number or string (`12.5`, `"12.5"`)                | ×1e6 (quote coin)                     |
 | `quantity`                                  | **max payout** in USD; positions pay $1 per contract at expiry | ×1e6, in $0.01 lots                   |
 | `strike`                                    | USD (`105_000`)                                                | ×1e9, must land on the admission grid |
 | `maxProbability`                            | 0..1 (`0.35` = 35¢ per $1 contract)                            | ×1e9                                  |
 | PLP shares (`withdrawPlp`, `plpBalance`)    | raw `bigint` shares                                            | 6-decimal coin                        |
 
-`side: "up"` wins if the settlement price is above the strike; `"down"` below.
+`side: "up"` wins if the settlement price is above the strike; `"down"` below; `"range"` (see
+[Range positions](#range-positions)) if it lands inside `(lower, upper]`.
 
 Trading closes slightly before expiry: the protocol enforces a short pre-expiry no-trade window
-(`no_trade_window_ms` on the live `ProtocolConfig`, 2s on the current testnet deployment), so a mint
-or redeem submitted inside it aborts `ETradeWindowClosed` rather than filling. Treat the last
-seconds of a window as untradeable rather than retrying.
+(`no_trade_window_ms` on the live `ProtocolConfig`, 2 s on both recorded deployments), so a mint or
+redeem submitted inside it aborts `ETradeWindowClosed` rather than filling. Treat the last seconds
+of a window as untradeable rather than retrying, and when choosing a market from `read.markets()`
+leave enough of the window to quote, sign and land — a quote taken seconds before expiry executes
+inside the window.
 
 ## Reference-price markets (Polymarket-style windows)
 
@@ -139,11 +154,11 @@ strikes away from the reference remain fully supported.
 ### Numeric strikes must sit on the admission grid
 
 New mint strikes must be a whole multiple of the market's **`admissionTickSize`** — a step
-deliberately coarser than `tickSize`, and it varies by cadence (on the current testnet deployment
-the 1m/5m/1h markets use `$1` and the 1d/1w markets `$100`, against a `$0.01` tick). Always read it
-off the market rather than assuming a value. The market's `referencePrice` is the one finite strike
-the chain admits off-grid. `read.markets()` and `read.market()` both report `admissionTickSize`, so
-a board can be built from it directly:
+deliberately coarser than `tickSize`, and it is configured per cadence (both recorded deployments
+run `$1` against a `$0.01` tick on their enabled cadences, 1m and 5m). Always read it off the market
+rather than assuming a value. The market's `referencePrice` is the one finite strike the chain
+admits off-grid. `read.markets()` and `read.market()` both report `admissionTickSize`, so a board
+can be built from it directly:
 
 ```ts
 const m = (await client.predict.read.markets())[0];
@@ -153,6 +168,23 @@ const strike = Math.round(target / m.admissionTickSize) * m.admissionTickSize;
 An off-grid numeric strike throws `PredictInputError` at build time rather than aborting on chain
 with `EInvalidAdmissionTick`.
 
+### Range positions
+
+`MarketDescriptor` has a third arm: `{ underlying, expiryMs, side: 'range', lower, upper }`. It pays
+$1 per contract when the settlement price lands inside `(lower, upper]` — left-open, right-closed,
+the same convention as the on-chain range key. Both bounds are USD strikes that must be finite, on
+the tick grid, with `lower < upper`, and **each is admission-grid checked** exactly like a binary
+numeric strike. `strike: 'reference'` is binary-only — a range has no single reference strike — and
+`read.price` is binary-only too; price a range locally with `pricer.range(lower, upper)`.
+
+```ts
+const tx = await client.predict.tx.mint(
+	myAddress,
+	{ underlying: 'BTC', expiryMs, side: 'range', lower: 104_000, upper: 106_000 },
+	{ quantity: 25, maxCost: 10 },
+);
+```
+
 ## What's in the box
 
 - **`client.predict.tx`** — `createManager`, `deposit`, `withdraw`, `mint`, `mintAmount`, `redeem`,
@@ -160,23 +192,32 @@ with `EInvalidAdmissionTick`.
   `setBuilderCode`, `unsetBuilderCode`. Market-resolving builders
   (`mint`/`mintAmount`/`redeem`/`claimSettled`) are async: they resolve the market object from
   `{ underlying, expiryMs, strike, side }` via the on-chain registry (cached per client).
-- **`client.predict.read`** — `markets()` (tradeable summaries: id, expiry, tick size, mint-paused,
-  reference price), `market(desc)` (state + live NAV), `price(m)` (anonymous both-sides pricing for
-  any strike, one chain call per strike), `pricer(m)` (a **client-side board pricer** — one chain
-  read of the resolved pricer, then price every strike locally; see below),
+- **`client.predict.read`** — `markets()` (summaries of the pool's **active** markets — live and not
+  yet settled, so a market past expiry that nobody has settled is still listed and quoting against
+  it aborts; filter on `expiryMs` and `mintPaused` before trading: id, expiry, tick size, admission
+  tick size, mint-paused, reference price), `market(desc)` (state + live NAV), `price(m)` (anonymous
+  both-sides pricing for any strike, one chain call per strike), `pricer(m)` (a **client-side board
+  pricer** — one chain read of the resolved pricer, then price every strike locally; see below),
   `quoteMint(owner, m, opts)` / `quoteRedeem(owner, m, opts)` (exact dry-run quotes: real fees from
   the real code path — and they throw the same typed errors the real trade would, so a quote doubles
   as preflight), `balance(owner)`, `plpBalance(owner)`, `pool()`, `positions(owner)` (chain-only
   enumeration of open positions), `hasPosition(owner, marketId, orderId)`. All reads run over the
   client's `simulateTransaction`; no indexer required.
 - **`client.predict.decode`** — pure execution-result decoders (no network): `mint`, `redeem`,
-  `claim`, `createManager`, `deposit`, `withdraw`, `plpRequest`, `plpCancel`, `builderCode`, each
-  with a plural form for batched PTBs. Execute transactions with events included and pass the
-  result; receipts come back in SDK units with raw bigints alongside. Decoding uses the events'
-  canonical BCS bytes, so it is transport-independent.
-- **PTB composition** — integrators who need to compose their own transactions can use the generated
-  Move bindings under `contracts/` directly (transaction thunks + BCS structs), the same layer the
-  facade builds on.
+  `claim`, `createManager`, `deposit`, `withdraw`, `plpRequest`, `plpCancel`, `builderCode`. Each
+  singular form throws unless exactly one matching event is present; `mints`, `redeems` and `claims`
+  are the plural forms for batched PTBs and return every receipt (the other decoders have no
+  plural). Execute transactions with events included and pass the result; receipts come back in SDK
+  units with raw bigints alongside. Decoding uses the events' canonical BCS bytes, so it is
+  transport-independent.
+- **PTB composition** — the generated Move bindings under `src/contracts/` ship in the package but
+  are not an exported subpath (`package.json` exports only `.`, `/account`, `/sessions`,
+  `/predict`), so do not import them. What `/predict` exports for composing your own PTBs:
+  `loadLivePricer(toGeneratedConfig(cfg), { expiryMarketId, ...cfg.underlyings[sym] })` — the
+  `pricer` every live trade call borrows, which the `/sessions` Predict wrappers take as a PTB
+  result; `generateAuth(cfg)` — the hot-potato `Auth` the account calls consume;
+  `toGeneratedConfig(cfg)` — the flat config slice the bindings resolve against; and
+  `deriveAccountWrapperId(cfg, owner)`.
 - **Typed errors** — invalid inputs throw `PredictInputError` before the chain sees them; failed
   simulations throw `PredictMoveError` with the decoded Move abort (`module`, `code`, `abortName`).
 
@@ -203,9 +244,9 @@ on-chain; the client only evaluates the digital. It throws the same typed stale-
 The math is a faithful float port of the deployed `pricing::compute_nd2` (SVI with the skew
 correction, signed params, and the remaining-time roll-down). It agrees with the chain closely —
 within ~1e-4 in probability, up to ~1e-4 near ATM where the chain's fixed-point truncation dominates
-(`tests/testnet/pricing.test.ts` bounds it live). The pure functions are exported under a `pricing`
-namespace for callers who already hold their own oracle inputs (e.g. a live feed) and want zero
-chain calls:
+(`test/predict/testnet/pricing.test.ts` bounds it live). The pure functions are exported under a
+`pricing` namespace for callers who already hold their own oracle inputs (e.g. a live feed) and want
+zero chain calls:
 
 ```ts
 import { pricing } from '@mysten/deepbook-v3/predict';
@@ -223,11 +264,29 @@ const rolled = pricing.rollDown(rawSvi, remainingMs, anchorTteMs); // decay a, b
 
 ## Networks & deployments
 
-**Testnet only today** — `getConfig("mainnet")` throws until a mainnet deployment exists. Object ids
-for the current testnet deployment are baked into the SDK (`TESTNET_CONFIG`); they are updated, with
-a release, whenever a new package version is deployed. Move-call targets flow through one resolution
-seam, which will switch to MVR names (`@deepbook/predict`) once registered — package upgrades then
-stop requiring an SDK release for target resolution.
+Two deployments are recorded. `getDeployment(network)` names each one and the deepbookv3 commit its
+ids were generated at:
+
+| Network   | Deployment                 | Chain id   | Source commit | `quoteCoinType`                                                                                                            |
+| --------- | -------------------------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `mainnet` | `deepbook-predict-mainnet` | `35834a8a` | `14a7e8f8`    | Circle native USDC — `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC`                      |
+| `testnet` | `deepbook-predict-testnet` | `4c78adac` | `a928bd2d`    | mintable test coin, displays as `DUSDC` — `0xc028557a1ed49e42ed091e115aedefd70a442b184c18fbec5c48d5b6c0b8c184::usdc::USDC` |
+
+Object ids for both are baked into the SDK — `MAINNET_CONFIG` / `TESTNET_CONFIG`, with
+`MAINNET_DEPLOYMENT` / `TESTNET_DEPLOYMENT` and `MAINNET_UNITS` / `TESTNET_UNITS` alongside — and
+are regenerated, with a release, whenever a deployment moves. `getConfig`, `getDeployment` and
+`getUnits` resolve both networks and throw on any other; `getAccountConfig` (`/account`) and
+`getSessionsConfig` (`/sessions`) read slices of the same generated record, so the three subpaths
+cannot address different deployments. Units are identical on both (`$0.01` lots, 6 quote decimals,
+1e9 fixed-point scale).
+
+Move-call targets resolve from the config's package ids, so a deployment of your own is addressed by
+passing `config` — `predict({ network, config })` or
+`new PredictClient({ client, network, config })` — and `network` is then not consulted.
+
+An expired market stays in `read.markets()` until someone settles it — the list is the pool's
+live-and-not-yet-settled set, not a tradeable set. On either network, check `expiryMs` against the
+clock (and `mintPaused`) before quoting rather than assuming the list is tradeable.
 
 ## Notes
 
@@ -239,12 +298,20 @@ stop requiring an SDK release for target resolution.
 - PLP supply/withdraw are queued and fill at the next pool flush; cancels take the queue `index` —
   get it from `decode.plpRequest(result).index`.
 - **Both take an optional price floor**, and default to none:
-  `supplyPlp(owner, amount, { minPlpOut })` (raw `bigint` shares) and
-  `withdrawPlp(owner, shares, { minUsdcOut })` (USD decimals). Each floors the flush's MARK for the
-  whole request rather than naming a quantity — a flush quoting less declines instead of filling
-  smaller. What a miss costs is the deployment's `lp_request_limit_flush_attempts`: at the shipped
-  count of one, the first flush below the floor cancels the request and refunds it, so re-queueing
-  is a fresh transaction. Leave the floor off and the request takes whatever mark the flush quotes.
+  `supplyPlp(owner, amountUsdc, { minPlpOut })` (`PlpSupplyOptions`, raw `bigint` shares; omitted →
+  `0n`) and `withdrawPlp(owner, shares, { minUsdcOut })` (`PlpWithdrawOptions`, USD decimals as
+  `number | string`, measured after the protocol's withdraw fee; omitted → no floor). Each floors
+  the flush's MARK for the whole request rather than naming a quantity — a flush quoting less
+  declines instead of filling smaller. What a miss costs is the deployment's
+  `lp_request_limit_flush_attempts`: the deployed value is one on both recorded deployments, so the
+  first flush below the floor cancels the request and refunds it, and re-queueing is a fresh
+  transaction (three is the configurable maximum, not the default). Leave the floor off and the
+  request takes whatever mark the flush quotes.
+- **First-time funding in one PTB**: `deposit(owner, amount, { create: true })` creates the wrapper,
+  deposits through the fresh handle and shares it last. `owner` must be the transaction signer (the
+  wrapper is derived from the sender), and it aborts if the account already exists — the builder
+  does no chain read, so gate on `wrapperIdFor(owner)` + a `getObject`, or fall back to `deposit`
+  without the flag on that abort.
 - `claimSettled` closes the order in full — the deployed entrypoint takes no quantity.
 - **`withdraw` lands in your address balance by default** (`0x2::coin::send_funds`), not a coin
   object — it merges into the versionless accumulator `deposit` already draws from, so the round

--- a/packages/deepbook-v3/README.md
+++ b/packages/deepbook-v3/README.md
@@ -2,12 +2,12 @@
 
 ## Entry points
 
-| Import                         | Contents                                                                                                                                                                                                            |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@mysten/deepbook-v3`          | DeepBook spot and margin — pools, orders, balance managers, flash loans, governance, margin managers/pools, TPSL.                                                                                                   |
-| `@mysten/deepbook-v3/account`  | The shared on-chain **account primitive** (`AccountContract`): the canonical `AccountWrapper`, `Auth`, and custody balances that DeepBook's core account wrapper and DeepBook Predict both build on.                |
-| `@mysten/deepbook-v3/sessions` | **Time-limited trading sessions** over a canonical Account (`SessionsContract`): grant an ephemeral address bounded authority until a fixed expiry. Covers the session lifecycle and the DeepBook Predict wrappers. |
-| `@mysten/deepbook-v3/predict`  | **DeepBook Predict** — binary markets: market discovery, quotes, mint/redeem/claim, PLP, typed receipts and a client-side board pricer. See [PREDICT.md](./PREDICT.md).                                             |
+| Import                         | Contents                                                                                                                                                                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@mysten/deepbook-v3`          | DeepBook spot and margin — pools, orders, balance managers, flash loans, governance, margin managers/pools, TPSL.                                                                                                            |
+| `@mysten/deepbook-v3/account`  | The shared on-chain **account primitive** (`AccountContract`): the canonical `AccountWrapper`, `Auth`, and custody balances that DeepBook's core account wrapper and DeepBook Predict both build on.                         |
+| `@mysten/deepbook-v3/sessions` | **Time-limited trading sessions** over a canonical Account (`SessionsContract`): grant an ephemeral address bounded authority until a fixed expiry. Covers the session lifecycle and the DeepBook Predict wrappers.          |
+| `@mysten/deepbook-v3/predict`  | **DeepBook Predict** — binary and range markets: market discovery, quotes, mint/redeem/claim, PLP, typed receipts and a client-side board pricer, with deployed ids for testnet and mainnet. See [PREDICT.md](./PREDICT.md). |
 
 Subpaths are separate module graphs — importing `@mysten/deepbook-v3/account` does not load any spot
 or margin code.
@@ -15,10 +15,13 @@ or margin code.
 Each subpath also exports the **deployed ids** for its own surface, so a caller never transcribes
 them: `getAccountConfig(network)` on `/account`, `getSessionsConfig(network)` on `/sessions`,
 `getConfig(network)` on `/predict`. All three read one generated record (`src/deployments/`), so a
-redeploy updates every subpath at once and they cannot end up addressing different deployments.
-`getDeployment(network)` names the deployment and the deepbookv3 commit those ids came from.
-Predict, sessions and the account primitive are testnet-only today; an unrecorded network throws
-rather than returning placeholder ids.
+redeploy updates every subpath at once and they cannot end up addressing different deployments. Two
+networks are recorded, `testnet` (`deepbook-predict-testnet`) and `mainnet`
+(`deepbook-predict-mainnet`); `getDeployment(network)` names the deployment and the deepbookv3
+commit those ids came from, and an unrecorded network throws rather than returning placeholder ids.
+The two deployments settle in different coins that share one Move module path — Circle native USDC
+on mainnet, a mintable test coin (displayed as `DUSDC`) on testnet — so take the coin type from
+`getConfig(network).quoteCoinType` on `/predict` rather than assuming either.
 
 ### `@mysten/deepbook-v3/account`
 
@@ -30,7 +33,7 @@ is computable off-chain with no chain read. `AccountContract` takes only the dep
 import { Transaction } from '@mysten/sui/transactions';
 import { AccountContract, getAccountConfig } from '@mysten/deepbook-v3/account';
 
-// Deployed ids ship with the package — no transcription.
+// Deployed ids ship with the package — no transcription. 'testnet' | 'mainnet'.
 const account = new AccountContract(getAccountConfig('testnet'));
 
 // …or drive a deployment of your own:
@@ -38,8 +41,10 @@ const custom = new AccountContract({ accountPackageId: '0x…', accountRegistry:
 
 const wrapperId = account.deriveAccountWrapperId(owner);
 
+// `quoteCoinType` is the deployment's settlement coin — `getConfig(network).quoteCoinType`
+// from `/predict` — not a symbol you assume.
 const tx = new Transaction();
-tx.add(account.depositFunds({ wrapperId, coin, coinType: USDC }));
+tx.add(account.depositFunds({ wrapperId, coin, coinType: quoteCoinType }));
 ```
 
 > `Account` exported from the package root is `@deepbook/core::account::Account` (the per-pool
@@ -61,7 +66,7 @@ withdrawal or arbitrary-mutation entrypoint.
 ```ts
 import { SessionsContract, getSessionsConfig } from '@mysten/deepbook-v3/sessions';
 
-// Deployed ids ship with the package — no transcription.
+// Deployed ids ship with the package — no transcription. 'testnet' | 'mainnet'.
 const sessions = new SessionsContract(getSessionsConfig('testnet'));
 
 const wrapperId = sessions.deriveAccountWrapperId(owner);


### PR DESCRIPTION
## Description

`PREDICT.md` and the `deepbook-v3` README still said Predict was Testnet-only and that `getConfig('mainnet')` throws. Since 2.3.0 the package carries both the `deepbook-predict-mainnet` and `deepbook-predict-testnet` records, and every config accessor resolves either network.

This updates the two docs to what the source does, with each change verified against `src/`:

- Both deployments documented: names, chain ids, source commits, `MAINNET_*` / `TESTNET_*` exports, and the rule that `getDeployment(network)` names the record behind the ids.
- The quote coin per network: Circle native USDC on Mainnet, a mintable test coin that displays as DUSDC on Testnet, both at `…::usdc::USDC`. Docs now say to read `quoteCoinType` from the config rather than assume a symbol or type.
- The `side: 'range'` arm of `MarketDescriptor`, previously undocumented, with the `(lower, upper]` payout convention and grid checks on both bounds.
- Decoders: only `mints`, `redeems`, and `claims` have plural forms.
- PTB composition: `contracts/` is not an exported subpath; what is exported is `loadLivePricer`, `generateAuth`, `deriveAccountWrapperId`, and `toGeneratedConfig`. Close-side floors are reachable through the `/sessions` `redeemLive` wrapper.
- `read.markets()` returns live-and-not-yet-settled markets, so a market past expiry that nobody settled is still listed; the quickstart now filters on time to expiry.
- `supplyPlp` / `withdrawPlp` floor options stated exactly as `PlpSupplyOptions` / `PlpWithdrawOptions`, with the deployed attempt count of one.
- Smaller corrections: the admission-grid cadence claim (only 1m and 5m are enabled on both deployments), a stale test path, an unexported "primitives layer" reference, a duplicated `const markets` in the quickstart, and the undocumented `deposit(owner, amount, { create: true })`.

Documentation only; no runtime change. A patch changeset is included because the README ships in the npm tarball.

Related: DBU-477; the docs.sui.io counterpart is MystenLabs/sui#27880.

## Test plan

- Every method name, option key, export, and id cross-checked against `src/predict/client.ts`, `src/predict/index.ts`, `src/sessions.ts`, `src/account.ts`, and `src/deployments/*.ts` on `main` at `e490ec84`, which is byte-identical to npm 2.3.0.
- Ids checked field for field against `packages/predict/deployment/deployment.mainnet.json` and `deployment.testnet.json` in deepbookv3.
- `prettier -c` passes on both files with the repo config.
- No `src/` or codegen changes; `git diff --stat` shows the two docs and the changeset only.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgx6dMdrf2jgbgmvapbVbT
