### PR TITLE
feat(deepbook-v3): export Predict's move-call bindings from /predict (DBU-808)

### DIFF
--- a/.changeset/deepbook-v3-predict-move-calls.md
+++ b/.changeset/deepbook-v3-predict-move-calls.md
@@ -1,0 +1,15 @@
+---
+'@mysten/deepbook-v3': minor
+---
+
+Predict: export the generated move-call bindings from `@mysten/deepbook-v3/predict`, the way
+`/account` already exports `accountMoveCalls`. Each `client.predict.tx.*` builder returns a finished
+`Transaction`, so a Predict call could not join a PTB the caller was building — creating an account,
+funding it and queueing a PLP supply in one transaction meant hand-writing `plp::request_supply` as a
+raw `moveCall`. Every Predict module with a callable function is now reachable as a namespace of
+transaction thunks (`plpMoveCalls`, `expiryMarketMoveCalls`, `predictAccountMoveCalls`,
+`protocolConfigMoveCalls`, `registryMoveCalls`, `builderCodeMoveCalls`, `marketManagerMoveCalls`,
+`pricingMoveCalls`, `rangeCodecMoveCalls`, and the cap modules), alongside the event layouts
+(`vaultEvents`, `orderEvents`, `configEvents`, `builderCodeEvents`). Pass
+`config: toGeneratedConfig(cfg)` and the shared objects fill themselves in; owner-authorized calls
+take an `Auth` from `generateAuth(cfg)`. Additive only: no existing export changes.

--- a/packages/deepbook-v3/PREDICT.md
+++ b/packages/deepbook-v3/PREDICT.md
@@ -210,14 +210,41 @@ const tx = await client.predict.tx.mint(
   plural). Execute transactions with events included and pass the result; receipts come back in SDK
   units with raw bigints alongside. Decoding uses the events' canonical BCS bytes, so it is
   transport-independent.
-- **PTB composition** — the generated Move bindings under `src/contracts/` ship in the package but
-  are not an exported subpath (`package.json` exports only `.`, `/account`, `/sessions`,
-  `/predict`), so do not import them. What `/predict` exports for composing your own PTBs:
+- **PTB composition** — each `client.predict.tx.*` builder returns a finished `Transaction`, so to
+  put a Predict call into a PTB you are building, use the generated move-call bindings `/predict`
+  exports: one namespace of transaction thunks per Predict module (`plpMoveCalls`,
+  `expiryMarketMoveCalls`, `predictAccountMoveCalls`, `protocolConfigMoveCalls`,
+  `registryMoveCalls`, `builderCodeMoveCalls`, `marketManagerMoveCalls`, `pricingMoveCalls`,
+  `rangeCodecMoveCalls`, `adminMoveCalls` and the cap modules) plus the event layouts
+  (`vaultEvents`, `orderEvents`, `configEvents`, `builderCodeEvents`). Pass
+  `config: toGeneratedConfig(cfg)` — the flat config slice the bindings resolve the shared objects
+  against — and give owner-authorized calls `auth: tx.add(generateAuth(cfg))`, the hot-potato `Auth`
+  the account calls consume. The account itself (create, deposit, share) is
+  `@mysten/deepbook-v3/account`'s `accountRegistryMoveCalls` / `accountMoveCalls`. Also exported:
   `loadLivePricer(toGeneratedConfig(cfg), { expiryMarketId, ...cfg.underlyings[sym] })` — the
   `pricer` every live trade call borrows, which the `/sessions` Predict wrappers take as a PTB
-  result; `generateAuth(cfg)` — the hot-potato `Auth` the account calls consume;
-  `toGeneratedConfig(cfg)` — the flat config slice the bindings resolve against; and
-  `deriveAccountWrapperId(cfg, owner)`.
+  result — and `deriveAccountWrapperId(cfg, owner)`.
+
+  ```ts
+  // Create an account, fund it, and queue a PLP supply — one PTB, one signature.
+  const config = toGeneratedConfig(cfg);
+  const wrapper = tx.add(accountRegistryMoveCalls._new({ config }));
+  tx.add(
+  	accountMoveCalls.depositFunds({
+  		config,
+  		arguments: { wrapper, auth: tx.add(generateAuth(cfg)), coin },
+  		typeArguments: [cfg.quoteCoinType],
+  	}),
+  );
+  tx.add(
+  	plpMoveCalls.requestSupply({
+  		config,
+  		arguments: { wrapper, auth: tx.add(generateAuth(cfg)), amount, minPlpOut },
+  	}),
+  );
+  tx.add(accountMoveCalls.share({ config, arguments: { self: wrapper } }));
+  ```
+
 - **Typed errors** — invalid inputs throw `PredictInputError` before the chain sees them; failed
   simulations throw `PredictMoveError` with the decoded Move abort (`module`, `code`, `abortName`).
 

--- a/packages/deepbook-v3/src/predict/client.ts
+++ b/packages/deepbook-v3/src/predict/client.ts
@@ -290,8 +290,9 @@ export function predict<Name extends string = 'predict'>({
  * The one object an app constructs. Wraps the config, a client for reads, and
  * a derived-account model so callers pass owner addresses, decimal amounts, and
  * human market coordinates — the facade converts to raw units, resolves markets
- * (cached), and delegates to the internal tx primitives / reads. Callers who need
- * to compose their own PTBs can use the generated bindings under `contracts/`.
+ * (cached), and delegates to the internal tx primitives / reads. Each `tx.*` builder
+ * returns a finished `Transaction`; callers composing their own PTBs use the generated
+ * move-call bindings this subpath exports (`plpMoveCalls`, `expiryMarketMoveCalls`, …).
  */
 export class PredictClient {
 	readonly cfg: PredictConfig;

--- a/packages/deepbook-v3/src/predict/index.ts
+++ b/packages/deepbook-v3/src/predict/index.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Public API for `@mysten/deepbook-v3/predict`. The curated surface is the `PredictClient`
 // facade plus the value types, unit conversions, tick helpers, typed errors, and typed
-// execution-result decoders — and the few primitives below that compose predict
-// accounts into PTBs on FOREIGN packages, which no facade shape can cover.
+// execution-result decoders — and, for composing your own PTBs, the few primitives below
+// that compose predict accounts with FOREIGN packages plus the generated move-call bindings.
 
 // === Facade === (register as a client extension: `client.$extend(predict({ network }))`)
 export { POSITION_LOT_SIZE, PredictClient, predict } from './client.js';
@@ -29,6 +29,30 @@ export type {
 // Predict-config-bound conveniences over `@mysten/deepbook-v3/account`, which owns the
 // shared account primitive — reach for its `AccountContract` to drive it directly.
 export { deriveAccountWrapperId, generateAuth } from './tx/common.js';
+
+// === Move-call bindings === the generated transaction thunks for every Predict module with a
+// callable function, for putting Predict calls into a PTB you are building — each facade `tx.*`
+// builder returns a finished `Transaction` instead. Mirrors `/account`'s `accountMoveCalls`. Pass
+// `config: toGeneratedConfig(cfg)` and the shared objects fill themselves in; owner-authorized
+// calls take an `Auth` from `generateAuth(cfg)`. Each namespace also carries its module's BCS
+// structs; the `*Events` namespaces are event layouts only.
+export * as adminMoveCalls from '../contracts/deepbook_predict/admin.js';
+export * as builderCodeMoveCalls from '../contracts/deepbook_predict/builder_code.js';
+export * as expiryMarketMoveCalls from '../contracts/deepbook_predict/expiry_market.js';
+export * as marketLifecycleCapMoveCalls from '../contracts/deepbook_predict/market_lifecycle_cap.js';
+export * as marketManagerMoveCalls from '../contracts/deepbook_predict/market_manager.js';
+export * as pauseCapMoveCalls from '../contracts/deepbook_predict/pause_cap.js';
+export * as plpMoveCalls from '../contracts/deepbook_predict/plp.js';
+export * as poolValuationCapMoveCalls from '../contracts/deepbook_predict/pool_valuation_cap.js';
+export * as predictAccountMoveCalls from '../contracts/deepbook_predict/predict_account.js';
+export * as pricingMoveCalls from '../contracts/deepbook_predict/pricing.js';
+export * as protocolConfigMoveCalls from '../contracts/deepbook_predict/protocol_config.js';
+export * as rangeCodecMoveCalls from '../contracts/deepbook_predict/range_codec.js';
+export * as registryMoveCalls from '../contracts/deepbook_predict/registry.js';
+export * as builderCodeEvents from '../contracts/deepbook_predict/builder_code_events.js';
+export * as configEvents from '../contracts/deepbook_predict/config_events.js';
+export * as orderEvents from '../contracts/deepbook_predict/order_events.js';
+export * as vaultEvents from '../contracts/deepbook_predict/vault_events.js';
 
 // === Config ===
 export {

--- a/packages/deepbook-v3/test/predict/move-calls.test.ts
+++ b/packages/deepbook-v3/test/predict/move-calls.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { readdirSync } from 'node:fs';
+import { bcs } from '@mysten/sui/bcs';
+import { Transaction } from '@mysten/sui/transactions';
+import { normalizeSuiObjectId } from '@mysten/sui/utils';
+import { expect, test } from 'vitest';
+import { accountMoveCalls, accountRegistryMoveCalls } from '../../src/account.js';
+import * as predictExports from '../../src/predict/index.js';
+import {
+	PredictClient,
+	TESTNET_CONFIG as cfg,
+	generateAuth,
+	plpMoveCalls,
+	toGeneratedConfig,
+} from '../../src/predict/index.js';
+
+const OWNER = '0x' + 'ab'.repeat(32);
+const COIN = '0x' + 'cd'.repeat(32);
+const config = toGeneratedConfig(cfg);
+
+// tx builders never touch the client — these tests only inspect the emitted PTB.
+const pc = new PredictClient({ network: 'testnet', client: {} as never });
+
+const b64 = (v: bigint) => Buffer.from(bcs.u64().serialize(v).toBytes()).toString('base64');
+
+function moveCalls(tx: Transaction) {
+	return tx.getData().commands.flatMap((c) => ('MoveCall' in c && c.MoveCall ? [c.MoveCall] : []));
+}
+
+function inputOf(tx: Transaction, arg: unknown) {
+	const a = arg as { $kind: string; Input?: number };
+	return a.$kind === 'Input' && a.Input !== undefined ? tx.getData().inputs[a.Input] : undefined;
+}
+
+function objectIdOf(tx: Transaction, arg: unknown): string | undefined {
+	const input = inputOf(tx, arg);
+	if (input && 'UnresolvedObject' in input && input.UnresolvedObject) {
+		return input.UnresolvedObject.objectId;
+	}
+	return undefined;
+}
+
+// The motivating case: create an account, fund it, queue a PLP supply and share the wrapper in ONE
+// PTB, using nothing but the published `/account` and `/predict` exports.
+test('a PLP supply composes with account creation in one PTB from public exports', () => {
+	const tx = new Transaction();
+	const wrapper = tx.add(accountRegistryMoveCalls._new({ config }));
+	tx.add(
+		accountMoveCalls.depositFunds({
+			config,
+			arguments: { wrapper, auth: tx.add(generateAuth(cfg)), coin: tx.object(COIN) },
+			typeArguments: [cfg.quoteCoinType],
+		}),
+	);
+	tx.add(
+		plpMoveCalls.requestSupply({
+			config,
+			arguments: {
+				wrapper,
+				auth: tx.add(generateAuth(cfg)),
+				amount: 15_000_000n,
+				minPlpOut: 14_850_000n,
+			},
+		}),
+	);
+	tx.add(accountMoveCalls.share({ config, arguments: { self: wrapper } }));
+
+	const calls = moveCalls(tx);
+	expect(calls.map((c) => `${c.module}::${c.function}`)).toEqual([
+		'account_registry::new',
+		'account::generate_auth',
+		'account::deposit_funds',
+		'account::generate_auth',
+		'plp::request_supply',
+		'account::share',
+	]);
+
+	const supply = calls[4];
+	expect(normalizeSuiObjectId(supply.package)).toBe(normalizeSuiObjectId(cfg.packages.predict));
+	// The shared objects come from `config`, not from the caller.
+	expect(objectIdOf(tx, supply.arguments[0])).toBe(normalizeSuiObjectId(cfg.objects.poolVault));
+	expect(objectIdOf(tx, supply.arguments[3])).toBe(
+		normalizeSuiObjectId(cfg.objects.protocolConfig),
+	);
+	// The wrapper is the fresh handle from `account_registry::new`, used by value before `share`.
+	expect(supply.arguments[1]).toEqual({ $kind: 'Result', Result: 0 });
+	expect(inputOf(tx, supply.arguments[4])?.Pure?.bytes).toBe(b64(15_000_000n));
+	expect(inputOf(tx, supply.arguments[5])?.Pure?.bytes).toBe(b64(14_850_000n));
+});
+
+// The exported thunk is the same binding the facade drives: composed by hand it emits exactly the
+// PTB `tx.supplyPlp` does.
+test('plpMoveCalls.requestSupply builds the same PTB as the facade supplyPlp', () => {
+	const facade = pc.tx.supplyPlp(OWNER, 15, { minPlpOut: 14_850_000n });
+
+	const composed = new Transaction();
+	composed.add(
+		plpMoveCalls.requestSupply({
+			config,
+			arguments: {
+				wrapper: pc.wrapperIdFor(OWNER),
+				auth: composed.add(generateAuth(cfg)),
+				amount: 15_000_000n,
+				minPlpOut: 14_850_000n,
+			},
+		}),
+	);
+
+	expect(composed.getData()).toEqual(facade.getData());
+});
+
+// Every generated Predict module with a callable function or an event layout is exported in full,
+// read from the generated directory itself — a module a future codegen run adds fails here until it
+// is put on the surface.
+test('every generated Predict module with a function or event layout is exported', async () => {
+	const exported = new Set(
+		Object.values(predictExports).flatMap((ns) =>
+			ns && typeof ns === 'object' ? Object.values(ns) : [],
+		),
+	);
+	const files = readdirSync(new URL('../../src/contracts/deepbook_predict/', import.meta.url));
+	const missing: string[] = [];
+	for (const file of files.filter((f) => f.endsWith('.ts'))) {
+		const members = Object.values(await import(`../../src/contracts/deepbook_predict/${file}`));
+		const surfaced = file.endsWith('_events.ts') || members.some((m) => typeof m === 'function');
+		if (surfaced && !members.every((m) => exported.has(m))) missing.push(file);
+	}
+
+	expect(missing).toEqual([]);
+});


### PR DESCRIPTION
## Description

`@mysten/deepbook-v3/predict` had no way to put a Predict call into a PTB the caller is building. Each `client.predict.tx.*` builder returns a finished `Transaction`, and the generated move-call bindings under `src/contracts/deepbook_predict/` ship in the package but were exported from no subpath — `PREDICT.md` told readers not to import them, while `PredictClient`'s doc comment pointed at them. `/account` already exports its bindings (`accountMoveCalls`, `accountRegistryMoveCalls`), so an account could be composed, but not a Predict call on it.

The concrete case: creating an account, funding it and queueing a PLP supply in one transaction (one signature from a multisig) had to hand-write `plp::request_supply` as a raw `moveCall`.

This exports the bindings the way `/account` does:

- A move-call namespace for every generated Predict module with a callable function — `plpMoveCalls`, `expiryMarketMoveCalls`, `predictAccountMoveCalls`, `protocolConfigMoveCalls`, `registryMoveCalls`, `builderCodeMoveCalls`, `marketManagerMoveCalls`, `pricingMoveCalls`, `rangeCodecMoveCalls`, `adminMoveCalls`, `pauseCapMoveCalls`, `marketLifecycleCapMoveCalls`, `poolValuationCapMoveCalls`.
- The event layouts — `vaultEvents`, `orderEvents`, `configEvents`, `builderCodeEvents`.
- `PREDICT.md`'s composition section now documents them, with a create → deposit → `request_supply` → share example; `PredictClient`'s doc comment points at the exports.

Callers pass `config: toGeneratedConfig(cfg)` (already exported) and the shared objects fill themselves in; owner-authorized calls take `auth: tx.add(generateAuth(cfg))` (already exported).

Additive only: no existing export changes, so `client.predict.tx.*` callers are unaffected. The changeset is `minor` for the new API surface. Making the facade's `tx.*` builders return composable thunks is the fuller fix, but it changes every existing call site, so it is left for a separate change.

DBU-808

## Test plan

- `pnpm build` in `packages/deepbook-v3` (`tsc --noEmit` + `tsdown`) — exit 0; the new names are present in `dist/predict/index.d.mts`.
- `pnpm test` — 25 files, 522 tests pass. New `test/predict/move-calls.test.ts`:
  - composes account creation → deposit → `plp::request_supply` → share in one PTB from the public `/account` and `/predict` exports only, and asserts the command order, that the pool vault and protocol config come from `config`, that the wrapper is the fresh handle used by value, and the amount / floor bytes;
  - asserts `plpMoveCalls.requestSupply` composed by hand emits exactly the PTB `client.predict.tx.supplyPlp` does (`getData()` equality);
  - reads `src/contracts/deepbook_predict/` and fails for any generated module with a callable function or an event layout that is not fully exported, so a module a future codegen run adds cannot be missed.
- Negative control: changing the facade call's amount failed the parity test; deleting the `registryMoveCalls` and `vaultEvents` exports failed the surface test with exactly `['registry.ts', 'vault_events.ts']`; restoring them passed.
- `move-calls.test.ts` typechecked on its own (`tsc --noEmit` over `src` + the test file), since the package's `tsconfig` covers `src` only.
- `pnpm lint` (oxlint + prettier) — exit 0.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
