### PR TITLE
Fix Slush Wallet build blocking four package releases

### DIFF
--- a/.changeset/tidy-wallet-build.md
+++ b/.changeset/tidy-wallet-build.md
@@ -1,0 +1,5 @@
+---
+'@mysten/slush-wallet': patch
+---
+
+Exclude unit tests from the production TypeScript build so releases do not require Vitest.

--- a/packages/slush-wallet/tsconfig.json
+++ b/packages/slush-wallet/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.shared.json",
 	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"],
 	"compilerOptions": {
 		"noEmit": true
 	}


### PR DESCRIPTION
## Description

The production-only release install omits Vitest, but Slush Wallet's TypeScript build includes its colocated unit tests. This causes TS2307 errors and blocks releases of `@mysten/slush-wallet`, `@mysten/dapp-kit-core`, `@mysten/dapp-kit-react`, and `@mysten/create-dapp`.

Exclude `src/**/*.test.ts` from Slush Wallet's production TypeScript config. Vitest continues to discover and run those tests. Includes a patch changeset.

Fixes the shared build failure in https://github.com/MystenLabs/ts-sdks/actions/runs/34534457197 and the other three failed releases at the same commit.

## Test plan

- Reproduced the exact CI errors at the release commit using a production-only install and the workflow's pinned build tools.
- Confirmed the minimal `pnpm --filter @mysten/slush-wallet exec tsc --noEmit` reproduction fails before the fix and passes afterward.
- Successfully built all four affected packages and their dependencies with the production-only install and pinned release tools.
- Slush Wallet unit tests: 3 files, 16 tests passed.
- Prettier and `git diff --check` passed.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
