### PR TITLE
fix(slush-wallet): preserve per-account session chains

### DIFF
--- a/.changeset/slush-account-chains.md
+++ b/.changeset/slush-account-chains.md
@@ -1,0 +1,6 @@
+---
+'@mysten/window-wallet-core': minor
+'@mysten/slush-wallet': minor
+---
+
+Preserve optional per-account chains in hosted wallet sessions and advertise only supported chains included in that list. Reject signing requests for chains excluded by the signed session. Older sessions that omit chains retain their existing behavior.

--- a/packages/slush-wallet/src/wallet/index.test.ts
+++ b/packages/slush-wallet/src/wallet/index.test.ts
@@ -3,7 +3,7 @@
 import { afterEach, expect, it, vi } from 'vitest';
 import { SlushWallet } from './index.js';
 
-function session(features?: string[]) {
+function session(features?: string[], chains?: string[]) {
 	const payload = {
 		exp: 9999999999,
 		iat: 1,
@@ -11,14 +11,19 @@ function session(features?: string[]) {
 		aud: 'dapp',
 		payload: {
 			accounts: [
-				{ address: '0xx', publicKey: 'AQID', ...(features === undefined ? {} : { features }) },
+				{
+					address: '0xx',
+					publicKey: 'AQID',
+					...(features === undefined ? {} : { features }),
+					...(chains === undefined ? {} : { chains }),
+				},
 			],
 		},
 	};
 	return `e30.${btoa(JSON.stringify(payload)).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '')}.signature`;
 }
-function wallet(features?: string[]) {
-	vi.stubGlobal('localStorage', { getItem: () => session(features) });
+function wallet(features?: string[], chains?: string[]) {
+	vi.stubGlobal('localStorage', { getItem: () => session(features, chains) });
 	return new SlushWallet({
 		name: 'test',
 		metadata: { id: 'slush', walletName: 'Slush', icon: 'data:image/png;base64,', enabled: true },
@@ -66,4 +71,22 @@ it('refreshes accounts when another tab replaces or clears the session', () => {
 		Object.assign(new Event('storage'), { key: null, storageArea: localStorage }),
 	);
 	expect(instance.accounts).toEqual([]);
+});
+
+it('preserves the checked chain subset in hosted accounts', () => {
+	expect(wallet(['sui:signTransaction'], ['sui:devnet']).accounts[0].chains).toEqual([
+		'sui:devnet',
+	]);
+});
+it('does not widen an explicit empty chain list or advertise unknown chains', () => {
+	expect(wallet([], []).accounts[0].chains).toEqual([]);
+	expect(wallet([], ['other:chain', 'sui:testnet']).accounts[0].chains).toEqual(['sui:testnet']);
+});
+it('preserves legacy sessions with no chain restriction', () => {
+	expect(wallet().accounts[0].chains).toEqual([
+		'sui:devnet',
+		'sui:testnet',
+		'sui:localnet',
+		'sui:mainnet',
+	]);
 });

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -281,13 +281,19 @@ export class SlushWallet implements Wallet {
 	};
 
 	#signPersonalMessage: SuiSignPersonalMessageMethod = async ({ message, account, chain }) => {
+		const selectedChain =
+			chain ??
+			(account.chains.includes(SUI_MAINNET_CHAIN)
+				? SUI_MAINNET_CHAIN
+				: SUI_CHAINS.find((supported) => account.chains.includes(supported)));
+		if (!selectedChain) throw new Error('Account has no supported chain');
 		const popup = this.#getNewPopupChannel();
 
 		const response = await popup.send({
 			type: 'sign-personal-message',
 			message: toBase64(message),
 			address: account.address,
-			chain: chain ?? SUI_MAINNET_CHAIN,
+			chain: selectedChain,
 			session: getSessionFromStorage(),
 		});
 

--- a/packages/slush-wallet/src/wallet/index.ts
+++ b/packages/slush-wallet/src/wallet/index.ts
@@ -90,7 +90,9 @@ function getAccountsFromSession(session: string) {
 	return payload.accounts.map((account) => {
 		return new ReadonlyWalletAccount({
 			address: account.address,
-			chains: SUI_CHAINS,
+			chains: account.chains
+				? SUI_CHAINS.filter((chain) => account.chains?.includes(chain))
+				: SUI_CHAINS,
 			// Older wallet sessions omit capabilities; an explicit empty list is watch-only.
 			features: account.features
 				? walletAccountFeatures.filter((feature) => account.features?.includes(feature))

--- a/packages/slush-wallet/src/wallet/personal-message-chain.test.ts
+++ b/packages/slush-wallet/src/wallet/personal-message-chain.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+import { afterEach, expect, it, vi } from 'vitest';
+import { createJwtSession, WalletPostMessageChannel } from '@mysten/window-wallet-core';
+import { SlushWallet } from './index.js';
+
+const { send } = vi.hoisted(() => ({ send: vi.fn() }));
+vi.mock('@mysten/window-wallet-core', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@mysten/window-wallet-core')>()),
+	DappPostMessageChannel: class {
+		send = send;
+	},
+}));
+const key = new Uint8Array(32).fill(1);
+afterEach(() => {
+	vi.unstubAllGlobals();
+	send.mockReset();
+});
+async function wallet(chains?: string[]) {
+	const session = await createJwtSession(
+		{
+			accounts: [
+				{ address: '0xx', publicKey: 'AQID', features: ['sui:signPersonalMessage'], chains },
+			],
+		},
+		{ secretKey: key, expirationTime: '1h', issuer: 'wallet', audience: 'https://dapp.example' },
+	);
+	vi.stubGlobal('localStorage', { getItem: () => session });
+	vi.stubGlobal('window', { opener: {}, addEventListener: vi.fn() });
+	send.mockImplementation(async (payload) => {
+		const channel = WalletPostMessageChannel.fromPayload({
+			version: '1',
+			requestId: '00000000-0000-4000-8000-000000000001',
+			appUrl: 'https://dapp.example',
+			appName: 'dapp',
+			payload,
+		});
+		await channel.verifyJwtSession(key);
+		return { bytes: 'AQID', signature: 'signature' };
+	});
+	return new SlushWallet({
+		name: 'test',
+		metadata: { id: 'slush', walletName: 'Slush', icon: 'data:image/png;base64,', enabled: true },
+	});
+}
+it('signs a chain-less personal message on the restricted account chain', async () => {
+	const instance = await wallet(['sui:testnet']);
+	await expect(
+		instance.features['sui:signPersonalMessage'].signPersonalMessage({
+			account: instance.accounts[0],
+			message: new Uint8Array([1]),
+		}),
+	).resolves.toEqual({ bytes: 'AQID', signature: 'signature' });
+	expect(send).toHaveBeenCalledWith(expect.objectContaining({ chain: 'sui:testnet' }));
+});
+it('keeps an explicit unsupported chain and rejects it through session verification', async () => {
+	const instance = await wallet(['sui:testnet']);
+	await expect(
+		instance.features['sui:signPersonalMessage'].signPersonalMessage({
+			account: instance.accounts[0],
+			message: new Uint8Array([1]),
+			chain: 'sui:mainnet',
+		}),
+	).rejects.toThrow('chain');
+	expect(send).toHaveBeenCalledWith(expect.objectContaining({ chain: 'sui:mainnet' }));
+});
+it('preserves the mainnet default for legacy accounts', async () => {
+	const instance = await wallet();
+	await instance.features['sui:signPersonalMessage'].signPersonalMessage({
+		account: instance.accounts[0],
+		message: new Uint8Array([1]),
+	});
+	expect(send).toHaveBeenCalledWith(expect.objectContaining({ chain: 'sui:mainnet' }));
+});
+it('refuses an account with no supported chains before opening a request', async () => {
+	const instance = await wallet([]);
+	await expect(
+		instance.features['sui:signPersonalMessage'].signPersonalMessage({
+			account: instance.accounts[0],
+			message: new Uint8Array([1]),
+		}),
+	).rejects.toThrow('chain');
+	expect(send).not.toHaveBeenCalled();
+});

--- a/packages/slush-wallet/src/wallet/session-verification.test.ts
+++ b/packages/slush-wallet/src/wallet/session-verification.test.ts
@@ -8,10 +8,11 @@ afterEach(() => vi.unstubAllGlobals());
 async function request(
 	type: 'sign-transaction' | 'sign-and-execute-transaction' | 'sign-personal-message',
 	features?: string[],
+	chains?: string[],
 ) {
 	vi.stubGlobal('window', { opener: {} });
 	const session = await createJwtSession(
-		{ accounts: [{ address: '0xx', publicKey: 'AQID', features }] },
+		{ accounts: [{ address: '0xx', publicKey: 'AQID', features, chains }] },
 		{ secretKey: key, expirationTime: '1h', issuer: 'wallet', audience: 'https://dapp.example' },
 	);
 	return WalletPostMessageChannel.fromPayload({
@@ -50,3 +51,18 @@ it('does not widen a restricted session to a different request type', async () =
 		(await request('sign-transaction', ['sui:signTransactionBlock'])).verifyJwtSession(key),
 	).resolves.toBeTruthy();
 });
+
+it.each(['sign-transaction', 'sign-and-execute-transaction', 'sign-personal-message'] as const)(
+	'rejects %s on chains excluded by the signed session',
+	async (type) => {
+		await expect(
+			(await request(type, undefined, ['sui:testnet'])).verifyJwtSession(key),
+		).rejects.toThrow('chain');
+		await expect((await request(type, undefined, [])).verifyJwtSession(key)).rejects.toThrow(
+			'chain',
+		);
+		await expect(
+			(await request(type, undefined, ['sui:devnet'])).verifyJwtSession(key),
+		).resolves.toBeTruthy();
+	},
+);

--- a/packages/window-wallet-core/src/jwt-session/index.ts
+++ b/packages/window-wallet-core/src/jwt-session/index.ts
@@ -9,6 +9,7 @@ const AccountSchema = v.object({
 	publicKey: v.string(),
 	label: v.optional(v.string()),
 	features: v.optional(v.array(v.string())),
+	chains: v.optional(v.array(v.string())),
 });
 
 const JwtSessionSchema = v.object({

--- a/packages/window-wallet-core/src/web-wallet-channel/wallet-post-message-channel.ts
+++ b/packages/window-wallet-core/src/web-wallet-channel/wallet-post-message-channel.ts
@@ -58,6 +58,13 @@ export class WalletPostMessageChannel {
 			throw new Error('Requested account not found in session');
 		}
 
+		if (
+			addressInSession.chains !== undefined &&
+			!addressInSession.chains.includes(this.#request.payload.chain)
+		) {
+			throw new Error('Requested chain not authorized by session');
+		}
+
 		const requiredFeatures = {
 			'sign-transaction': ['sui:signTransaction', 'sui:signTransactionBlock'],
 			'sign-and-execute-transaction': ['sui:signAndExecuteTransaction'],


### PR DESCRIPTION
## Description

Hosted Slush accounts currently advertise every Sui chain even when the wallet can sign for an aliased address only on some networks. Carry an optional per-account `chains` list through JWT sessions and map it to the account's advertised supported chains. Reject direct signing requests for chains excluded by the signed session.

Sessions without `chains` preserve their existing behavior. Explicit empty lists stay empty, and the SDK does not advertise unknown chains. Includes minor changesets for both affected packages. Companion to the network-specific capability fix in MystenLabs/slush#4346.

## Test plan

- [x] 26 tests across four Slush Wallet suites, including restricted/empty/legacy chain lists and session enforcement for all three signing request types, and omitted-chain personal-message compatibility.
- [x] Both package typechecks and builds.
- [x] Targeted Oxlint, Prettier, and git diff checks.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
