### PR TITLE
[hashi] call the latest enabled package after an upgrade

### DIFF
--- a/.changeset/hashi-call-latest-package.md
+++ b/.changeset/hashi-call-latest-package.md
@@ -1,0 +1,8 @@
+---
+'@mysten/hashi': patch
+---
+
+Fix deposits and withdrawals aborting with `EVersionDisabled` after the Hashi package is upgraded.
+Hashi Move calls now target the latest enabled package, read from the Hashi object's upgrade cap
+when the transaction is serialized. `packageId` stays the original package, so coin, object and
+event types are unchanged.

--- a/packages/hashi/src/client.ts
+++ b/packages/hashi/src/client.ts
@@ -602,33 +602,77 @@ export class HashiClient {
 	// operator/committee calls are intentionally not part of this surface.
 	call = {
 		deposit: (options: { utxo: RawTransactionArgument<string> }) =>
-			depositModule.deposit({
-				package: this.#packageId,
-				arguments: { hashi: this.#hashiObjectId, utxo: options.utxo },
-			}),
+			this.#retarget(
+				depositModule.deposit({
+					package: this.#packageId,
+					arguments: { hashi: this.#hashiObjectId, utxo: options.utxo },
+				}),
+			),
 		requestWithdrawal: (options: {
 			btc: RawTransactionArgument<string>;
 			bitcoinAddress: RawTransactionArgument<number[]>;
 		}) =>
-			withdrawModule.requestWithdrawal({
-				package: this.#packageId,
-				arguments: {
-					hashi: this.#hashiObjectId,
-					btc: options.btc,
-					bitcoinAddress: options.bitcoinAddress,
-				},
-			}),
+			this.#retarget(
+				withdrawModule.requestWithdrawal({
+					package: this.#packageId,
+					arguments: {
+						hashi: this.#hashiObjectId,
+						btc: options.btc,
+						bitcoinAddress: options.bitcoinAddress,
+					},
+				}),
+			),
 		/**
 		 * Cancel a pending withdrawal request. Returns a `Balance<BTC>` hot potato
 		 * that must be consumed in the same PTB (e.g. wrapped into a Coin and
 		 * transferred back to the sender).
 		 */
 		cancelWithdrawal: (options: { requestId: RawTransactionArgument<string> }) =>
-			withdrawModule.cancelWithdrawal({
-				package: this.#packageId,
-				arguments: { hashi: this.#hashiObjectId, requestId: options.requestId },
-			}),
+			this.#retarget(
+				withdrawModule.cancelWithdrawal({
+					package: this.#packageId,
+					arguments: { hashi: this.#hashiObjectId, requestId: options.requestId },
+				}),
+			),
 	};
+
+	/** Wraps a call thunk so its transaction's Hashi calls target the latest enabled package. */
+	#retarget<T>(call: (tx: Transaction) => T) {
+		return (tx: Transaction) => {
+			tx.add(this.#addRetargetPlugin);
+			return call(tx);
+		};
+	}
+
+	// `tx.add` runs a given thunk once per transaction (forks included), so this registers once.
+	// Serialization plugins run for `toJSON`, `build` and `getDigest` alike.
+	#addRetargetPlugin = (tx: Transaction) => {
+		tx.addSerializationPlugin(async (data, _options, next) => {
+			const packageId = normalizeSuiAddress(this.#packageId);
+			const calls = data.commands.flatMap((command) =>
+				command.MoveCall && normalizeSuiAddress(command.MoveCall.package) === packageId
+					? [command.MoveCall]
+					: [],
+			);
+			if (calls.length > 0) {
+				const target = await this.#resolveCallPackageId();
+				for (const call of calls) call.package = target;
+			}
+			await next();
+		});
+	};
+
+	/**
+	 * `assert_version_enabled` gates on the called package's version, so call the upgrade cap's
+	 * package once its version is enabled, and the configured (original) package otherwise.
+	 */
+	async #resolveCallPackageId(): Promise<string> {
+		const { json } = await this.#fetchHashiObject();
+		const { enabled_versions, upgrade_cap: cap } = json.versioning;
+		return cap && enabled_versions.contents.some((v) => BigInt(v) === BigInt(cap.version))
+			? cap.package
+			: this.#packageId;
+	}
 
 	/**
 	 * Parses the `Hashi.config.config` VecMap contents into a typed snapshot,

--- a/packages/hashi/src/types.ts
+++ b/packages/hashi/src/types.ts
@@ -15,7 +15,7 @@ export interface HashiClientOptions<Name = string> {
 	name?: Name;
 	/** Override the auto-resolved Hashi shared object ID (for custom/local deployments). */
 	hashiObjectId?: string;
-	/** Override the auto-resolved Hashi package ID (for custom/local deployments). */
+	/** Override the original (type-defining) Hashi package ID; Move calls route to the latest enabled version. */
 	packageId?: string;
 	/** Override the auto-resolved Bitcoin network for address encoding. */
 	bitcoinNetwork?: BitcoinNetwork;

--- a/packages/hashi/test/unit/client.test.ts
+++ b/packages/hashi/test/unit/client.test.ts
@@ -6,6 +6,7 @@ import { HashiClient, hashi } from '../../src/client.js';
 import {
 	AmountBelowMinimumError,
 	HashiConfigError,
+	HashiFetchError,
 	HashiGuardianError,
 	HashiPausedError,
 	InvalidBitcoinAddressError,
@@ -82,12 +83,16 @@ function guardianBtcConfigEntry(bytes: Uint8Array = TEST_GUARDIAN_BTC_X_ONLY) {
 }
 
 /**
- * Build a mocked `Hashi.get()` response with a custom config `contents` array.
- * Other fields carry minimal-but-valid placeholders so the BCS-decoded json
- * shape matches what the SDK expects.
+ * Build a mocked `Hashi.get()` response with a custom config `contents` array
+ * and optional `versioning`. Other fields carry minimal-but-valid placeholders
+ * so the BCS-decoded json shape matches what the SDK expects.
  */
 function mockHashiWithConfig(
 	contents: Array<{ key: string; value: { $kind: string; [k: string]: unknown } }>,
+	versioning: {
+		enabled_versions: { contents: string[] };
+		upgrade_cap: { id: string; package: string; version: string; policy: number } | null;
+	} = { enabled_versions: { contents: [] }, upgrade_cap: null },
 ) {
 	vi.spyOn(Hashi, 'get').mockResolvedValueOnce({
 		json: {
@@ -99,11 +104,8 @@ function mockHashiWithConfig(
 				pending_epoch_change: null,
 				mpc_public_key: [],
 			},
-			config: {
-				config: { contents },
-				enabled_versions: { contents: [] },
-				upgrade_cap: null,
-			},
+			config: { config: { contents } },
+			versioning,
 			treasury: { objects: HASHI_OBJECT_ID },
 			proposals: HASHI_OBJECT_ID,
 			tob: HASHI_OBJECT_ID,
@@ -2175,6 +2177,128 @@ describe('HashiClient', () => {
 
 				const moveCalls = commands.filter((c) => c.$kind === 'MoveCall');
 				expect(moveCalls.some((c) => c.MoveCall?.function === 'request_withdrawal')).toBe(true);
+			});
+		});
+
+		describe('call package routing', () => {
+			// Not PACKAGE_ID: it is 0x2, so it would also match the framework's `0x2::coin` calls.
+			const ORIGINAL = '0x00000000000000000000000000000000000000000000000000000000000000f1';
+			const V2 = '0x00000000000000000000000000000000000000000000000000000000000000f2';
+			const BTC = `${ORIGINAL}::btc::BTC`;
+			let hashiClient: HashiClient;
+
+			beforeEach(() => {
+				hashiClient = new HashiClient({
+					client,
+					hashiObjectId: HASHI_OBJECT_ID,
+					packageId: ORIGINAL,
+				});
+			});
+
+			function mockVersioning(cap: { package: string; version: string } | null, enabled: string[]) {
+				mockHashiWithConfig(WELL_FORMED_CONFIG, {
+					enabled_versions: { contents: enabled },
+					upgrade_cap: cap && { id: REQUEST_ID, policy: 0, ...cap },
+				});
+			}
+
+			/** Runs the serialization plugins (no network) and returns the resulting Move calls. */
+			async function serializedMoveCalls(tx: Transaction) {
+				await tx.prepareForSerialization({ supportedIntents: ['CoinWithBalance'] });
+				return tx.getData().commands.flatMap((c) => (c.MoveCall ? [c.MoveCall] : []));
+			}
+
+			it('calls the upgraded package from every builder, keeping types on the original', async () => {
+				mockVersioning({ package: V2, version: '2' }, ['2']);
+				const deposit = hashiClient.tx.deposit({
+					txid: '0x' + 'ab'.repeat(32),
+					utxos: [{ vout: 0, amountSats: 100_000n }],
+					recipient: TEST_SUI_ADDRESS,
+				});
+				expect((await serializedMoveCalls(deposit)).map((c) => [c.function, c.package])).toEqual([
+					['utxo_id', V2],
+					['utxo', V2],
+					['deposit', V2],
+				]);
+
+				mockVersioning({ package: V2, version: '2' }, ['2']);
+				const withdrawal = hashiClient.tx.requestWithdrawal({
+					amount: 50_000n,
+					bitcoinAddress: new Uint8Array(32),
+				});
+				expect(await serializedMoveCalls(withdrawal)).toMatchObject([
+					{ function: 'request_withdrawal', package: V2 },
+				]);
+				const intent = withdrawal.getData().commands.find((c) => c.$kind === '$Intent');
+				expect(intent?.$Intent?.data).toMatchObject({ type: BTC });
+
+				mockVersioning({ package: V2, version: '2' }, ['2']);
+				const cancel = hashiClient.tx.cancelWithdrawal({
+					requestId: REQUEST_ID,
+					recipient: TEST_SUI_ADDRESS,
+				});
+				expect(await serializedMoveCalls(cancel)).toMatchObject([
+					{ function: 'cancel_withdrawal', package: V2 },
+					{ function: 'from_balance', package: normalizeSuiAddress('0x2'), typeArguments: [BTC] },
+				]);
+			});
+
+			it('keeps the configured package when the upgrade cap still points at it', async () => {
+				mockVersioning({ package: ORIGINAL, version: '1' }, ['1']);
+				const tx = hashiClient.tx.requestWithdrawal({
+					amount: 50_000n,
+					bitcoinAddress: new Uint8Array(32),
+				});
+				expect(await serializedMoveCalls(tx)).toMatchObject([{ package: ORIGINAL }]);
+			});
+
+			it('keeps the configured package, reading Hashi once, when no upgrade cap is set', async () => {
+				const getSpy = vi.spyOn(Hashi, 'get');
+				mockVersioning(null, ['1']);
+				const tx = hashiClient.tx.deposit({
+					txid: '0x' + 'cd'.repeat(32),
+					utxos: [
+						{ vout: 0, amountSats: 100_000n },
+						{ vout: 2, amountSats: 50_000n },
+					],
+					recipient: TEST_SUI_ADDRESS,
+				});
+				const packages = (await serializedMoveCalls(tx)).map((c) => c.package);
+				expect(packages).toEqual(Array(6).fill(ORIGINAL));
+				expect(getSpy).toHaveBeenCalledTimes(1);
+			});
+
+			it('keeps the configured package when the cap version is not enabled', async () => {
+				mockVersioning({ package: V2, version: '2' }, ['1']);
+				const tx = hashiClient.tx.cancelWithdrawal({
+					requestId: REQUEST_ID,
+					recipient: TEST_SUI_ADDRESS,
+				});
+				expect((await serializedMoveCalls(tx))[0]).toMatchObject({ package: ORIGINAL });
+			});
+
+			it('retargets call thunks added to a caller-built transaction', async () => {
+				mockVersioning({ package: V2, version: '2' }, ['2']);
+				const tx = new Transaction();
+				const btc = tx.add(hashiClient.call.cancelWithdrawal({ requestId: REQUEST_ID }));
+				tx.moveCall({
+					target: '0x2::balance::destroy_zero',
+					typeArguments: [BTC],
+					arguments: [btc],
+				});
+
+				// Wallets sign what `toJSON` serializes.
+				const { commands } = JSON.parse(await tx.toJSON());
+				expect(commands[0].MoveCall.package).toBe(V2);
+			});
+
+			it('rejects serialization when the Hashi object cannot be read', async () => {
+				vi.spyOn(Hashi, 'get').mockRejectedValueOnce(new Error('fullnode unavailable'));
+				const tx = hashiClient.tx.cancelWithdrawal({
+					requestId: REQUEST_ID,
+					recipient: TEST_SUI_ADDRESS,
+				});
+				await expect(serializedMoveCalls(tx)).rejects.toBeInstanceOf(HashiFetchError);
 			});
 		});
 	});


### PR DESCRIPTION
## Description

Testnet's first Hashi upgrade left only v2 enabled, and `assert_version_enabled` checks the version of the package being called. `@mysten/hashi` still calls the original package, so every deposit, withdrawal request and cancellation it builds aborts with `EVersionDisabled`. Pointing `packageId` at v2 isn't a fix, because types keep the original package id.

`HashiClient`'s `call.*` thunks, which back the `tx.*` builders and direct methods, now register a serialization plugin. It reads `Hashi.versioning` and, when the upgrade cap's version is enabled, retargets `MoveCall.package` from the original package to the cap's package. Type arguments and the balance intent are left alone. The plugin runs for `toJSON`, `build` and `getDigest`. If the Hashi object can't be read, serialization rejects with `HashiFetchError` instead of falling back to the original package. As in hashi-frontend, a `Transaction.from(tx)` copy made before serialization isn't retargeted.

## Test plan

- New `call package routing` unit tests cover: an upgraded cap, a cap still at the original package, no cap, a cap version that isn't enabled, a `call.*` thunk in a caller-built PTB (checked in the `toJSON` output), one Hashi read per serialization, and a failed read.
- `pnpm turbo build --filter @mysten/hashi`, `pnpm --filter @mysten/hashi test` (typecheck + 194 unit tests) and `pnpm --filter @mysten/hashi lint`.
- Packed the SDK and simulated `tx.deposit` and `tx.requestWithdrawal` against testnet (nothing signed): both simulate OK.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
