### PR TITLE
[hashi] pin the Sui binary in the localnet integration job

### DIFF
--- a/.github/workflows/hashi-ci.yml
+++ b/.github/workflows/hashi-ci.yml
@@ -79,12 +79,19 @@ jobs:
           # makes the relationship unambiguous in cache hit/miss logs.
           shared-key: hashi-${{ env.HASHI_PIN }}
 
+      # Pinned instead of hashi's install-sui.sh, which installs the newest testnet release:
+      # HASHI_PIN can't bootstrap a localnet on testnet-v1.79.0. Bump alongside HASHI_PIN.
       - name: Install Sui binary
-        # install-sui.sh queries the GitHub releases API with GITHUB_TOKEN
-        # (set -u, so it must be set) — mirrors the env in hashi's own ci.yml.
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: bash hashi/.github/scripts/install-sui.sh
+          SUI_VERSION: 'testnet-v1.78.1'
+          SUI_SHA256: '892bb34c3719b7609baed451dec4d6110254791f69315e7b63fe51804822027e'
+        run: |
+          wget -q "https://sui-releases.s3-accelerate.amazonaws.com/${SUI_VERSION}/sui"
+          echo "${SUI_SHA256}  sui" | sha256sum -c -
+          chmod +x sui
+          sudo mv sui /usr/local/bin/
+          sui --version
+          echo "SUI_BINARY=/usr/local/bin/sui" >> "$GITHUB_ENV"
 
       # Mirrors the "Install Bitcoin Core" step in
       # hashi/.github/workflows/ci.yml, but pinned rather than tracking the


### PR DESCRIPTION
## Description

`Localnet Integration` has failed on every run since 2026-09-02, `main` included. The job installs Sui with hashi's `install-sui.sh`, which takes the newest `testnet-*` release. That became `testnet-v1.79.0` on 2026-09-01, and the hashi revision in `HASHI_PIN` can't bootstrap a localnet against it: `hashi-localnet` exits with `invalid value: integer 3, expected variant index 0 <= i < 3` before any test runs. The last green run on `main` installed `testnet-v1.78.1`.

This pins the job to `testnet-v1.78.1` with a sha256 check, the same way the bitcoind step is pinned, to be bumped together with `HASHI_PIN`. It's the same fix as #1250, which was closed without merging.

## Test plan

- Downloaded `testnet-v1.78.1/sui` from the release bucket: x86-64 Linux ELF, sha256 matches `SUI_SHA256`.
- `actionlint` shows no new findings (only the existing SC2086 infos in other steps); prettier passes.
- This PR's `Localnet Integration` run: pending.

---

### AI Assistance Notice

> Please disclose the usage of AI. This is primarily to help inform reviewers of how careful they need to review PRs, and to keep track of AI usage across our team. Please fill this out accurately, and do not modify the content or heading for this section!

- [x] This PR was primarily written by AI.
- [ ] I used AI for docs / tests, but manually wrote the source code.
- [ ] I used AI to understand the problem space / repository.
- [ ] I did not use AI for this PR.
